### PR TITLE
Add native RNIC work queue model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,24 @@ jobs:
         run: ruff check .
       - name: Test
         run: pytest -q
+
+  native-rnic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure RNIC model
+        run: >-
+          cmake -S simllm/backends/rnic -B build/rnic
+          -DCMAKE_BUILD_TYPE=Debug
+          -DSIMLLM_RNIC_BUILD_TESTS=ON
+          -DSIMLLM_RNIC_BUILD_TOOLS=ON
+          -DSIMLLM_RNIC_WARNINGS_AS_ERRORS=ON
+      - name: Build RNIC model
+        run: cmake --build build/rnic --parallel
+      - name: Test RNIC model
+        run: ctest --test-dir build/rnic --output-on-failure
+      - name: Validate RNIC release sweep
+        run: >-
+          python examples/rnic_wq_v1/run_rnic_wq_v1.py
+          --check
+          --build-dir build/rnic_wq_v1_ci

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ runs/
 *.npz
 *.csv
 !tests/data/*.csv
+!examples/rnic_wq_v1/results.csv
 
 # Local agent rule files (kept out of the public repo on purpose)
 CLAUDE.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ every size are welcome, from a topology config to a new frontend adapter.
 ## Development setup
 
 ```bash
-git clone https://github.com/yifeng-ethz/simllm.git
+git clone https://github.com/openfabric-systems/simllm.git
 cd simllm
 git submodule update --init third_party/atlahs third_party/htsim
 pip install -e .[dev]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,16 @@ ruff check .
 pytest -q
 ```
 
+Changes under `simllm/backends/rnic/` also run the dependency-free native
+gate:
+
+```bash
+cmake -S simllm/backends/rnic -B build/rnic -DCMAKE_BUILD_TYPE=Debug \
+  -DSIMLLM_RNIC_WARNINGS_AS_ERRORS=ON
+cmake --build build/rnic --parallel
+ctest --test-dir build/rnic --output-on-failure
+```
+
 ## Where to contribute
 
 - **Workload generators** (`simllm/workload/`): arrival processes, length

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include examples/rnic_wq_v1/expectations.md
+include examples/rnic_wq_v1/RESULTS.md
+include examples/rnic_wq_v1/results.csv
+include examples/rnic_wq_v1/run_rnic_wq_v1.py

--- a/README.md
+++ b/README.md
@@ -120,13 +120,14 @@ script, and an audited `RESULTS.md`. Start with these:
 | Study | Question | Headline result |
 |---|---|---|
 | [m4](examples/m4/RESULTS.md) | Does the closed loop work end to end? | A live vLLM engine at `tensor_parallel_size=8` runs under the `SimExecutor` with `htsim_rnic` inside the step loop; all 36 pre-registered checks pass, fluid closed forms to 0 ps |
-| [dcqcn_micro](examples/dcqcn_micro/RESULTS.md) | **NIC calibration: message size and incast.** How does goodput scale with message size, and is incast bandwidth shared fairly? | Model tracks the real-NIC (UCCL) message-size anchors from above at saturation but undershoots at 64 to 256 KB (0.79x at 64 KB): the calibration target for HTSIM-5; incast fair share is near-ideal (Jain 0.993 to 1.000 across fan-in 2 to 20) |
+| [dcqcn_micro](examples/dcqcn_micro/RESULTS.md) | **NIC calibration: message size and incast.** How does goodput scale with message size, and is incast bandwidth shared fairly? | Model tracks the real-NIC (UCCL) message-size anchors at saturation but undershoots at 64 to 256 KB (0.79x at 64 KB): common WQ/PCIe calibration is BACK-9/10 and persistent post-CNP DCQCN state is HTSIM-5; incast fair share is near-ideal (Jain 0.993 to 1.000 across fan-in 2 to 20) |
 | [dcqcn_vs_cn](examples/dcqcn_vs_cn/RESULTS.md) | When does DCQCN collapse, and when does it honestly win? | Buffer-exceeding incast collapses DCQCN by 2 to 3 orders of magnitude (32x64 KiB: p99 slowdown 1161x vs rnic-cn 1.60); buffer-absorbed incast is a registered DCQCN win (1.07 vs 1.68) |
 | [cn_ladder](examples/cn_ladder/RESULTS.md) | Does the explicit-rate `rnic-cn` endpoint meet its acceptance bar? | 46 of 49 incast ladder cells within the 20% target of the ideal baseline; under a lossy all-to-all, DCQCN p99 slowdown is 1902x vs rnic-cn 19.3x (lossless, deterministic) |
 | [breakdown](examples/breakdown/RESULTS.md) | Where does request time actually go? | Network share of request time rises from 52% (TP=2) to 89% (TP=8) at 400G, 96% at 100G |
 | [m1](examples/m1/RESULTS.md) | Standalone core: workload to GOAL to htsim to metrics | Ten runs reproduce their closed forms with 0 ps residual |
 | [m5](examples/m5/RESULTS.md) | MoE expert-parallel all-to-all | Pairwise all-to-allv closed forms exact to 0 ps across size and width |
 | [core2_lowering](examples/core2_lowering/RESULTS.md) | Execution lowering and WQE bookkeeping | Legacy path, graph-only replay and frozen closed form agree to 0 ps on all rows; flow and WQE ledgers field-identical |
+| [rnic_wq_v1](examples/rnic_wq_v1/RESULTS.md) | **RNIC queueing: what do doorbell batches, signaling and network credits change?** | All 11 native C++ sweep cells match their closed forms exactly; batching cuts 32 doorbells to 2, signaling cuts 32 CQEs to 2 independently, and four network credits cut JCT from 16,110 ps to 4,140 ps |
 
 The message-size calibration curve and the definitive comparator figure:
 
@@ -138,6 +139,9 @@ The message-size calibration curve and the definitive comparator figure:
 The NIC calibration anchors themselves (UCCL, DCQCN, HPCC, Kalia et al.
 measurements distilled into parameter sets) are recorded in
 [docs/papers/msg-size-vs-bandwidth.md](docs/papers/msg-size-vs-bandwidth.md).
+The hardware/CC boundary, mlx5 hook, CX-7 evidence rules and full boundary
+campaign are in
+[docs/papers/rnic-hardware-calibration.md](docs/papers/rnic-hardware-calibration.md).
 
 ## Models
 
@@ -146,14 +150,29 @@ the module doc that owns it.
 
 ### Network and NIC
 
+RNIC hardware and congestion control are separate model axes. A full-RNIC
+comparison holds the hardware profile fixed and swaps only the htsim
+transport/CC policy. The analytical fluid baseline keeps an explicit hardware
+bypass so closed-form validation remains available.
+
+#### RNIC hardware
+
 | Model | Status | What it is |
 |---|---|---|
-| `rnic-nn` | available | Packetized ideal-NIC baseline (no congestion control); the reference every profile normalizes to |
-| `rnic-nn-fluid` | available | Continuous fluid baseline with deterministic closed forms; the 0 ps validation anchor |
-| `rnic-cn` | available | Explicit-rate collective-network endpoint: deterministic reservation ledger, per-packet spraying with resequencing, lossless without PFC |
-| DCQCN | available | RoCEv2 comparator with mlx5-faithful loss recovery (go-back-N + CNP rate cut, optional limited selective repeat), ECN-only and ECN+PFC modes, PFC storm metrics |
-| WQE lifecycle | available | SQ/RQ/CQ queues and per-WQE transport identities (DCQCN QP or rnic-cn link pair), timing-neutral bookkeeping in the backend |
-| Per-WQE start behavior | planned ([HTSIM-5/6](docs/modules/backends.md)) | WQE initiation latency, shared per-pair rate state and submission-queue pipelining/lookahead, calibrated against the real-NIC message-size anchors |
+| RDMA Work Queue | partial, first native slice available ([study](examples/rnic_wq_v1/RESULTS.md), [BACK-8/9](docs/modules/backends.md)) | SimLLM C++ now models one finite SQ/CQ pair, WR-prefix posting, doorbell batches, ordered retirement, signaling, polling, owner wrap, network backpressure and controlled queue failures; RQ/SRQ, shared CQs and mlx5 encoding remain planned |
+| PCIe, MMIO and DMA | planned ([BACK-10](docs/modules/backends.md)) | Doorbell and BlueFlame paths, WQE and context fetches, payload reads/writes, CQE writes, PCIe ordering, NUMA, IOMMU and GPU Direct topology |
+| QP, QPC and context memory | planned ([BACK-11](docs/modules/backends.md)) | QP pairing and state transitions plus QPC, MTT/MPT and WQE-cache residency in a measured device-cache and host-ICM hierarchy |
+| TX/RX hardware pipelines | planned ([BACK-12](docs/modules/backends.md)) | Packetization, schedulers, port buffers, ACK/NAK/RNR/retry, CQE completion, PFC gates and location-specific fault injection |
+| CX-7 observable state | planned ([BACK-13/14/15](docs/modules/backends.md)) | Versioned driver-visible registers, counters and traces, verbs capture/replay, and Collie-seeded boundary calibration; undocumented internals stay explicit calibrated abstractions |
+
+#### Congestion-control and transport policies
+
+| Model | Status | What it is |
+|---|---|---|
+| `rnic-nn` | available, hardware adapter planned ([HTSIM-9](docs/modules/backends.md)) | Packetized no-CC policy and the reference for normalized FCT; full-RNIC runs use the same hardware path as physical policies |
+| `rnic-nn-fluid` | available | Continuous fluid policy with deterministic closed forms and the explicit hardware-bypass 0 ps anchor |
+| `rnic-cn` | available, hardware adapter planned ([HTSIM-6/9](docs/modules/backends.md)) | Explicit-rate policy with deterministic reservations, packet spraying and resequencing, lossless without PFC |
+| DCQCN | available, hardware adapter planned ([HTSIM-5/9](docs/modules/backends.md)) | RoCEv2 comparator with per-QP CNP state, rate reduction/recovery and ECN plus optional PFC; DCQCN calibration lands before programmable CC |
 | LogGOPSim flow level | planned ([BACK-2](docs/modules/backends.md)) | Fast flow-level sweeps before packet-level runs |
 
 Fabrics are two-tier Clos topologies with detailed switch models (VoQ

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ seams, the manifest schemas and the GOAL trace format, is in
 ## Getting Started
 
 ```bash
-git clone https://github.com/yifeng-ethz/simllm.git
+git clone https://github.com/openfabric-systems/simllm.git
 cd simllm
 
 # Backends (~250 MB). Do NOT use --recursive: ATLAHS carries large nested

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ status and open tasks; nothing here overrides them.
 | Developer map | this file | Process, fidelity order, module status, study index |
 | Full design | [architecture.md](architecture.md) | Components, vLLM/SGLang integration seams, manifest schemas, execution/resource boundary, GOAL trace format, coupling modes, metrics |
 | Module truth | [modules/*.md](modules/) | Per-module design, current status, numbered open tasks |
-| Calibration sources | [papers/](papers/) | Measurement anchors distilled from the literature (e.g. [msg-size-vs-bandwidth.md](papers/msg-size-vs-bandwidth.md)) |
+| Calibration sources | [papers/](papers/) | Literature anchors and evidence plans, including [message-size parameters](papers/msg-size-vs-bandwidth.md) and the [RNIC hardware/CX-7 boundary campaign](papers/rnic-hardware-calibration.md) |
 | Studies | [../examples/](../examples/) | Pre-registered expectations, run scripts, audited results, plots |
 
 ## Development process
@@ -103,8 +103,9 @@ linked task IDs own the detail.
    couple to resource contention.
 4. **Resource queues and data movement.** The first coarse
    `DeviceRuntime`: launch and stream queues, GPU/HBM, copy engines and
-   DMA, NCCL channels, per-GPU WQE queues, the shared NIC, completion
-   and control queues: [CORE-4](modules/core.md#open-tasks).
+   DMA, NCCL channels, per-GPU WQE queues, GPU-affine RNICs, completion
+   and control queues: [CORE-4](modules/core.md#open-tasks). Structural
+   RNIC service then lands under BACK-8 through BACK-12.
 5. **Dependency-driven overlap.** Replace the serial step chain only
    after KV and resource queues exist; framework lowering declares
    dependencies, runtime arbitration determines realized overlap:
@@ -127,7 +128,7 @@ One line per module; the linked doc is the source of truth.
 | [placement](modules/placement.md) | Implemented: placement manifest round trip, declared placements, gpu-rank mapping, vLLM extraction; fabric manifest design-only | PLACE-1/2/3 |
 | [traffic](modules/traffic.md) | Implemented: collective patterns, TP step mapping, MoE all-to-all, GOAL renderers for steps and execution graphs | TRAF-2/3/4/5/6/7/8/9/10 |
 | [goal](modules/goal.md) | Implemented: GOAL trace + txt2bin helper | none |
-| [backends](modules/backends.md) | Implemented: htsim_rnic/dcqcn/uec invocation, completion + WQE CSV parsing, FCT normalization, step sink, step lowerer | BACK-2/5/6/7; backend-repo HTSIM-1/2/4/5/6/7/8, ATLAHS-1 |
+| [backends](modules/backends.md) | Implemented: htsim invocation/parsing plus the first native C++ RNIC SQ/CQ and network-port slice; htsim composition remains open | BACK-2/5-15; backend-repo HTSIM-1/2/4-9, ATLAHS-1 |
 | [adapters-vllm](modules/adapters-vllm.md) | Implemented: SimExecutor on pinned v0.26.0, full RPC surface, step-record streaming, placement exporter, live tp=8 closed loop | VLLM-3 through VLLM-12 |
 | [adapters-sglang](modules/adapters-sglang.md) | Implemented: SimTpModelWorker via plugin entry point at pinned commit, live CPU-engine smoke | SGL-3 through SGL-10 |
 
@@ -145,8 +146,9 @@ script, and an audited `RESULTS.md`. Reproduce with
 | [breakdown](../examples/breakdown/RESULTS.md) | Per-request compute/memory/network decomposition, expected vs actual, TP {2,4,8} x {100G,400G} | 21/22 pass; network share 52% (TP=2) to 89% (TP=8) at 400G, 96% at 100G |
 | [cn_ladder](../examples/cn_ladder/RESULTS.md) | `rnic-cn` acceptance: incast ladder and mixed all-to-all against the ideal baselines and DCQCN | 46/49 ladder cells within the 20% target; lossy a2a16: DCQCN median 1.52 but p99 1902x vs rnic-cn median 2.06, p99 19.3x, lossless |
 | [dcqcn_vs_cn](../examples/dcqcn_vs_cn/RESULTS.md) | Mechanism-level scenarios: incast above/below buffer, ECMP collisions, cross-node TP ring | 18/20 checked rows pass; DCQCN collapses 2 to 3 orders of magnitude past the buffer, wins the buffer-absorbed cell (1.07 vs 1.68) and the path-disjoint ring |
-| [dcqcn_micro](../examples/dcqcn_micro/RESULTS.md) | NIC micro-behavior calibration: message-size law, incast fair share, join/exit convergence, repeated-WQE streams | Jain fairness 0.993 to 1.000; model undershoots real-NIC anchors at 64 to 256 KB (no per-WQE host cost yet), the registered HTSIM-5 calibration target; contended repeated-WQE collapse reproduced to the derived digit |
+| [dcqcn_micro](../examples/dcqcn_micro/RESULTS.md) | NIC micro-behavior calibration: message-size law, incast fair share, join/exit convergence, repeated-WQE streams | Jain fairness 0.993 to 1.000; the timing-neutral WQ undershoots real-NIC anchors at 64 to 256 KB, now the BACK-9/10 hardware target; persistent post-CNP rate state remains HTSIM-5; contended repeated-WQE collapse is reproduced to the derived digit |
 | [core2_lowering](../examples/core2_lowering/RESULTS.md) | Execution lowering, graph-only JSON replay and WQE bookkeeping | Legacy sink, graph replay and frozen closed form agree to 0 ps on all five rows (including the MoE sentinel); flow and WQE ledgers field-identical; backend WQE layer timing-neutral (344/344 backend tests) |
+| [rnic_wq_v1](../examples/rnic_wq_v1/RESULTS.md) | Native RNIC SQ/CQ structure, doorbell batching, signaling and network-credit backpressure | 11/11 cells exact; controlled SQ-full, drop and CQ-overrun boundaries pass in the native harness |
 | [gpu_service_model](../examples/gpu_service_model/RESULTS.md) | Isolated CTA/SM/warp scheduling, occupancy, HBM and direction-specific copy service, plus strict capture/replay artifacts | 22/22 frozen structural cells exact to zero cycles; A100/H100 timing remains an explicitly uncertain, unvalidated bootstrap |
 
 ## Milestones
@@ -180,7 +182,7 @@ script, and an audited `RESULTS.md`. Reproduce with
   the persistent co-simulator (BRIDGE-1), KV lifecycle and the resource
   runtime (CORE-3 through CORE-5), calibration against real captures.
   General fabric manifests (PLACE-1/2) stay deferred behind the fixed
-  eight-GPU, one-NIC node profile.
+  eight-GPU profile with one 400G RNIC per GPU.
 - **M5 (in progress).** All-to-all traffic studies (MoE expert
   parallelism) landed ([m5](../examples/m5/RESULTS.md)). The trace-driven
   isolated-kernel and copy-service mechanisms plus A100/H100 bootstrap

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -118,11 +118,11 @@ assignment mirrors the htsim RNIC drivers' `-goal_rank_mapping` option:
 transfers stay off the fabric).
 
 General fabric discovery is not on the critical path for the first execution
-runtime. That profile fixes each node at eight GPUs and one shared 400G NIC:
-one logical WQE submission queue or QP per GPU feeds one physical NIC arbiter
-and serializer, while intra-node traffic uses an NVLink-class resource. This
-retains the queue structure needed for head-of-line blocking, fairness and
-control priority without first solving arbitrary GPU-to-NIC inventory.
+runtime. That profile fixes each node at eight GPUs and one GPU-affine 400G
+RNIC per GPU: one logical WQE submission queue or QP per GPU feeds its rail
+endpoint, while intra-node traffic uses an NVLink-class resource. This retains
+the queue structure needed for head-of-line blocking, fairness and control
+priority without first solving arbitrary GPU-to-NIC inventory.
 
 ### Execution and resource boundary (`simllm/core/execution.py`)
 
@@ -144,7 +144,7 @@ framework scheduler and KV control plane
        GPU work queue -> isolated kernel scheduler/SM/HBM service
        directional copy engines and DMA descriptors
        NCCL channels and per-GPU/QP WQE queues
-       one shared NIC arbiter and serializer per node
+       one GPU-affine RNIC arbiter and serializer per GPU
        completion and high-priority control queues
   -> CompletionEvent stream
        \-> operation + created-object subject -> RequestBookkeeper
@@ -197,13 +197,16 @@ tail-latency attribution.
 `simllm-request-bookkeeping-v1` is the independent, append-only runtime fact
 stream. It keeps the graph immutable while correlating request stages and
 owner-created objects: opaque framework vRAM allocations, execution
-operations, NCCL commands, SQ/RQ/CQ, WQEs and either DCQCN QPs or `rnic-cn`
-directed L2 link pairs. WQE completion is the lowest public network unit.
-Packet identities and packet lifecycle remain backend-private. The initial CQ
-policy consumes completion immediately at the WQE timestamp. RQ is an
-identity-only placeholder in this contract. Every WQE names one SQ, RQ and CQ;
-physical profiles also name one DCQCN QP or `rnic-cn` directed link pair,
-while null profiles explicitly record transport kind `none`.
+operations, NCCL commands, SQ/RQ/CQ and WQEs. Its compatibility transport
+identity is currently either a DCQCN QP or `rnic-cn` directed L2 link pair.
+WQE completion is the lowest public network unit.
+Packet identities and packet lifecycle remain backend-private. The current
+compatibility ledger consumes CQ completion immediately at the WQE timestamp
+and keeps RQ as an identity-only placeholder. BACK-9 replaces those
+timing-neutral transitions with structural SQ/RQ/SRQ/CQ service, and BACK-11
+gives every full-RNIC policy a hardware QP while keeping its CC/link-pair
+identity separate. Every WQE still names one SQ, RQ and CQ; null profiles
+explicitly record transport kind `none`.
 Reusable vRAM, queue, QP and link-pair objects retain the scope in which they
 were created, while each later use records its own step, execution, operation
 and request scope. Causal lineage may narrow a batched request set and rejects
@@ -277,14 +280,32 @@ references do not impose their original transient scope on later users.
 
 ### Network backend (`simllm/backends/`, `third_party/`)
 
+The full packet path has two independent layers. SimLLM owns a C++ RNIC
+hardware extension under `simllm/backends/rnic/`: RDMA WQ/CQ, QP/QPC,
+MMIO/PCIe/DMA and TX/RX hardware. htsim owns selectable transport/CC policies
+and the packet fabric. A versioned C++ adapter passes opaque packet/flow tokens
+and feedback events between them; no QP, queue, context or DMA object crosses
+that boundary. The model is linked into the directly invoked simulator, so
+there is no Python callback in the packet event loop. The detailed evidence
+and calibration plan is
+[papers/rnic-hardware-calibration.md](papers/rnic-hardware-calibration.md).
+The first implemented slice is the standalone C++17 SQ/CQ plus opaque
+flow-level `NetworkPort`. Its descriptor carries GOAL flow/tag identity and a
+separate policy-context token, while completion uses a network-owned token.
+It does not equate flow acceptance or delivery with first/last packet issue.
+The slice is validated in
+[examples/rnic_wq_v1](../examples/rnic_wq_v1/RESULTS.md). Its live
+`AtlahsFlowRuntime` wrapper and packet-level htsim adapter remain BACK-8 and
+HTSIM-9.
+
 The GOAL trace is executed by a discrete-event simulator:
 
 - **htsim** (packet-level): `htsim_uec -goal <bin> -topo <topo>` executes the
   GOAL schedule over a Clos topology with full transport behavior, and
   `htsim_rnic` (currently pinned on the append-only
   `2026_08_05/simllm-addon` branch) runs the RNIC
-  fidelity profiles: the null-network baselines `rnic-nn`/`rnic-nn-fluid`
-  and the explicit-rate collective-network endpoint `rnic-cn`. The
+  policy profiles: the packetized no-CC baseline `rnic-nn`, explicit-hardware
+  bypass baseline `rnic-nn-fluid` and explicit-rate endpoint `rnic-cn`. The
   GOAL-driven `htsim_dcqcn_atlahs` comparator is also available. Only the
   Slingshot-like profile `rnic-ss` remains a profile-wiring follow-up
   (HTSIM-1 in [modules/backends.md](modules/backends.md)); the factory rejects
@@ -359,7 +380,7 @@ with error bounds reported per metric.
 Accuracy validation advances only after calibrated compute and the resource
 runtime are available. Use identical framework commit, model, parallelism,
 request trace, seed and warm-up policy in simulation and silicon. Progress
-through single-GPU compute, eight-GPU intra-node, two-node shared-NIC,
+through single-GPU compute, eight-GPU intra-node, two-node rail-RNIC,
 offered-load sweeps, KV pressure, chunked prefill/preemption or retraction,
 then mixed and bursty workloads. Report p50, p90, p99 and p99.9 TTFT/TPOT,
 with residuals attributed to request queues, KV state, kernel service, HBM,

--- a/docs/modules/backends.md
+++ b/docs/modules/backends.md
@@ -76,6 +76,58 @@ build/htsim/datacenter/htsim_rnic -goal trace.bin -linkspeed_bps 400000000000 -r
 Changes to the backends go through their own repos on
 `<YYYY_MM_DD>/simllm-addon` branches; SimLLM only bumps pins.
 
+## RNIC hardware and transport-policy split
+
+RNIC hardware and transport/congestion control are independent model axes.
+The reusable hardware model is SimLLM-owned C++ under
+`simllm/backends/rnic/`; htsim continues to own the fabric and the selectable
+`rnic-nn`, `rnic-cn` and DCQCN policies. Full-RNIC comparisons must hold one
+hardware configuration fixed while swapping only the policy. The
+`rnic-nn-fluid` closed-form path retains an explicit hardware bypass for the
+existing zero-residual validation anchor.
+
+The composed direct-simulator path is:
+
+```text
+GOAL Send
+  -> SimLLM RDMA Work Queue and RNIC hardware
+       WR/WQE -> SQ/RQ -> doorbell -> PCIe/QPC/DMA -> TX
+  -> htsim transport/CC policy and packet fabric
+  -> SimLLM RNIC RX -> payload DMA -> CQE -> poll or interrupt
+  -> GOAL completion
+```
+
+The SimLLM sources build a C++ library linked into the directly invoked htsim
+binary; there is no Python callback in the packet event loop. The composed
+runtime still presents `AtlahsFlowRuntime` to `AtlahsHtsimApi`. HTSIM-9 owns
+the backend extension that lets a SimLLM hardware runtime call an htsim
+policy and fabric through opaque flow and packet tokens. QP, WQE, CQ, QPC,
+PCIe and DMA objects never cross that boundary.
+
+State ownership is explicit:
+
+- SimLLM RNIC hardware owns WR/WQE/CQE contents, SQ/RQ/SRQ/CQ, QP state and
+  pairing, PSN and reliability state, context and translation caches, PCIe,
+  MMIO, DMA, packetization/reassembly, TX/RX queues, the hardware rate gate,
+  PFC gates, counters and completion delivery.
+- htsim transport/CC policies own policy state such as DCQCN alpha,
+  current/target rate and recovery timers, or the `rnic-cn` reservation and
+  predeclaration ledger. The hardware applies their decisions at its rate
+  gate.
+- htsim fabric owns links, switch queues, ECN marking, propagation, wire and
+  switch drops, and PFC-frame transport. SimLLM owns the RNIC buffer
+  watermarks that originate PFC and the paused priority state that consumes
+  it.
+
+The current `AtlahsWqeLedger` remains a compatibility accounting view until
+BACK-9 replaces its timing-neutral transitions with the structural RDMA Work
+Queue. A WQE will no longer have one ambiguous start time. The model records
+post, doorbell publication and observation, WQE fetch or BlueFlame transfer,
+QPC readiness, scheduler admission, first and last packet, transport
+retirement, CQE visibility and CQ polling separately.
+The evidence classes, mlx5 hook and boundary-test matrix are recorded in
+[the RNIC hardware calibration plan](../papers/rnic-hardware-calibration.md).
+
 ## Status
 
 `htsim_rnic` invocation, completion parsing and FCT normalization landed
@@ -107,6 +159,19 @@ manual driver smokes checked both physical transport fields. The frozen
 lowering study retained every JCT and combined flow/WQE row exactly; see
 [examples/core2_lowering/RESULTS.md](../../examples/core2_lowering/RESULTS.md).
 
+On 2026-08-07 the first SimLLM-owned native RNIC slice landed under
+`simllm/backends/rnic/` as a dependency-free C++17 library. One QP-bound SQ/CQ
+pair now has finite capacity, accepted-prefix WR posting, batched doorbells,
+ordered transport retirement, signaled/unsignaled reclamation, CQ owner wrap,
+polling, network would-block and controlled SQ-full, network-drop and
+CQ-overrun evidence. Its versioned `NetworkPort` passes opaque transfer tokens
+plus flow/tag and policy-context identity without transferring WQ/QP/CQ
+ownership. Flow-level acceptance/outcome timestamps remain separate from the
+packet issue timestamps that HTSIM-9 must supply. The htsim wrapper is not yet
+connected, so the old HTSIM ledger remains the live compatibility path.
+The pre-registered native study passes all 11 cells exactly; see
+[examples/rnic_wq_v1/RESULTS.md](../../examples/rnic_wq_v1/RESULTS.md).
+
 BACK-4 was retracted on 2026-08-03. Multi-QP striping as a DCQCN mitigation
 was withdrawn by maintainer decision: DCQCN is the expected-fail comparator,
 and its ECMP-collision and slow-start behavior is the phenomenon under study.
@@ -130,6 +195,104 @@ and its ECMP-collision and slow-start behavior is the phenomenon under study.
   highest-numbered node's GPUs to pad the GOAL implicitly (see
   examples/breakdown/RESULTS.md method notes); the sink should pass
   `num_goal_ranks` through to `render_step_goal` when a topology is set.
+- BACK-8: create the protocol-neutral SimLLM RNIC hardware extension under
+  `simllm/backends/rnic/`. Its C++ event core must be independent of Python
+  and of any one CC policy, compose with htsim through HTSIM-9, and preserve
+  direct binary invocation. Define versioned configuration and result
+  records, deterministic event ordering, opaque policy/fabric tokens and a
+  hardware-bypass mode. Acceptance requires the same hardware configuration
+  hash across `rnic-nn`, `rnic-cn` and DCQCN comparison rows, plus exact
+  preservation of the current null/fluid closed forms in bypass mode.
+  The standalone C++17 library, opaque flow-level `NetworkPort`, strict native
+  build and deterministic fake adapter are complete. Remaining scope is the
+  outer `AtlahsFlowRuntime` wrapper, live htsim composition, run records,
+  configuration hash and bypass equivalence.
+- BACK-9: replace the timing-neutral WQE ledger with the structural **RDMA
+  Work Queue**, merging the old WQE lifecycle and per-WQE-start work. Model
+  verbs WR chains, WQE construction, SQ/RQ/SRQ rings, many-WQ CQ sharing,
+  doorbell batches, WQEBB and WR indices, fences, inline data, signaled and
+  unsignaled sends, receive consumption, finite depth, wrap and reclamation.
+  CQ is a real host-memory queue with requester/responder/error CQEs, owner
+  phase, producer/consumer indices, 64/128-byte format profiles, compression,
+  moderation, poll and completion-channel paths, interrupts and overrun.
+  Normalized CQE content includes WR ID, QPN/source QP, opcode, status,
+  opcode-valid byte count, immediate/invalidate data, flags, syndrome and
+  vendor syndrome; provider-derived fields and valid bits stay explicit.
+  Record `posted_at`, `doorbelled_at`, `doorbell_seen_at`, WQE-fetch begin/end,
+  `qpc_ready_at`, `admitted_at`, first/last packet, transport retirement,
+  CQE visibility and poll time. Define NIC start as first-packet issue, never
+  as `ibv_post_send` return.
+  The first one-SQ/one-CQ send slice is complete, including prefix acceptance,
+  finite depth, batching, ordered retirement, signaling, poll-time reclaim,
+  CQ wrap/owner generation and controlled first-failure evidence. Remaining
+  scope includes RQ/SRQ, multiple WQs and shared CQs, WQEBB encoding, fences,
+  inline/BlueFlame paths, CQE format profiles, compression, moderation,
+  completion channels and interrupts.
+- BACK-10: implement the shared PCIe/MMIO/DMA queueing model. Keep distinct
+  service classes for UAR doorbells, BlueFlame write-combining copies, DB
+  records, WQE reads, QPC/ICM and MTT/MPT fetches, payload reads/writes, CQE
+  writes, command queues, interrupts and ODP/IOMMU faults. Parameters include
+  PCIe generation/width, TLP overhead, MPS/MRRS, posted-write and read
+  completion latency distributions, outstanding-read limits, credits,
+  completion buffering, relaxed ordering, ACS routing, IOMMU, DDIO, NUMA and
+  GPU Direct topology. Every byte and wait must be attributed to one class.
+- BACK-11: implement QP lifecycle, RNIC pairing and context placement. Cover
+  RESET, INIT, RTR, RTS, SQD/SQE, ERR and teardown; PD/MR/MPT/MTT ownership;
+  peer QPN/PSN/GID/path exchange; retry/RNR parameters; and failed or timed-out
+  pairing. Provide both manual out-of-band TCP pairing and `rdma_cm`/IB-CM
+  pairing, with TCP treated as host control for RoCE/InfiniBand and as data
+  transport only for iWARP. The generic memory hierarchy is `on_die_sram`, an
+  optional `device_memory` tier and `host_pinned_memory`. The CX-7 default is
+  an internal context cache plus host ICM over PCIe; the middle tier stays
+  disabled until public evidence or measurements justify it. Every full-RNIC
+  policy uses the same hardware QP objects; a separate opaque policy context
+  carries DCQCN or `rnic-cn` identity. Migrate the current compatibility
+  ledger without breaking its reader. Pair two RNIC endpoints explicitly;
+  model TCP connect and attribute exchange, CM events and QP firmware-command
+  time as control-path events. Model QPC, WQE-cache and MTT/MPT locality
+  separately.
+- BACK-12: implement the TX/RX hardware pipelines and cross-layer fault
+  boundary. Include WQE decode, context/translation lookup, opcode-specific
+  DMA, packetization, per-QP eligibility, arbitration, rate and PFC gates, MAC
+  queues, RX matching/reassembly, SEND-to-RQ consumption, one-sided access,
+  ACK/NAK/RNR, retry/timeout, error transition, CQE DMA and interrupt/poll
+  delivery. Add deterministic, Bernoulli and burst injection at named TX,
+  wire/switch and RX boundaries; every loss reports location, reason and
+  controlled/asserted/inferred evidence. RNIC PFC covers per-priority
+  headroom, XOFF/XON hysteresis, pause quanta/refresh, paused-egress gating and
+  insufficient-headroom drops; HTSIM-9 transports the frames through the
+  fabric. The DCQCN policy adapter is delivered and calibrated before wider
+  PFC and programmable-CC work.
+- BACK-13: build a versioned CX-7 observable-state model and capture schema.
+  Inventory only public Linux mlx5, rdma-core, NVIDIA MFT/DOCA and device-
+  reported fields. Tag each as `documented`, `driver-inferred` or
+  `calibrated-opaque`, with PSID, firmware, kernel, rdma-core, MFT, PCIe and
+  topology provenance. Capture supported named registers, resource dumps,
+  queue/counter snapshots, `ethtool -S`, RDMA hardware counters,
+  `rdma resource`/`rdma statistic`, devlink health, DCB/PFC state,
+  PCIe/AER/telemetry and
+  tracepoints. Do not invent physical addresses, internal cache geometry,
+  scheduler registers or firmware-private behavior.
+- BACK-14: add an ibverbs capture/replay bridge for controlled calibration.
+  Capture control verbs at QP/CQ/MR creation and modification, then capture
+  data-path WR chains and CQ polls at the rdma-core mlx5 provider boundary,
+  because the fast path bypasses the kernel and generic wrappers can be
+  inlined or bypassed. Normalize both live capture and SimLLM lowering into
+  the BACK-9 WR/WQE schema. An optional preload wrapper is a convenience path,
+  not the signoff oracle. Preserve WR chains, SGEs, flags, queue identities,
+  QP state and timestamps without recording payload contents by default.
+- BACK-15: run the pre-registered RNIC calibration and boundary campaign.
+  Start with DCQCN, then WQ/CQ and PCIe, QPC/cache, port loss and PFC. Sweep at
+  least two dimensions per claim: WQ depth/batch/SGE/payload/signaling; QP and
+  MR working sets; page size and context locality; PCIe width/NUMA/ordering;
+  CQ depth/poll cadence; MTU/direction/loopback; loss location/rate/burst;
+  DCQCN timers/rates/ECN; and PFC headroom/incast/RTT. Use Collie cases as
+  reproducer seeds, not CX-7 truth, since its Mellanox results are CX-6 and
+  omit packet-loss, control-path and NDA diagnostic-counter details. Match
+  transaction identity through the first loss or queue knee, classify every
+  drop by evidence tier, and defend WQE latency, FCT/JCT, useful/raw bytes,
+  queue depth, cache miss, retry, CQE, CNP and pause metrics.
+
 ## Backend-repo follow-ups (tracked here, executed in their repos)
 
 - HTSIM-1: `rnic-ss` (Slingshot-like) profile wiring; the runtime factory
@@ -139,16 +302,22 @@ and its ECMP-collision and slow-start behavior is the phenomenon under study.
 - HTSIM-2: goodput/state/queue trace flags for `rnic-cn`; they need trace
   hooks in the reviewed runtime first.
 - HTSIM-4: GOAL parser hardening and the checked-in `txt2bin` build target.
-- HTSIM-5: behavioral per-WQE starting for the DCQCN comparator (maintainer
-  direction 2026-08-05). The common SQ/RQ/CQ ledger and directed-pair QP
-  identity landed in `d778326`; fixed WQE initiation latency, DCQCN rate state
-  shared by WQEs of one pair, and behavioral SQ pipelining remain. Calibrate
-  them against the message-size-vs-bandwidth
-  anchors and candidate parameter sets in
+- HTSIM-5: persistent DCQCN policy state across hardware WQEs. On
+  2026-08-07 the former hardware-specific per-WQE-start scope was merged into
+  the BACK-9 RDMA Work Queue; this stable ID remains open for the unfinished
+  CC behavior. One QP's alpha, current/target rate, CNP suppression, byte and
+  timer recovery state must survive across its WQEs and reset only with the
+  modeled QP lifecycle. A new QP starts at its configured line/local-QoS rate;
+  HTSIM-9 carries CNP/ECN feedback to this policy and carries its rate update
+  back to the SimLLM hardware gate. The policy never owns that gate. Doorbell,
+  DMA and CQ costs are common across all policies and must not be charged only
+  to DCQCN. Calibrate policy parameters against
   [docs/papers/msg-size-vs-bandwidth.md](../papers/msg-size-vs-bandwidth.md)
-  (UCCL Fig. 14/15a, the 256 KB half-rate datum, DCQCN paper and vendor
-  timer sets). Acceptance bars recorded there, micro-behavior anchors in
-  examples/dcqcn_micro. Source-level findings from the micro study's
+  using the DCQCN algorithm and vendor timer sets plus post-CNP repeated-WQE
+  traces. The UCCL no-loss curve and 256 KB half-rate datum now calibrate
+  BACK-9/BACK-10 hardware and must not be fitted again in the policy. The
+  existing micro-behavior anchors are in examples/dcqcn_micro. Source-level
+  findings from the micro study's
   review, now the concrete work items: every send op constructs a fresh
   DCQCN source at line rate with no cross-WQE rate state
   (dcqcn_atlahs_runtime.cpp:398), the additive/hyper increase is
@@ -162,19 +331,33 @@ and its ECMP-collision and slow-start behavior is the phenomenon under study.
   algorithm book's S_max regime but reachable by WQE-flood workloads;
   the measured per-flow control cost also scales with flow count, not
   bytes (16 KiB flood streams cap at 0.36 to 0.46 C). Both are adjacent to
-  HTSIM-6's remaining behavioral work: queue lookahead removes the per-WQE
-  declare cost, and the event-loop scaling needs its own look.
-- HTSIM-6: rnic-cn WQE-queue lookahead (maintainer design 2026-08-05): a
-  timing-neutral SQ and directed link-pair identity landed in `d778326`.
-  The established-pair fast path still must avoid waiting when granted
-  bandwidth suffices, and the endpoint must pre-declare one RTT ahead for
-  queued WQEs of the same destination to hide later declare latency. Design
-  and expected effects are in the same doc; the behavior belongs in the htsim
-  algorithm book alongside the bootstrap control slots.
+  HTSIM-6 and BACK-9: policy lookahead removes the repeated declare cost,
+  structural WQ backpressure limits how much work can be exposed, and the
+  event-loop scaling needs its own look.
+- HTSIM-6: `rnic-cn` policy lookahead (maintainer design 2026-08-05). The
+  established-pair fast path must not wait when granted bandwidth suffices,
+  and the policy receives bounded lookahead from BACK-9 so it can pre-declare
+  one RTT ahead for queued work toward the same destination. The WQ, WQE and
+  QPC remain SimLLM hardware state; htsim retains only link-pair reservation,
+  control-slot and predeclaration state. The timing-neutral SQ and directed
+  link-pair identity in `d778326` remain the compatibility ledger until the
+  adapter lands.
 - HTSIM-8: repair the backend `commit_check.sh` validation gate. Current
   `origin/main` has no `validate_outputs` baselines, `validate.py` divides by
   zero in every attempted case, and the script lacks fail-fast handling, so
   it reports a false success. Add checked-in baselines or remove that compare,
   fix zero-flow diagnostics, and make every failed command fail the gate.
+- HTSIM-9: add the htsim side of the SimLLM RNIC extension. The combined
+  session still implements `AtlahsFlowRuntime`, while the inner versioned port
+  carries only opaque flow/packet tokens, transmit descriptors, delivery,
+  drop/ECN, receive, pause and link-state events. Hardware submits an opaque
+  CC-context token plus packet metadata; the policy returns eligibility/rate
+  updates, and htsim returns delivery or feedback to the hardware. It must use
+  the same SimLLM hardware implementation for `rnic-nn`, `rnic-cn` and DCQCN,
+  transport PFC frames through htsim queues, and keep the fluid bypass
+  explicit. No WQ, CQ, QP, QPC, PCIe, DMA or hardware scheduling state may
+  live in this adapter.
+  Develop it only in the HTSIM repo's dated append-only addon branch, then
+  update the SimLLM submodule pin.
 - ATLAHS-1: correct the vendored-fallback wording (the vendored htsim tree
   cannot satisfy the resolver) and pin a known-good HTSIM commit.

--- a/docs/papers/msg-size-vs-bandwidth.md
+++ b/docs/papers/msg-size-vs-bandwidth.md
@@ -1,13 +1,12 @@
-# Message size vs bandwidth: extracted data and starting-behavior parameters
+# Message size vs bandwidth: hardware and CC calibration parameters
 
-Working note for calibrating the DCQCN comparator's per-WQE starting
-behavior (and the rnic-cn WQE-queue prefetch design). Source PDFs live in
-the gitignored `papers/` directory at the repo root; this summary and the
-extracted numbers are the committed record. Maintainer direction
-(2026-08-05): every WQE is a flow start, so the comparator must reproduce
-the measured message-size-vs-bandwidth curves, with two candidate
-mechanisms to parameterize: the mlx5-style fixed per-WQE latency and the
-DCQCN rate ramp.
+Working note for calibrating the common RNIC hardware initiation envelope,
+the persistent DCQCN rate state and the `rnic-cn` WQ lookahead policy. Source
+PDFs live in the gitignored `papers/` directory at the repo root; this summary
+and the extracted numbers are the committed record. The 2026-08-07
+architecture split assigns WQ/PCIe/DMA behavior to the SimLLM hardware model
+and CC state to htsim. The complete queueing, mlx5 capture and CX-7 evidence
+plan is [rnic-hardware-calibration.md](rnic-hardware-calibration.md).
 
 ## Sources
 
@@ -84,15 +83,18 @@ DCQCN rate ramp.
 
 ## Candidate parameter sets
 
-Two mechanisms, parameterized separately; the calibrated comparator
-composes them (a WQE pays the fixed initiation latency, and its flow
-inherits the QP's DCQCN rate state).
+Two separately owned mechanisms are composed in a full-RNIC run. Model A is a
+reduced-form check on common hardware initiation and queue service; Model B is
+the CC policy state inherited by later WQEs on the same QP. Model A must not be
+charged only to DCQCN.
 
-### Model A: mlx5 fixed per-WQE latency
+### Model A: common RNIC hardware initiation envelope
 
 Effective goodput of a stream of S-byte WQEs with Q outstanding:
 `B(S, Q) = S / (T0/Q + S/C)`; the half-rate message size is
-`S_half = T0 C / Q`. Fitting T0:
+`S_half = T0 C / Q`. If the structural posting, MMIO, WQE/context fetch,
+admission and completion queues are collapsed into one diagnostic number,
+fitting T0 gives:
 
 | Set | T0 | Anchor |
 |---|---|---|
@@ -104,6 +106,12 @@ The UCCL Fig. 15a 8 KB plateau under contended all-to-all fits T0 of
 about 12 us at Q = 128, consistent with A3 once contention is added; A2
 sits between the clean anchors, and A2 at Q = 16 predicts 32 KB at
 ~34 GB/s, inside the Fig. 14 band.
+
+T0 is not an implementation sleep on every WQE. BACK-9/BACK-10 must reproduce
+the envelope through explicit doorbell batching, finite queues, shared PCIe
+service, context locality and overlapped WQE issue, while retaining each stage
+timestamp. The fitted values remain regression summaries and initialization
+bounds for measurements that are not yet available.
 
 ### Model B: DCQCN rate ramp (per-QP state the WQE inherits)
 
@@ -150,34 +158,37 @@ Readings:
   have no pipelining or state reuse across WQEs of the same
   destination. Real NICs pipeline the queue (UCCL's Q = 16 curve), and
   the maintainer's cn design amortizes the control cost (below).
-- The current dcqcn model never ramps: it has no CNP-driven rate state,
-  so an uncontended flow always runs at line rate. Everything in Model
-  B is missing; the loss recovery and rate cut exist only under actual
-  congestion events.
+- The current DCQCN runtime recreates source state per WQE, so policy state
+  does not persist into later WQEs on the same QP. An uncontended WQE starts
+  at line rate, as it should; post-CNP persistence and recovery across WQEs in
+  Model B remain missing.
 
 ## Calibration and design tasks
 
-- HTSIM-5 (backend, see docs/modules/backends.md): give the DCQCN
-  comparator per-WQE starting behavior: a fixed initiation latency
-  (Model A, sets A1 to A3 as CLI parameters, default A2) and per-QP
-  DCQCN rate state shared by WQEs of the same source-destination pair
-  (Model B, sets D1 to D3, default D3 at 400G), plus pipelined WQE
-  queues (Q outstanding). Acceptance: reproduce the UCCL Fig. 14
-  no-loss curve within 15 percent at Q = 16, and the maintainer's
-  256 KB half-rate datum at Q = 1 under A2.
-- HTSIM-6 (backend, maintainer design 2026-08-05): rnic-cn WQE-queue
-  lookahead. A WQE toward a destination whose link table is already
-  established (DECLAREs never expire) must not wait when the granted
-  bandwidth suffices; and the endpoint checks its WQE queue one RTT
-  ahead and pre-declares bandwidth for queued WQEs of the same
-  destination, hiding the declare latency of later WQEs behind the
-  transmission of earlier ones. Expected effect on the probe: the
-  16-deep same-destination queue collapses from 16 x 11.0 us of serial
-  control cost toward fluid-plus-one-setup, and the sub-BDP corners
-  (the 1.68x buffer-absorbed incast, the 14.3x a2a16 tail vs rnic-nn)
-  shrink toward the large-flow 1.13 to 1.17x band.
+- BACK-9/BACK-10 (SimLLM): implement Model A as structural WQ/CQ and
+  MMIO/PCIe/DMA service shared by every full-RNIC policy. Sweep the A1 to A3
+  envelope as a diagnostic, not as three hard-coded sleeps. Acceptance:
+  reproduce UCCL Fig. 14 no-loss goodput within 15 percent at Q = 16 and the
+  maintainer's 256 KB half-rate datum at Q = 1 under the A2 summary, while
+  accounting for every stage and PCIe byte.
+- HTSIM-5 (backend): implement Model B as persistent DCQCN policy state shared
+  by WQEs of one hardware QP. Sweep D1 to D3, start a new QP at line/local-QoS
+  rate, then verify that a controlled CNP affects later WQEs until timer/byte
+  recovery restores the rate. The policy must not add doorbell, DMA or CQ
+  cost.
+- HTSIM-6 (backend): implement `rnic-cn` policy lookahead. A WQE toward a
+  destination whose link table is already established must not wait when the
+  granted bandwidth suffices; the policy receives bounded lookahead from
+  BACK-9 and pre-declares one RTT ahead. Expected effect on the probe: the
+  16-deep same-destination queue collapses from 16 x 11.0 us of serial control
+  cost toward fluid-plus-one-setup, and the sub-BDP corners (the 1.68x
+  buffer-absorbed incast, the 14.3x a2a16 tail vs `rnic-nn`) shrink toward the
+  large-flow 1.13 to 1.17x band.
+- BACK-8/HTSIM-9 own the common C++ boundary. A comparison is invalid if the
+  hardware configuration hash differs between `rnic-nn`, `rnic-cn` and
+  DCQCN.
 
 The probe above is a gap measurement, not a registered study; the
-registered validation of the calibrated behaviors happens with the
-HTSIM-5/HTSIM-6 landings, with expectations frozen against the anchor
-tables in this note.
+registered validation of the calibrated behaviors happens with the relevant
+BACK-9/BACK-10/HTSIM-5/HTSIM-6 landings, with expectations frozen against the
+anchor tables in this note.

--- a/docs/papers/rnic-hardware-calibration.md
+++ b/docs/papers/rnic-hardware-calibration.md
@@ -1,0 +1,245 @@
+# RNIC hardware calibration and boundary plan
+
+This is the public evidence and calibration plan for the SimLLM RNIC hardware
+model. The numbered implementation tasks are BACK-8 through BACK-15 and
+HTSIM-5, HTSIM-6 and HTSIM-9 in
+[the backend module registry](../modules/backends.md). Source PDFs are kept in
+the gitignored `papers/` directory; this file records what may be claimed from
+them and how measurements will be used.
+
+## Architecture decision
+
+RNIC hardware and transport/congestion control are independent model axes.
+The structural hardware model is SimLLM-owned C++ under
+`simllm/backends/rnic/`. It is compiled into the directly invoked simulator
+process so the packet event loop has no Python callback. htsim retains the
+selectable `rnic-nn`, `rnic-cn` and DCQCN policies and the packet fabric.
+
+```text
+ibverbs capture or GOAL lowering
+  -> SimLLM WR/WQE, WQ, QP/QPC, PCIe/DMA and TX hardware
+  -> versioned htsim policy/fabric port
+  -> htsim CC decision, packet queues, ECN, loss and PFC transport
+  -> SimLLM RX, reliability, payload DMA and CQ/CQE hardware
+  -> poll, completion channel or interrupt
+```
+
+Every full-RNIC comparison uses the same hardware configuration hash and
+changes only the policy. `rnic-nn-fluid` retains an explicit hardware bypass
+for closed-form validation. The boundary carries opaque flow and packet
+tokens, packet metadata, transmit eligibility, delivery, ECN/CNP, drop,
+pause and link events. WQ, CQ, QP, QPC, PCIe and DMA objects do not cross it.
+
+State ownership is deliberately narrow:
+
+- SimLLM owns WR/WQE/CQE contents, SQ/RQ/SRQ/CQ service, QP lifecycle and
+  pairing, PSN and reliability state, context and translation caches,
+  MMIO/PCIe/DMA, packetization and reassembly, TX/RX arbitration, the
+  hardware rate gate, PFC watermarks/gates and completion delivery.
+- An htsim policy owns only its algorithm state. DCQCN owns alpha,
+  current/target rate, CNP suppression and recovery timers. `rnic-cn` owns
+  reservation, control-slot and predeclaration state. Policy updates drive
+  the SimLLM hardware rate gate.
+- The htsim fabric owns links, switch queues, ECN marking, propagation,
+  wire/switch drops and PFC-frame transport. A SimLLM RNIC originates or
+  consumes a PFC frame from its modeled per-priority buffers.
+
+This split prevents a DCQCN result from paying a different doorbell, cache or
+DMA cost than `rnic-nn` or `rnic-cn`. It also permits one hardware calibration
+to be reused when a later policy is added.
+
+## Corrections to the initial mental model
+
+Four refinements are required by the public evidence:
+
+1. **Per-WQE start is a timeline, not a constant.** `ibv_post_send` may
+   publish a linked WR list with one doorbell, the provider may inline a WQE
+   through BlueFlame, and the NIC may fetch and overlap several WQEs. The
+   structural model records posting, publication, observation, fetch,
+   context readiness, admission and packet issue separately. A fitted fixed
+   latency remains useful only as a reduced-form diagnostic.
+2. **TCP is a pairing option, not RoCE data transport.** A manual program may
+   exchange QPN, PSN, GID and path attributes over a TCP socket before QP
+   transitions, while `rdma_cm` or IB-CM provides another control path. TCP
+   carries RDMA data only for iWARP. Both control-plane pairers feed the same
+   QP state machine.
+3. **The three-tier context hierarchy is generic.** The model exposes
+   `on_die_sram`, optional `device_memory` and `host_pinned_memory`. Public
+   evidence supports an internal context cache with host ICM backing over
+   PCIe, but does not establish a ConnectX-7 HBM tier or its geometry. The
+   optional middle tier is disabled in the CX-7 profile until a documented
+   or measured source justifies it.
+4. **Collie supplies search dimensions and reproducer seeds.** Its public
+   Mellanox cases are based on ConnectX-6, omit switch-loss experiments and
+   cannot publish several NDA diagnostic counters. Its anomaly thresholds
+   are not copied into a CX-7 profile as constants.
+
+## Truth and observability contract
+
+Every CX-7 model field carries one evidence class:
+
+| Class | Meaning | Permitted use |
+|---|---|---|
+| `documented` | Defined in a public specification, driver interface or vendor manual | Reproduce the named field, units, access and documented semantics |
+| `driver-inferred` | Behavior follows from reviewed Linux mlx5 or rdma-core source but lacks a public silicon contract | Implement the observed software-visible behavior and retain source/version provenance |
+| `calibrated-opaque` | Internal stage is not public but its aggregate effect is identifiable from controlled measurements | Use a named latent parameter with confidence bounds; do not expose a fabricated physical register |
+
+The register model is therefore a versioned observable-state facade, not a
+claim to reproduce a private CX-7 register map. Each field records logical
+name, units, width, access, reset/snapshot behavior, collection command,
+firmware/PSID, kernel, rdma-core and MFT versions, PCIe topology, timestamp and
+evidence class. Unsupported physical addresses, cache associativity,
+scheduler registers and firmware-private state remain absent.
+
+| Surface | What can anchor the model | Important limit |
+|---|---|---|
+| rdma-core mlx5 provider | WR validation, WQE construction, DB record, UAR/BlueFlame publication, CQ polling and CQE decoding | This is user-space fast-path evidence, not a silicon timing specification |
+| Linux mlx5 RDMA driver | QP/CQ/MR creation and modification, firmware command fields, resource dumps and hardware-counter plumbing | Normal send/receive posting bypasses the kernel |
+| Linux network/devlink/DCB | `ethtool -S`, RDMA hardware counters, resource/statistic views, health reporters, PFC configuration and pause counters | Availability depends on kernel, firmware and enabled counter groups |
+| PCIe and platform telemetry | Link generation/width, MPS/MRRS, NUMA path, IOMMU state, AER and device locality | It exposes the path, not private RNIC scheduling |
+| NVIDIA MFT/DOCA telemetry | Supported named registers, resource dumps and device counters | Only fields actually returned on the tested PSID/firmware may enter the facade |
+
+Primary software references are the rdma-core mlx5
+[QP posting path](https://github.com/linux-rdma/rdma-core/blob/master/providers/mlx5/qp.c)
+and [CQ polling path](https://github.com/linux-rdma/rdma-core/blob/master/providers/mlx5/cq.c),
+the Linux mlx5 [RDMA QP control path](https://github.com/torvalds/linux/blob/master/drivers/infiniband/hw/mlx5/qp.c),
+[counter documentation](https://docs.kernel.org/networking/device_drivers/ethernet/mellanox/mlx5/counters.html)
+and [devlink interface](https://docs.kernel.org/networking/devlink/mlx5.html).
+
+## ibverbs capture and replay hook
+
+The capture point must reflect how mlx5 applications really submit work:
+
+1. Capture QP, CQ, SRQ, PD and MR creation/modification at the provider and
+   kernel control paths. Record returned resource identities, QP transitions,
+   path attributes, retry/RNR settings and memory mappings.
+2. Instrument the rdma-core mlx5 provider data path around send/receive WR
+   validation, WQE construction, the publication barrier, DB-record update,
+   UAR/BlueFlame doorbell and CQ polling. This sees linked WR lists and
+   provider-specific fast paths that a kernel probe cannot see.
+3. Keep a generic `LD_PRELOAD` verbs wrapper as a convenient application
+   experiment, not the signoff oracle. Direct operation tables, inlining and
+   provider extensions can bypass it.
+4. Normalize capture and SimLLM lowering into one BACK-9 schema. Preserve WR
+   ID, opcode, SGEs, flags, queue identity, QP state, batch position and all
+   observable timestamps. Payload bytes are excluded by default.
+5. Correlate CQ polling to the normalized CQE. `wr_id` is normally recovered
+   by the provider from its WQ metadata rather than read as a literal raw CQE
+   field, so the schema records both the raw-source fields and provider-derived
+   fields.
+
+The manual pairer follows the normal RC example pattern: establish a host TCP
+connection, exchange QPN/PSN/GID/path data, then apply RESET to INIT to RTR to
+RTS transitions. The alternate pairer records `rdma_cm` events. Both produce
+the same normalized pairing record and both cover timeout, rejection,
+attribute mismatch and teardown.
+
+## Structural RDMA Work Queue
+
+The landed `AtlahsWqeLedger` is only a timing-neutral compatibility view. The
+replacement is a queueing model with explicit transactions and credits:
+
+| Object/stage | Required behavior |
+|---|---|
+| WR and WQE | Linked WR lists, opcode/SGE/fence/inline/signaling semantics, WQEBB use, batch position and stable transaction identity |
+| SQ | Finite host ring, producer and NIC consumer, wrap/reclamation, doorbell batching, DB records, UAR and BlueFlame paths |
+| RQ and SRQ | Posted receive buffers, matching/consumption, RNR behavior, finite depth, replenishment and sharing |
+| CQ | Finite host-memory ring, producer/consumer and owner phase, requester/responder/error formats, 64/128-byte profiles, moderation, compression, overrun, polling and completion channels |
+| PCIe and DMA | Separate queues and credits for MMIO, WQE/context/translation/payload reads, payload/CQE writes, completions, commands and interrupts |
+| TX and RX | Context readiness, packetization/reassembly, arbitration, policy rate gate, PFC gate, port queues, ACK/NAK/retry and error transition |
+
+The normalized CQE contains WR ID, QPN or source QP, opcode, status, byte
+count, immediate/invalidate data, flags, syndrome and vendor syndrome, with
+provenance for every provider-derived field. Unsignaled sends retire SQ space
+without requiring one CQE per WQE; receives and errors still follow their
+documented completion rules.
+
+Each WQE records at least:
+
+```text
+posted_at
+doorbelled_at
+doorbell_seen_at
+wqe_fetch_begin_at
+wqe_fetch_end_at
+qpc_ready_at
+admitted_at
+first_packet_at
+last_packet_at
+transport_retired_at
+cqe_visible_at
+polled_at
+```
+
+Stages that a selected path bypasses, such as a WQE DMA fetch after a
+BlueFlame copy, are explicitly `not_applicable`, never silently zero.
+`first_packet_at` is the defined NIC start. The other timestamps allow a
+calibration to identify whether a boundary came from CPU posting, MMIO, DMA,
+context locality, hardware scheduling, transport or CQ service instead of
+fitting all of them into one number.
+
+## Evidence corpus
+
+| Source | Local PDF and SHA-256 | Use in this model |
+|---|---|---|
+| [Collie, NSDI 2022](https://www.usenix.org/conference/nsdi22/presentation/kong) | `papers/collie-nsdi22.pdf`, `6ad0c5418193ad65cbe08b9472a5631506c6a9ec1ac5a20abdd1d8433172039e` | Anomaly-search dimensions and Mellanox reproducer seeds |
+| [Understanding the Microarchitecture of Modern RNICs, NSDI 2023](https://www.usenix.org/system/files/nsdi23-kong.pdf) | `papers/rdma-microarchitecture-nsdi23.pdf`, `ce026cfaa7a25eaa3b585edaa26078e4300bb145837f8fc48641c9502b1ef2d9` | Context/WQE/translation caches, data-path boundaries and cache-pressure experiments |
+| [SRNIC, NSDI 2023](https://www.usenix.org/system/files/nsdi23-wang-zilong.pdf) | `papers/srnic-nsdi23.pdf`, `6c03f49a630babef65cf8a42bd3d671b3af9edff77b408bd26c96eb6691808c4` | Structural QP/WQE/PCIe model and scale thought experiments, not CX-7 constants |
+| [Design Guidelines for High Performance RDMA Systems, ATC 2016](https://www.usenix.org/system/files/conference/atc16/atc16_paper-kalia.pdf) | `papers/kalia-atc16-rdma-guidelines.pdf`, `f69540e83bfc79e1885fd4ed9b64239fb409c5618627694452cf3fbe03c918fb` | Doorbell/BlueFlame, batching, inline and completion-signaling mechanics |
+| [Understanding PCIe performance for end host networking, SIGCOMM 2018](https://web.stanford.edu/class/cs244/papers/neugebauer-sigcomm18.pdf) | `papers/pcie-end-host-sigcomm18.pdf`, `f535d231cbe334f8ee136ec9a124de743b1f76b025c558d9cff756561ed0322e` | PCIe transaction, concurrency, MPS/MRRS, NUMA and IOMMU experiments |
+| [DCQCN, SIGCOMM 2015](https://www.microsoft.com/en-us/research/publication/congestion-control-for-large-scale-rdma-deployments/) | `papers/dcqcn-sigcomm15.pdf`, `879074a33b78ceb93f9f66d59b217fba9e7621320cc68bc47914747cf5cf31f8` | Persistent per-QP DCQCN state and recovery parameters |
+| [HPCC, SIGCOMM 2019](https://arxiv.org/abs/1903.10924) | `papers/hpcc-sigcomm19.pdf`, `8199b81f7325b8797623b6c44fad90eb2664b4bc6a8e0f9bdbad7e043b02fe8a` | DCQCN timer/ECN sensitivity and PFC tradeoffs |
+| [UCCL](https://arxiv.org/abs/2504.17307) | `papers/uccl-2504.17307.pdf`, `5a6fe7e2735f972bfcc3c5d1c501098989c908a5c8adf9171fd017829d178994` | ConnectX-7-class message-size, outstanding-work and loss anchors |
+
+Collie varies operation, payload, MTU, QP count, WQ depth, batch, SGE/MR
+layout, direction, concurrency, host memory and PCIe placement. Those
+dimensions seed the campaign below. They are expanded with explicit loss,
+control-plane pairing, CQ service, GPU Direct and CX-7 provenance.
+
+## Pre-registered boundary campaign
+
+Each campaign gets its own frozen `expectations.md` before execution. Every
+claim sweeps at least two parameters, retains raw results outside Git under
+`/data3/yifeng/`, and reports both median behavior and tail/first-failure
+evidence.
+
+| Campaign | Minimum sweep | Expected invariant or boundary |
+|---|---|---|
+| WR/WQE publication | payload `{32 B, 4 KiB, 32 KiB, 256 KiB, 4 MiB}` x outstanding `{1, 4, 16}` x doorbell batch `{1, 4, 16}` | MMIO events per WQE fall with batching; useful goodput approaches line rate with enough independent work; a queue/cache knee must be localized rather than hidden in one latency |
+| CQ service | CQ depth `{64, 1024, 16384}` x signaling interval `{1, 16, 64}` x busy-poll cadence | Unsignaled operation reduces CQE DMA and polling work; producer never overwrites an owned entry without an explicit overrun/error; normalized completions preserve WR identity |
+| QP/QPC and translation locality | active QPs `{1, 16, 256, 4096, 16384}` x sequential/round-robin reuse x MR page size `{4 KiB, 2 MiB}` | Hot locality is flat until capacity pressure; misses add attributable PCIe/context service; QPC and MTT/MPT knees need not coincide |
+| PCIe/MMIO/DMA | local/remote NUMA x CPU/GPU memory x observed MPS/MRRS and outstanding-read settings | Bytes and latency reconcile per transaction class; remote/IOMMU paths cannot outperform an otherwise identical local/bypass path without measured evidence |
+| TX/RX loss | injection location `{pre-TX, wire/switch, pre-RX}` x deterministic `1/256`, Bernoulli `{1e-6, 1e-4, 1e-2}` and burst `{1, 8, 64}` | Controlled drop count is exact for deterministic runs; first missing packet and first affected WQE remain identifiable; retry, timeout and completion status depend on location and opcode |
+| PFC | incast fan-in `{2, 8, 32}` x headroom `{0.5, 1, 2}` times post-XOFF in-flight bytes x path RTT `{1, 5, 20 us}` | Adequate headroom prevents priority-buffer loss; insufficient headroom produces an attributed RX drop; pause duty cycle and blocked unrelated traffic are reported separately from DCQCN |
+| DCQCN first | fan-in and background load x ECN thresholds x timer/rate parameter sets | A new QP begins at line/local-QoS rate before feedback; a CNP changes persistent per-QP state seen by later WQEs; changing CC never changes hardware MMIO/DMA/cache accounting |
+| `rnic-cn` lookahead | same-destination queue depth x available grant x payload | Established sufficient grants avoid repeated setup; bounded lookahead hides later declaration behind current transfer without moving WQ/QPC state into htsim |
+
+The loss ledger uses three evidence tiers: `controlled` when the injector names
+the transaction, `asserted` when an invariant or model assertion identifies
+the first loss, and `inferred` only when counters bracket the event. A run is
+not accepted if it reports only aggregate goodput while losing transaction
+identity.
+
+Core metrics are WQE stage latency, per-flow FCT, phase makespan/JCT,
+TTFT/TPOT, useful and raw PCIe/wire bytes, queue occupancy, context and
+translation misses, retry/RNR/timeout, CQE count and age, CNP/ECN state, pause
+duration and drops by named boundary. Physical-policy FCT is also normalized
+to the identical `rnic-nn` GOAL where starts are aligned.
+
+## Work order and closure
+
+1. BACK-13 and BACK-14 establish the provenance schema and capture path early,
+   so implementation parameters come from evidence rather than retrospective
+   fitting.
+2. BACK-8 and HTSIM-9 establish the C++ hardware/policy ABI and prove that all
+   full-RNIC profiles share one hardware configuration.
+3. BACK-9 and BACK-10 implement WQ/CQ plus PCIe/MMIO/DMA queues and close the
+   no-loss message-size and batching anchors.
+4. BACK-11 adds QP pairing, lifecycle and separate QPC/WQE/translation
+   locality; its cache tiers remain generic and evidence-labelled.
+5. BACK-12 adds TX/RX reliability, named loss boundaries and PFC hardware.
+   HTSIM-5 closes persistent DCQCN state first, then HTSIM-6 closes `rnic-cn`
+   lookahead.
+6. BACK-15 runs the full cross-layer campaign. Closure requires defended
+   queue knees and first-failure evidence, not only passing unit tests or a
+   visually similar bandwidth curve.

--- a/examples/rnic_wq_v1/RESULTS.md
+++ b/examples/rnic_wq_v1/RESULTS.md
@@ -1,0 +1,100 @@
+# RNIC WQ v1 results
+
+All 11 pre-registered sweep cells pass exactly. The dependency-free native
+unit harness also passes every directed SQ/CQ/network-port boundary check.
+
+## Method
+
+The study builds the SimLLM-owned C++17 `simllm::rnic` library and its fake
+network port, runs CTest, then executes the parameter grid frozen in
+[expectations.md](expectations.md). The fake network is only a deterministic
+credit and completion oracle. It does not claim to model wire packets or
+htsim behavior.
+
+Reproduce from the repository root:
+
+```bash
+python examples/rnic_wq_v1/run_rnic_wq_v1.py
+```
+
+Raw rows are in [results.csv](results.csv).
+
+## Sweep A: doorbell batching and signaling
+
+All nine `B x S` cells match their closed forms with zero residual.
+
+| Doorbell batch B | Measured doorbells | Measured JCT (ps) | Expected JCT (ps) |
+|---:|---:|---:|---:|
+| 1 | 32 | 32010 | 32010 |
+| 4 | 8 | 8040 | 8040 |
+| 16 | 2 | 2160 | 2160 |
+
+For every B, signaling intervals `{1, 4, 16}` produce exactly `{32, 8, 2}`
+CQEs and leave JCT unchanged. This is the expected result because the study
+polls at every event, CQ never overruns, and CQE-write latency is zero.
+Doorbell count is exactly `32 / B`; JCT is exactly
+`(32 / B) * 1000 + B * 10` ps.
+
+The important separation is visible: batching changes hardware publication
+work, while signaling changes completion traffic. The model does not use a
+single per-WQE delay to stand in for both.
+
+## Sweep B: network backpressure
+
+Both credit cells match the pre-registered queueing equation exactly.
+
+| Network capacity C | Measured busy attempts | Expected | Measured JCT (ps) | Expected (ps) |
+|---:|---:|---:|---:|---:|
+| 1 | 15 | 15 | 16110 | 16110 |
+| 4 | 12 | 12 | 4140 | 4140 |
+
+The exact form is `100 + C * 10 + (16 / C) * 1000` ps. A busy return stalls
+the SQ head until the network advertises its next retry time. No later WQE
+bypasses that head.
+
+## Conservation and evidence
+
+Every sweep row reports:
+
+- posted WQEs = delivered WQEs = reclaimed WQEs;
+- SQ high watermark equal to the offered WQE count;
+- zero controlled error evidence;
+- zero CQ overruns and no fatal state.
+
+The native directed harness separately proves:
+
+- accepted-prefix behavior when a three-WR chain reaches an SQ of depth two;
+- all-unsignaled SQ exhaustion and later-signaled reclamation;
+- ordered retirement under out-of-order network callbacks;
+- deterministic network-busy retry without head bypass;
+- an RX-boundary injected drop producing a controlled error CQE even when the
+  WQE was unsignaled;
+- CQ overrun identifying the first undeliverable CQE without overwriting the
+  owned entry, then freezing later CQ publication and reclaim without
+  exposing a schedulable event that can spin the event loop;
+- CQ slot wrap with owner generation `{0, 0, 1, 1}`;
+- a policy retry gate surviving an unrelated network completion;
+- serialized CQE-write service, no skipped older CQE, and explicit host-first
+  same-time polling;
+- distinct network-acceptance/outcome timestamps without fabricated packet
+  issue timestamps;
+- controlled immediate rejection and rejection of contradictory or
+  out-of-range drop evidence;
+- rejection of unknown network tokens and timestamp overflow.
+
+## What this closes and what remains
+
+This validates the first structural mechanism of BACK-8/BACK-9: one finite SQ
+and CQ bound to one QP, WR-chain accepted-prefix posting, doorbell batches,
+absolute producer/reclaim sequencing, signaled and unsignaled completion,
+controlled queue failures, and an engine-neutral network-side ABI. The ABI
+preserves GOAL flow/tag identity and an opaque policy-context token while the
+network retains its own completion token; no CC implementation owns WQ, CQ or
+QP state.
+
+BACK-8 remains open for the live `AtlahsFlowRuntime` wrapper and versioned run
+records. BACK-9 remains open for RQ/SRQ, multiple SQs sharing CQs, mlx5 WQEBB
+encoding, fences, inline/BlueFlame paths, CQE compression/moderation and
+interrupt delivery. PCIe/QPC/packet/retry behavior remains BACK-10 through
+BACK-12. No physical latency parameter has been fitted from these synthetic
+runs.

--- a/examples/rnic_wq_v1/expectations.md
+++ b/examples/rnic_wq_v1/expectations.md
@@ -1,0 +1,98 @@
+# RNIC WQ v1 expectations
+
+Frozen before the first native WQ model run on 2026-08-07.
+
+## Scope
+
+This study validates the first structural slice of BACK-8/BACK-9: one finite
+send queue and one finite completion queue bound to one QP, a batched
+doorbell, ordered WQE retirement, signaled/unsignaled completion semantics and
+an opaque network-side transfer port. One accepted network descriptor is one
+WQE extent in this slice. Packetization, receive queues, retries, QPC caching
+and PCIe service remain later slices.
+
+All runs use deterministic picosecond time. CQ polling occurs at every event,
+CQE-write/QPC/scheduler latency is zero, the final WQE is signaled, and the
+network neither drops nor rejects a transfer.
+
+## Sweep A: doorbell batching and signaling
+
+Post `N = 32` WQEs at time zero into an SQ/CQ of depth 64. Sweep doorbell
+batch size `B` in `{1, 4, 16}` and signaling interval `S` in `{1, 4, 16}`.
+Use doorbell service `D = 1000 ps`, WQE-fetch service `F = 10 ps`, network
+capacity 32 and zero network latency. All doorbells are issued at time zero.
+Because `D >= B * F`, each batch's fetches finish before the next doorbell is
+observed.
+
+Pre-registered exact expectations:
+
+- doorbell count is `N / B`;
+- CQE count is `N / S`;
+- JCT is `(N / B) * D + B * F`;
+- signaling changes CQE traffic but not JCT in this poll-fast, non-overrunning
+  configuration;
+- all 32 WQEs are accepted, delivered and reclaimed, with zero drops, SQ-full
+  rejections, network-busy attempts and CQ overruns.
+
+| B | Expected doorbells | Expected JCT (ps) |
+|---|---:|---:|
+| 1 | 32 | 32010 |
+| 4 | 8 | 8040 |
+| 16 | 2 | 2160 |
+
+| S | Expected CQEs |
+|---|---:|
+| 1 | 32 |
+| 4 | 8 |
+| 16 | 2 |
+
+## Sweep B: network backpressure
+
+Post `N = 16` signaled WQEs as one batch into an SQ/CQ of depth 32. Use
+`D = 100 ps`, `F = 10 ps`, fixed network latency `L = 1000 ps`, and sweep
+network in-flight capacity `C` in `{1, 4}`. Since C divides N, the completion
+lanes remain regular.
+
+Pre-registered exact expectations:
+
+- JCT is `D + C * F + (N / C) * L`;
+- network-busy attempts are `N - C`;
+- doorbell count is 1 and CQE count is 16;
+- all WQEs are delivered and reclaimed with no loss or overrun.
+
+| C | Expected busy attempts | Expected JCT (ps) |
+|---|---:|---:|
+| 1 | 15 | 16110 |
+| 4 | 12 | 4140 |
+
+## Directed boundary checks
+
+The native unit harness must additionally prove:
+
+1. Posting past SQ depth is a controlled rejection naming the WR, not a dark
+   drop.
+2. A successful unsignaled WQE retires but retains SQ occupancy until a later
+   signaled CQE is polled.
+3. Out-of-order network callbacks retire in SQ order.
+4. A controlled network drop creates an error CQE even for an unsignaled WQE
+   and preserves drop location/reason.
+5. Publishing a CQE into a full CQ creates a controlled fatal CQ-overrun event
+   naming the WQE.
+6. A busy network port stalls the SQ head and retries at the advertised time
+   without reordering.
+
+Before the final validation rerun, the native review added these adversarial
+checks without changing either sweep equation:
+
+7. The first lost CQE makes CQ overrun terminal. A later network completion
+   cannot publish a CQE or reclaim through the failed WQE.
+8. A completion for another network token cannot revoke a policy or PFC retry
+   gate advertised for the SQ head.
+9. The flow-level port records network acceptance and outcome but leaves first
+   and last packet timestamps unset until a packetized adapter supplies real
+   TX issue events.
+10. CQE writes serialize, and same-timestamp host-poll versus device-progress
+    priority is selected explicitly by call order without skipping any CQE
+    scheduled strictly before the poll.
+11. Contradictory delivery/drop evidence and timestamp overflow fail as
+    asserted model errors before they can corrupt counters or time.

--- a/examples/rnic_wq_v1/results.csv
+++ b/examples/rnic_wq_v1/results.csv
@@ -1,0 +1,12 @@
+sweep,wqes,doorbell_batch,signal_every,network_capacity,network_latency_ps,doorbell_service_ps,fetch_service_ps,doorbells,cqes,network_busy,jct_ps,posted,delivered,reclaimed,sq_high_watermark,cq_high_watermark,evidence_count,expected_doorbells,expected_cqes,expected_network_busy,expected_jct_ps,check
+doorbell_signaling,32,1,1,32,0,1000,10,32,32,0,32010,32,32,32,32,1,0,32,32,0,32010,PASS
+doorbell_signaling,32,1,4,32,0,1000,10,32,8,0,32010,32,32,32,32,1,0,32,8,0,32010,PASS
+doorbell_signaling,32,1,16,32,0,1000,10,32,2,0,32010,32,32,32,32,1,0,32,2,0,32010,PASS
+doorbell_signaling,32,4,1,32,0,1000,10,8,32,0,8040,32,32,32,32,1,0,8,32,0,8040,PASS
+doorbell_signaling,32,4,4,32,0,1000,10,8,8,0,8040,32,32,32,32,1,0,8,8,0,8040,PASS
+doorbell_signaling,32,4,16,32,0,1000,10,8,2,0,8040,32,32,32,32,1,0,8,2,0,8040,PASS
+doorbell_signaling,32,16,1,32,0,1000,10,2,32,0,2160,32,32,32,32,1,0,2,32,0,2160,PASS
+doorbell_signaling,32,16,4,32,0,1000,10,2,8,0,2160,32,32,32,32,1,0,2,8,0,2160,PASS
+doorbell_signaling,32,16,16,32,0,1000,10,2,2,0,2160,32,32,32,32,1,0,2,2,0,2160,PASS
+network_backpressure,16,16,1,1,1000,100,10,1,16,15,16110,16,16,16,16,1,0,1,16,15,16110,PASS
+network_backpressure,16,16,1,4,1000,100,10,1,16,12,4140,16,16,16,16,1,0,1,16,12,4140,PASS

--- a/examples/rnic_wq_v1/run_rnic_wq_v1.py
+++ b/examples/rnic_wq_v1/run_rnic_wq_v1.py
@@ -1,0 +1,259 @@
+"""Build and run the pre-registered native RNIC WQ v1 sweeps."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import re
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SOURCE_DIR = REPO_ROOT / "simllm" / "backends" / "rnic"
+DEFAULT_BUILD_DIR = REPO_ROOT / "build" / "rnic_wq_v1"
+RESULTS = Path(__file__).with_name("results.csv")
+
+
+def _native_executable(build_dir: Path, name: str) -> Path:
+    candidates = (
+        build_dir / name,
+        build_dir / f"{name}.exe",
+        build_dir / "Release" / name,
+        build_dir / "Release" / f"{name}.exe",
+    )
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    joined = ", ".join(str(candidate) for candidate in candidates)
+    raise RuntimeError(f"native executable not found; checked {joined}")
+
+
+def _build(build_dir: Path) -> Path:
+    subprocess.run(
+        [
+            "cmake",
+            "-S",
+            str(SOURCE_DIR),
+            "-B",
+            str(build_dir),
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DSIMLLM_RNIC_BUILD_TESTS=ON",
+            "-DSIMLLM_RNIC_BUILD_TOOLS=ON",
+            "-DSIMLLM_RNIC_WARNINGS_AS_ERRORS=ON",
+        ],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "cmake",
+            "--build",
+            str(build_dir),
+            "--config",
+            "Release",
+            "--parallel",
+        ],
+        check=True,
+    )
+    listed = subprocess.run(
+        ["ctest", "--test-dir", str(build_dir), "-C", "Release", "-N"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    match = re.search(r"Total Tests:\s+(\d+)", listed.stdout)
+    if match is None or int(match.group(1)) == 0:
+        raise RuntimeError("CTest did not discover the RNIC native test")
+    subprocess.run(
+        [
+            "ctest",
+            "--test-dir",
+            str(build_dir),
+            "-C",
+            "Release",
+            "--output-on-failure",
+        ],
+        check=True,
+    )
+    return _native_executable(build_dir, "simllm_rnic_wq_probe")
+
+
+def _probe(probe: Path, **parameters: int) -> dict[str, int]:
+    option_names = {
+        "wqes": "--wqes",
+        "doorbell_batch": "--doorbell-batch",
+        "signal_every": "--signal-every",
+        "network_capacity": "--network-capacity",
+        "network_latency_ps": "--network-latency-ps",
+        "doorbell_service_ps": "--doorbell-service-ps",
+        "fetch_service_ps": "--fetch-service-ps",
+        "sq_depth": "--sq-depth",
+        "cq_depth": "--cq-depth",
+    }
+    command = [str(probe)]
+    for name, value in parameters.items():
+        command.extend([option_names[name], str(value)])
+    completed = subprocess.run(command, check=True, capture_output=True, text=True)
+    rows = list(csv.DictReader(io.StringIO(completed.stdout)))
+    if len(rows) != 1:
+        raise RuntimeError(f"probe returned {len(rows)} rows, expected one")
+    return {name: int(value) for name, value in rows[0].items()}
+
+
+def _common_checks(row: dict[str, int], wqes: int) -> list[str]:
+    failures = []
+    for name in ("posted", "delivered", "reclaimed"):
+        if row[name] != wqes:
+            failures.append(f"{name}={row[name]} expected {wqes}")
+    if row["sq_high_watermark"] != wqes:
+        failures.append(
+            f"sq_high_watermark={row['sq_high_watermark']} expected {wqes}"
+        )
+    if row["evidence_count"] != 0:
+        failures.append(f"evidence_count={row['evidence_count']} expected 0")
+    return failures
+
+
+def _sweep_a(probe: Path) -> list[dict[str, int | str]]:
+    rows: list[dict[str, int | str]] = []
+    wqes = 32
+    doorbell_service_ps = 1000
+    fetch_service_ps = 10
+    for batch in (1, 4, 16):
+        for signal_every in (1, 4, 16):
+            measured = _probe(
+                probe,
+                wqes=wqes,
+                doorbell_batch=batch,
+                signal_every=signal_every,
+                network_capacity=32,
+                network_latency_ps=0,
+                doorbell_service_ps=doorbell_service_ps,
+                fetch_service_ps=fetch_service_ps,
+                sq_depth=64,
+                cq_depth=64,
+            )
+            expected_doorbells = wqes // batch
+            expected_cqes = wqes // signal_every
+            expected_jct_ps = expected_doorbells * doorbell_service_ps + (
+                batch * fetch_service_ps
+            )
+            failures = _common_checks(measured, wqes)
+            for name, expected in (
+                ("doorbells", expected_doorbells),
+                ("cqes", expected_cqes),
+                ("network_busy", 0),
+                ("jct_ps", expected_jct_ps),
+            ):
+                if measured[name] != expected:
+                    failures.append(f"{name}={measured[name]} expected {expected}")
+            rows.append(
+                {
+                    "sweep": "doorbell_signaling",
+                    **measured,
+                    "expected_doorbells": expected_doorbells,
+                    "expected_cqes": expected_cqes,
+                    "expected_network_busy": 0,
+                    "expected_jct_ps": expected_jct_ps,
+                    "check": "PASS" if not failures else "; ".join(failures),
+                }
+            )
+    return rows
+
+
+def _sweep_b(probe: Path) -> list[dict[str, int | str]]:
+    rows: list[dict[str, int | str]] = []
+    wqes = 16
+    doorbell_service_ps = 100
+    fetch_service_ps = 10
+    network_latency_ps = 1000
+    for capacity in (1, 4):
+        measured = _probe(
+            probe,
+            wqes=wqes,
+            doorbell_batch=16,
+            signal_every=1,
+            network_capacity=capacity,
+            network_latency_ps=network_latency_ps,
+            doorbell_service_ps=doorbell_service_ps,
+            fetch_service_ps=fetch_service_ps,
+            sq_depth=32,
+            cq_depth=32,
+        )
+        expected_doorbells = 1
+        expected_cqes = 16
+        expected_network_busy = wqes - capacity
+        expected_jct_ps = (
+            doorbell_service_ps
+            + capacity * fetch_service_ps
+            + (wqes // capacity) * network_latency_ps
+        )
+        failures = _common_checks(measured, wqes)
+        for name, expected in (
+            ("doorbells", expected_doorbells),
+            ("cqes", expected_cqes),
+            ("network_busy", expected_network_busy),
+            ("jct_ps", expected_jct_ps),
+        ):
+            if measured[name] != expected:
+                failures.append(f"{name}={measured[name]} expected {expected}")
+        rows.append(
+            {
+                "sweep": "network_backpressure",
+                **measured,
+                "expected_doorbells": expected_doorbells,
+                "expected_cqes": expected_cqes,
+                "expected_network_busy": expected_network_busy,
+                "expected_jct_ps": expected_jct_ps,
+                "check": "PASS" if not failures else "; ".join(failures),
+            }
+        )
+    return rows
+
+
+def _render_csv(rows: list[dict[str, int | str]]) -> bytes:
+    stream = io.StringIO(newline="")
+    fieldnames = list(rows[0])
+    writer = csv.DictWriter(stream, fieldnames=fieldnames, lineterminator="\n")
+    writer.writeheader()
+    writer.writerows(rows)
+    return stream.getvalue().encode()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--build-dir",
+        type=Path,
+        default=DEFAULT_BUILD_DIR,
+        help="CMake build directory (default: build/rnic_wq_v1)",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="fail if measured CSV differs from the tracked results",
+    )
+    arguments = parser.parse_args()
+
+    probe = _build(arguments.build_dir.resolve())
+    rows = _sweep_a(probe) + _sweep_b(probe)
+    rendered = _render_csv(rows)
+    failed = [row for row in rows if row["check"] != "PASS"]
+    if arguments.check:
+        if not RESULTS.is_file() or RESULTS.read_bytes() != rendered:
+            raise SystemExit(
+                f"measured RNIC rows differ from tracked {RESULTS}"
+            )
+        print(f"tracked results match {len(rows)} measured rows")
+    else:
+        RESULTS.write_bytes(rendered)
+        print(f"wrote {len(rows)} rows to {RESULTS}")
+    print(f"checks: {len(rows) - len(failed)}/{len(rows)} PASS")
+    if failed:
+        for row in failed:
+            print(row["check"])
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,8 @@ plot = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/yifeng-ethz/simllm"
-Issues = "https://github.com/yifeng-ethz/simllm/issues"
+Homepage = "https://github.com/openfabric-systems/simllm"
+Issues = "https://github.com/openfabric-systems/simllm/issues"
 
 # SGLang discovers and runs this before constructing its Scheduler. The
 # callable is a no-op unless SIMLLM_SGLANG_ENABLE=1, so an installed simllm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,17 @@ simllm = "simllm.adapters.sglang.plugin:register"
 [tool.setuptools.packages.find]
 include = ["simllm*"]
 
+[tool.setuptools.package-data]
+"simllm.backends.rnic" = [
+    "CMakeLists.txt",
+    "README.md",
+    "include/simllm/rnic/*.h",
+    "src/*.cpp",
+    "tests/*.h",
+    "tests/*.cpp",
+    "tools/*.cpp",
+]
+
 [tool.ruff]
 line-length = 100
 target-version = "py310"

--- a/simllm/backends/rnic/CMakeLists.txt
+++ b/simllm/backends/rnic/CMakeLists.txt
@@ -1,0 +1,88 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(simllm_rnic LANGUAGES CXX)
+
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    set(SIMLLM_RNIC_DEV_DEFAULT ON)
+else()
+    set(SIMLLM_RNIC_DEV_DEFAULT OFF)
+endif()
+
+option(SIMLLM_RNIC_BUILD_TESTS
+       "Build dependency-free RNIC native tests"
+       ${SIMLLM_RNIC_DEV_DEFAULT})
+option(SIMLLM_RNIC_BUILD_TOOLS
+       "Build RNIC validation tools"
+       ${SIMLLM_RNIC_DEV_DEFAULT})
+option(SIMLLM_RNIC_WARNINGS_AS_ERRORS
+       "Treat RNIC compiler warnings as errors"
+       OFF)
+
+add_library(simllm_rnic STATIC
+    src/work_queue.cpp
+)
+add_library(simllm::rnic ALIAS simllm_rnic)
+
+target_include_directories(simllm_rnic
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+target_compile_features(simllm_rnic PUBLIC cxx_std_17)
+set_target_properties(simllm_rnic PROPERTIES
+    CXX_EXTENSIONS OFF
+    POSITION_INDEPENDENT_CODE ON
+)
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    target_compile_options(simllm_rnic PRIVATE
+        -Wall
+        -Wextra
+        -Wpedantic
+    )
+    if(SIMLLM_RNIC_WARNINGS_AS_ERRORS)
+        target_compile_options(simllm_rnic PRIVATE -Werror)
+    endif()
+endif()
+
+if(SIMLLM_RNIC_BUILD_TESTS)
+    enable_testing()
+    add_executable(simllm_rnic_work_queue_test
+        tests/work_queue_test.cpp
+    )
+    target_link_libraries(simllm_rnic_work_queue_test PRIVATE simllm::rnic)
+    target_include_directories(simllm_rnic_work_queue_test PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests
+    )
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        target_compile_options(simllm_rnic_work_queue_test PRIVATE
+            -Wall
+            -Wextra
+            -Wpedantic
+        )
+        if(SIMLLM_RNIC_WARNINGS_AS_ERRORS)
+            target_compile_options(simllm_rnic_work_queue_test PRIVATE -Werror)
+        endif()
+    endif()
+    add_test(NAME simllm_rnic_work_queue_test
+             COMMAND simllm_rnic_work_queue_test)
+endif()
+
+if(SIMLLM_RNIC_BUILD_TOOLS)
+    add_executable(simllm_rnic_wq_probe
+        tools/wq_probe.cpp
+    )
+    target_link_libraries(simllm_rnic_wq_probe PRIVATE simllm::rnic)
+    target_include_directories(simllm_rnic_wq_probe PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests
+    )
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        target_compile_options(simllm_rnic_wq_probe PRIVATE
+            -Wall
+            -Wextra
+            -Wpedantic
+        )
+        if(SIMLLM_RNIC_WARNINGS_AS_ERRORS)
+            target_compile_options(simllm_rnic_wq_probe PRIVATE -Werror)
+        endif()
+    endif()
+endif()

--- a/simllm/backends/rnic/CMakeLists.txt
+++ b/simllm/backends/rnic/CMakeLists.txt
@@ -86,3 +86,33 @@ if(SIMLLM_RNIC_BUILD_TOOLS)
         endif()
     endif()
 endif()
+
+if(SIMLLM_RNIC_BUILD_TESTS AND SIMLLM_RNIC_BUILD_TOOLS)
+    set(SIMLLM_RNIC_NEGATIVE_PROBE_CHECK
+        "${CMAKE_CURRENT_BINARY_DIR}/check_negative_probe_$<CONFIG>.cmake")
+    file(GENERATE
+        OUTPUT "${SIMLLM_RNIC_NEGATIVE_PROBE_CHECK}"
+        CONTENT [=[
+execute_process(
+    COMMAND "$<TARGET_FILE:simllm_rnic_wq_probe>"
+            "--doorbell-service-ps" "-1"
+    RESULT_VARIABLE result
+    OUTPUT_VARIABLE output
+    ERROR_VARIABLE error
+)
+if(NOT result STREQUAL "2")
+    message(FATAL_ERROR
+        "negative probe returned ${result}, expected 2\n${output}\n${error}")
+endif()
+set(expected "--doorbell-service-ps must be an unsigned integer")
+string(FIND "${error}" "${expected}" match)
+if(match EQUAL -1)
+    message(FATAL_ERROR
+        "negative probe missed parser diagnostic\n${output}\n${error}")
+endif()
+]=]
+    )
+    add_test(NAME simllm_rnic_wq_probe_rejects_negative_service
+             COMMAND ${CMAKE_COMMAND}
+                     -P "${SIMLLM_RNIC_NEGATIVE_PROBE_CHECK}")
+endif()

--- a/simllm/backends/rnic/README.md
+++ b/simllm/backends/rnic/README.md
@@ -1,0 +1,50 @@
+# Native RNIC queue core
+
+This directory contains the SimLLM-owned C++17 RNIC hardware core. The module
+design, status and open-task registry remain in
+[`docs/modules/backends.md`](../../../docs/modules/backends.md).
+
+The implemented v1 slice is one finite SQ and CQ bound to one QP. It models
+accepted-prefix WR posting, explicit doorbell batches, serialized fetch and
+CQE-write service, ordered retirement, signaled and unsignaled reclaim, CQ
+owner wrap, polling, network retry gates and controlled queue failures.
+
+## Network boundary
+
+`NetworkPort` is independent of Python, htsim and any congestion-control
+algorithm. A submitted descriptor carries:
+
+- opaque WQE/WR correlation IDs;
+- GOAL flow ID and tag;
+- one stable opaque policy-context token;
+- source, destination, traffic class, payload extent and eligibility time.
+
+The port returns a network-owned token and later returns one delivery or drop
+event for that token. A Busy result retains the SQ head until its advertised
+retry time. Completion of another token does not revoke that deadline.
+
+This first port admits one flow extent per WQE. Network acceptance and outcome
+times are real v1 observations. First/last packet timestamps stay unset until
+HTSIM-9 adds explicit packet-issue events, so flow admission is never mislabeled
+as NIC packet start.
+
+At one timestamp, deliver network events to `onNetworkEvent` before retrying
+the SQ with `progress`. CQ priority is then explicit call order. Calling
+`progress(t)` before `pollCompletionQueue(t)` gives device CQE publication
+priority. Polling first gives host consumption priority and sees only CQEs
+strictly older than the timestamp; CQEs due exactly at that timestamp remain
+host-first. A fatal CQ overrun remains non-quiescent but exposes no next event,
+so event loops must test `fatal()` and abort rather than spin.
+
+## Standalone build
+
+```bash
+cmake -S simllm/backends/rnic -B build/rnic \
+  -DCMAKE_BUILD_TYPE=Debug \
+  -DSIMLLM_RNIC_WARNINGS_AS_ERRORS=ON
+cmake --build build/rnic --parallel
+ctest --test-dir build/rnic --output-on-failure
+```
+
+When this directory is consumed with `add_subdirectory`, tests and validation
+tools default off. The link target is `simllm::rnic`.

--- a/simllm/backends/rnic/__init__.py
+++ b/simllm/backends/rnic/__init__.py
@@ -1,0 +1,6 @@
+"""Native RNIC hardware models.
+
+The C++ source in this package is built as a standalone ``simllm::rnic``
+library. It intentionally has no Python or htsim dependency; HTSIM-9 will
+link it into the directly invoked simulator.
+"""

--- a/simllm/backends/rnic/include/simllm/rnic/network_port.h
+++ b/simllm/backends/rnic/include/simllm/rnic/network_port.h
@@ -1,0 +1,126 @@
+#ifndef SIMLLM_RNIC_NETWORK_PORT_H
+#define SIMLLM_RNIC_NETWORK_PORT_H
+
+#include <cstdint>
+
+namespace simllm::rnic {
+
+using Picoseconds = std::uint64_t;
+using WqeId = std::uint64_t;
+using FlowId = std::uint64_t;
+using PolicyContextToken = std::uint64_t;
+using NetworkToken = std::uint64_t;
+
+inline constexpr std::uint32_t kNetworkPortAbiVersion = 1;
+
+enum class NetworkSubmitStatus {
+    Accepted,
+    Busy,
+    Rejected,
+};
+
+enum class NetworkEventKind {
+    Delivered,
+    Dropped,
+};
+
+enum class DropLocation {
+    None,
+    TxPort,
+    Fabric,
+    RxPort,
+};
+
+enum class DropReason {
+    None,
+    Injected,
+    QueueOverflow,
+    LinkDown,
+    PolicyRejected,
+};
+
+// Version 1 carries one admitted WQE extent. Packetization may emit several
+// extents later without exposing SQ, CQ, QP or QPC objects to the network.
+struct NetworkTxDescriptor {
+    std::uint32_t abi_version{kNetworkPortAbiVersion};
+    // Correlation IDs are opaque to NetworkPort implementations. They do not
+    // grant ownership of the corresponding RNIC or application objects.
+    WqeId wqe_id{0};
+    std::uint64_t wr_id{0};
+    FlowId flow_id{0};
+    std::uint32_t flow_tag{0};
+    PolicyContextToken policy_context_token{0};
+    std::uint32_t source{0};
+    std::uint32_t destination{0};
+    std::uint32_t qpn{0};
+    std::uint8_t traffic_class{0};
+    std::uint64_t payload_bytes{0};
+    std::uint32_t extent_index{0};
+    std::uint32_t extent_count{1};
+    Picoseconds eligible_at_ps{0};
+};
+
+struct NetworkSubmitResult {
+    NetworkSubmitStatus status{NetworkSubmitStatus::Rejected};
+    NetworkToken token{0};
+    bool has_retry_time{false};
+    Picoseconds retry_at_ps{0};
+    DropLocation rejection_location{DropLocation::TxPort};
+    DropReason rejection_reason{DropReason::PolicyRejected};
+
+    static NetworkSubmitResult accepted(NetworkToken accepted_token) {
+        NetworkSubmitResult result;
+        result.status = NetworkSubmitStatus::Accepted;
+        result.token = accepted_token;
+        result.rejection_location = DropLocation::None;
+        result.rejection_reason = DropReason::None;
+        return result;
+    }
+
+    static NetworkSubmitResult busy(Picoseconds retry_time_ps) {
+        NetworkSubmitResult result;
+        result.status = NetworkSubmitStatus::Busy;
+        result.has_retry_time = true;
+        result.retry_at_ps = retry_time_ps;
+        result.rejection_location = DropLocation::None;
+        result.rejection_reason = DropReason::None;
+        return result;
+    }
+
+    static NetworkSubmitResult rejected(
+        DropLocation location = DropLocation::TxPort,
+        DropReason reason = DropReason::PolicyRejected) {
+        NetworkSubmitResult result;
+        result.status = NetworkSubmitStatus::Rejected;
+        result.rejection_location = location;
+        result.rejection_reason = reason;
+        return result;
+    }
+};
+
+struct NetworkEvent {
+    std::uint32_t abi_version{kNetworkPortAbiVersion};
+    NetworkEventKind kind{NetworkEventKind::Delivered};
+    NetworkToken token{0};
+    WqeId wqe_id{0};
+    Picoseconds event_time_ps{0};
+    bool ecn_marked{false};
+    DropLocation drop_location{DropLocation::None};
+    DropReason drop_reason{DropReason::None};
+};
+
+class NetworkPort {
+public:
+    virtual ~NetworkPort() = default;
+
+    // Busy must carry a strictly future retry time. Accepted tokens must be
+    // nonzero and unique until their NetworkEvent is returned. A completion
+    // for another token does not revoke an advertised retry time.
+    virtual NetworkSubmitResult trySubmit(
+        const NetworkTxDescriptor& descriptor,
+        Picoseconds now_ps) = 0;
+};
+
+}  // namespace simllm::rnic
+
+#endif  // SIMLLM_RNIC_NETWORK_PORT_H

--- a/simllm/backends/rnic/include/simllm/rnic/work_queue.h
+++ b/simllm/backends/rnic/include/simllm/rnic/work_queue.h
@@ -69,6 +69,10 @@ struct WorkQueueConfig {
     PolicyContextToken policy_context_token{1};
     std::size_t sq_depth{64};
     std::size_t cq_depth{64};
+    // Service durations use the nonnegative signed-64-bit domain. Keeping the
+    // storage unsigned preserves timestamp arithmetic, while construction
+    // rejects values above INT64_MAX so a negative signed input cannot wrap
+    // into a multi-day service time.
     Picoseconds doorbell_service_ps{0};
     Picoseconds wqe_fetch_service_ps{0};
     Picoseconds qpc_lookup_service_ps{0};

--- a/simllm/backends/rnic/include/simllm/rnic/work_queue.h
+++ b/simllm/backends/rnic/include/simllm/rnic/work_queue.h
@@ -1,0 +1,241 @@
+#ifndef SIMLLM_RNIC_WORK_QUEUE_H
+#define SIMLLM_RNIC_WORK_QUEUE_H
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "simllm/rnic/network_port.h"
+
+namespace simllm::rnic {
+
+inline constexpr std::uint32_t kWorkQueueConfigVersion = 1;
+
+enum class WqeOpcode {
+    Send,
+};
+
+enum class WqeState {
+    Posted,
+    Doorbelled,
+    InFlight,
+    AwaitingOrderedRetirement,
+    RetiredUnsignaled,
+    CompletionPending,
+    CqeVisible,
+    Reclaimed,
+    Completed,
+    Error,
+};
+
+enum class CompletionStatus {
+    Success,
+    TransportError,
+    NetworkRejected,
+};
+
+enum class PostStatus {
+    Accepted,
+    SqFull,
+    Fatal,
+};
+
+inline constexpr std::uint32_t kCqeValidWrId = 1U << 0;
+inline constexpr std::uint32_t kCqeValidQpn = 1U << 1;
+inline constexpr std::uint32_t kCqeValidOpcode = 1U << 2;
+inline constexpr std::uint32_t kCqeValidStatus = 1U << 3;
+inline constexpr std::uint32_t kCqeValidVendorSyndrome = 1U << 4;
+inline constexpr std::uint32_t kCqeValidByteCount = 1U << 5;
+
+enum class EvidenceTier {
+    Controlled,
+};
+
+enum class EvidenceKind {
+    SqFull,
+    NetworkRejected,
+    NetworkDrop,
+    CqOverrun,
+};
+
+struct WorkQueueConfig {
+    std::uint32_t version{kWorkQueueConfigVersion};
+    std::uint64_t sq_id{1};
+    std::uint64_t cq_id{1};
+    std::uint32_t source{0};
+    std::uint32_t qpn{1};
+    PolicyContextToken policy_context_token{1};
+    std::size_t sq_depth{64};
+    std::size_t cq_depth{64};
+    Picoseconds doorbell_service_ps{0};
+    Picoseconds wqe_fetch_service_ps{0};
+    Picoseconds qpc_lookup_service_ps{0};
+    Picoseconds scheduler_service_ps{0};
+    Picoseconds cqe_write_service_ps{0};
+};
+
+struct WorkRequest {
+    std::uint64_t wr_id{0};
+    FlowId flow_id{0};
+    std::uint32_t flow_tag{0};
+    std::uint32_t destination{0};
+    std::uint64_t payload_bytes{0};
+    std::uint8_t traffic_class{0};
+    WqeOpcode opcode{WqeOpcode::Send};
+    bool signaled{true};
+};
+
+struct WqeTimeline {
+    Picoseconds posted_at_ps{0};
+    std::optional<Picoseconds> doorbelled_at_ps;
+    std::optional<Picoseconds> doorbell_seen_at_ps;
+    std::optional<Picoseconds> wqe_fetch_begin_at_ps;
+    std::optional<Picoseconds> wqe_fetch_end_at_ps;
+    std::optional<Picoseconds> qpc_ready_at_ps;
+    std::optional<Picoseconds> admitted_at_ps;
+    std::optional<Picoseconds> network_accepted_at_ps;
+    std::optional<Picoseconds> network_outcome_at_ps;
+    // These remain unset in the flow-extent v1 port. A packetized adapter
+    // must populate them from explicit TX issue events, not acceptance or
+    // end-to-end delivery timestamps.
+    std::optional<Picoseconds> first_packet_at_ps;
+    std::optional<Picoseconds> last_packet_at_ps;
+    std::optional<Picoseconds> transport_retired_at_ps;
+    std::optional<Picoseconds> cqe_visible_at_ps;
+    std::optional<Picoseconds> polled_at_ps;
+    std::optional<Picoseconds> sq_reclaimed_at_ps;
+};
+
+struct WqeRecord {
+    WqeId wqe_id{0};
+    std::uint64_t sq_sequence{0};
+    std::uint64_t doorbell_batch_id{0};
+    WorkRequest request;
+    WqeTimeline timeline;
+    WqeState state{WqeState::Posted};
+    std::optional<NetworkToken> network_token;
+    std::optional<CompletionStatus> completion_status;
+    bool ecn_marked{false};
+};
+
+struct PostResult {
+    PostStatus status{PostStatus::Fatal};
+    WqeId wqe_id{0};
+    std::uint64_t sq_sequence{0};
+};
+
+struct PostBatchResult {
+    PostStatus status{PostStatus::Accepted};
+    std::vector<PostResult> accepted;
+    std::optional<std::size_t> bad_wr_index;
+};
+
+struct DoorbellBatch {
+    std::uint64_t batch_id{0};
+    std::size_t wqe_count{0};
+    Picoseconds rung_at_ps{0};
+    Picoseconds observed_at_ps{0};
+};
+
+struct CompletionEntry {
+    std::uint64_t cqe_sequence{0};
+    std::uint64_t cq_producer_index{0};
+    std::size_t cq_slot{0};
+    std::uint8_t owner_generation{0};
+    std::uint64_t wr_id{0};
+    WqeId wqe_id{0};
+    std::uint64_t sq_sequence{0};
+    std::uint32_t qpn{0};
+    WqeOpcode opcode{WqeOpcode::Send};
+    CompletionStatus status{CompletionStatus::Success};
+    std::uint32_t valid_fields{0};
+    std::uint64_t byte_count{0};
+    std::uint32_t vendor_syndrome{0};
+    Picoseconds visible_at_ps{0};
+    Picoseconds polled_at_ps{0};
+};
+
+struct EvidenceEvent {
+    EvidenceTier tier{EvidenceTier::Controlled};
+    EvidenceKind kind{EvidenceKind::SqFull};
+    WqeId wqe_id{0};
+    std::uint64_t wr_id{0};
+    Picoseconds observed_at_ps{0};
+    DropLocation drop_location{DropLocation::None};
+    DropReason drop_reason{DropReason::None};
+};
+
+struct WorkQueueCounters {
+    std::uint64_t posted_wqes{0};
+    std::uint64_t sq_full_rejections{0};
+    std::uint64_t doorbells{0};
+    std::uint64_t doorbelled_wqes{0};
+    std::uint64_t network_submit_attempts{0};
+    std::uint64_t network_accepted{0};
+    std::uint64_t network_busy{0};
+    std::uint64_t network_rejected{0};
+    std::uint64_t network_delivered{0};
+    std::uint64_t network_dropped{0};
+    std::uint64_t cqes_visible{0};
+    std::uint64_t cqes_polled{0};
+    std::uint64_t cq_overruns{0};
+    std::uint64_t sq_reclaimed_wqes{0};
+    std::size_t sq_high_watermark{0};
+    std::size_t cq_high_watermark{0};
+};
+
+class WorkQueue {
+public:
+    WorkQueue(WorkQueueConfig config, NetworkPort& network_port);
+    ~WorkQueue();
+
+    WorkQueue(const WorkQueue&) = delete;
+    WorkQueue& operator=(const WorkQueue&) = delete;
+    WorkQueue(WorkQueue&&) noexcept;
+    WorkQueue& operator=(WorkQueue&&) noexcept;
+
+    PostResult postSend(const WorkRequest& request, Picoseconds now_ps);
+    PostBatchResult postSendBatch(
+        const std::vector<WorkRequest>& requests,
+        Picoseconds now_ps);
+    DoorbellBatch ringDoorbell(Picoseconds now_ps);
+    // Deliver same-timestamp NetworkEvents before progress() so a completed
+    // network credit is visible when its advertised retry deadline arrives.
+    std::size_t progress(Picoseconds now_ps);
+    void onNetworkEvent(const NetworkEvent& event);
+
+    // progress() and pollCompletionQueue() are separate event actions. A poll
+    // first publishes any CQE strictly older than t. For CQEs due exactly at
+    // t, calling progress first gives device-publication priority while
+    // polling first gives host-consumer priority.
+    std::vector<CompletionEntry> pollCompletionQueue(
+        std::size_t max_entries,
+        Picoseconds now_ps);
+
+    // Fatal queues remain physically non-quiescent but have no schedulable
+    // internal event. Event loops must check fatal() when this returns empty.
+    std::optional<Picoseconds> nextEventTime() const;
+    bool hasPendingPhysicalWork() const noexcept;
+    bool fatal() const noexcept;
+    std::size_t occupiedSqEntries() const noexcept;
+    std::size_t completionQueueDepth() const noexcept;
+    std::size_t unpublishedWqeCount() const noexcept;
+
+    const WorkQueueConfig& config() const noexcept;
+    const WorkQueueCounters& counters() const noexcept;
+    const std::vector<WqeRecord>& records() const noexcept;
+    const std::vector<EvidenceEvent>& evidence() const noexcept;
+    const WqeRecord& wqe(WqeId wqe_id) const;
+
+    void validateInvariants() const;
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace simllm::rnic
+
+#endif  // SIMLLM_RNIC_WORK_QUEUE_H

--- a/simllm/backends/rnic/src/work_queue.cpp
+++ b/simllm/backends/rnic/src/work_queue.cpp
@@ -5,6 +5,7 @@
 #include <limits>
 #include <map>
 #include <stdexcept>
+#include <string>
 #include <utility>
 
 namespace simllm::rnic {
@@ -15,6 +16,16 @@ Picoseconds checkedAdd(Picoseconds lhs, Picoseconds rhs) {
         throw std::overflow_error("RNIC timestamp overflow");
     }
     return lhs + rhs;
+}
+
+void validateServiceTime(Picoseconds value, const char* field_name) {
+    constexpr Picoseconds max_service_time =
+        static_cast<Picoseconds>(std::numeric_limits<std::int64_t>::max());
+    if (value > max_service_time) {
+        throw std::invalid_argument(
+            std::string("RNIC ") + field_name
+            + " must be between 0 and INT64_MAX ps");
+    }
 }
 
 bool validDropLocation(DropLocation location) {
@@ -61,6 +72,16 @@ public:
             throw std::invalid_argument(
                 "RNIC policy-context token must be nonzero");
         }
+        validateServiceTime(
+            config_.doorbell_service_ps, "doorbell_service_ps");
+        validateServiceTime(
+            config_.wqe_fetch_service_ps, "wqe_fetch_service_ps");
+        validateServiceTime(
+            config_.qpc_lookup_service_ps, "qpc_lookup_service_ps");
+        validateServiceTime(
+            config_.scheduler_service_ps, "scheduler_service_ps");
+        validateServiceTime(
+            config_.cqe_write_service_ps, "cqe_write_service_ps");
     }
 
     PostResult postSend(const WorkRequest& request, Picoseconds now_ps) {
@@ -117,50 +138,77 @@ public:
     }
 
     DoorbellBatch ringDoorbell(Picoseconds now_ps) {
-        observeTime(now_ps);
+        validateTime(now_ps);
         if (unpublished_.empty()) {
+            last_observed_time_ps_ = now_ps;
             return DoorbellBatch{0, 0, now_ps, now_ps};
         }
         if (fatal_) {
             throw std::logic_error("cannot ring RNIC doorbell after fatal error");
         }
 
-        const std::uint64_t batch_id = next_batch_id_++;
+        if (next_batch_id_ == std::numeric_limits<std::uint64_t>::max()) {
+            throw std::overflow_error("RNIC doorbell batch ID overflow");
+        }
+        const std::uint64_t batch_id = next_batch_id_;
         const Picoseconds doorbell_base = std::max(now_ps, doorbell_cursor_ps_);
         const Picoseconds observed_at =
             checkedAdd(doorbell_base, config_.doorbell_service_ps);
-        doorbell_cursor_ps_ = observed_at;
         const std::size_t count = unpublished_.size();
 
-        while (!unpublished_.empty()) {
-            const WqeId wqe_id = unpublished_.front();
-            unpublished_.pop_front();
-            WqeRecord& record = mutableWqe(wqe_id);
-            record.doorbell_batch_id = batch_id;
-            record.timeline.doorbelled_at_ps = now_ps;
-            record.timeline.doorbell_seen_at_ps = observed_at;
-
+        struct PlannedDoorbellWqe {
+            WqeId wqe_id{0};
+            Picoseconds fetch_begin{0};
+            Picoseconds fetch_end{0};
+            Picoseconds qpc_ready{0};
+            Picoseconds admitted{0};
+        };
+        std::vector<PlannedDoorbellWqe> plan;
+        plan.reserve(count);
+        std::deque<WqeId> planned_ready = ready_;
+        Picoseconds planned_fetch_cursor = wqe_fetch_cursor_ps_;
+        Picoseconds planned_scheduler_cursor = scheduler_cursor_ps_;
+        for (const WqeId wqe_id : unpublished_) {
+            const WqeRecord& record = wqe(wqe_id);
+            if (record.state != WqeState::Posted) {
+                throw std::logic_error(
+                    "unpublished RNIC WQE is not in Posted state");
+            }
             const Picoseconds fetch_begin =
-                std::max(observed_at, wqe_fetch_cursor_ps_);
+                std::max(observed_at, planned_fetch_cursor);
             const Picoseconds fetch_end =
                 checkedAdd(fetch_begin, config_.wqe_fetch_service_ps);
-            wqe_fetch_cursor_ps_ = fetch_end;
+            planned_fetch_cursor = fetch_end;
             const Picoseconds qpc_ready =
                 checkedAdd(fetch_end, config_.qpc_lookup_service_ps);
             const Picoseconds scheduler_begin =
-                std::max(qpc_ready, scheduler_cursor_ps_);
+                std::max(qpc_ready, planned_scheduler_cursor);
             const Picoseconds admitted =
                 checkedAdd(scheduler_begin, config_.scheduler_service_ps);
-            scheduler_cursor_ps_ = admitted;
-
-            record.timeline.wqe_fetch_begin_at_ps = fetch_begin;
-            record.timeline.wqe_fetch_end_at_ps = fetch_end;
-            record.timeline.qpc_ready_at_ps = qpc_ready;
-            record.timeline.admitted_at_ps = admitted;
-            record.state = WqeState::Doorbelled;
-            ready_.push_back(wqe_id);
+            planned_scheduler_cursor = admitted;
+            plan.push_back(PlannedDoorbellWqe{
+                wqe_id, fetch_begin, fetch_end, qpc_ready, admitted});
+            planned_ready.push_back(wqe_id);
         }
 
+        for (const PlannedDoorbellWqe& item : plan) {
+            WqeRecord& record = mutableWqe(item.wqe_id);
+            record.doorbell_batch_id = batch_id;
+            record.timeline.doorbelled_at_ps = now_ps;
+            record.timeline.doorbell_seen_at_ps = observed_at;
+            record.timeline.wqe_fetch_begin_at_ps = item.fetch_begin;
+            record.timeline.wqe_fetch_end_at_ps = item.fetch_end;
+            record.timeline.qpc_ready_at_ps = item.qpc_ready;
+            record.timeline.admitted_at_ps = item.admitted;
+            record.state = WqeState::Doorbelled;
+        }
+        ready_.swap(planned_ready);
+        unpublished_.clear();
+        ++next_batch_id_;
+        last_observed_time_ps_ = now_ps;
+        doorbell_cursor_ps_ = observed_at;
+        wqe_fetch_cursor_ps_ = planned_fetch_cursor;
+        scheduler_cursor_ps_ = planned_scheduler_cursor;
         ++counters_.doorbells;
         counters_.doorbelled_wqes += count;
         return DoorbellBatch{batch_id, count, now_ps, observed_at};
@@ -254,6 +302,26 @@ public:
                     throw std::logic_error(
                         "rejected RNIC network result lacks controlled evidence");
                 }
+                NetworkEvent event;
+                event.kind = NetworkEventKind::Dropped;
+                event.wqe_id = record.wqe_id;
+                event.event_time_ps = now_ps;
+                event.drop_location = result.rejection_location;
+                event.drop_reason = result.rejection_reason;
+                const CandidateOutcome candidate{
+                    record.wqe_id,
+                    PendingOutcome{
+                        event, CompletionStatus::NetworkRejected}};
+                RetirementPlan retirement_plan =
+                    planRetirements(&candidate);
+                evidence_.reserve(evidence_.size() + 1);
+                const auto inserted = pending_outcomes_.emplace(
+                    candidate.wqe_id, candidate.outcome);
+                if (!inserted.second) {
+                    throw std::logic_error(
+                        "duplicate RNIC WQE network outcome");
+                }
+
                 ready_.pop_front();
                 ++counters_.network_rejected;
                 evidence_.push_back(EvidenceEvent{
@@ -265,18 +333,9 @@ public:
                     result.rejection_location,
                     result.rejection_reason,
                 });
-                NetworkEvent event;
-                event.kind = NetworkEventKind::Dropped;
-                event.wqe_id = record.wqe_id;
-                event.event_time_ps = now_ps;
-                event.drop_location = result.rejection_location;
-                event.drop_reason = result.rejection_reason;
                 record.timeline.network_outcome_at_ps = now_ps;
-                pending_outcomes_.emplace(
-                    record.wqe_id,
-                    PendingOutcome{event, CompletionStatus::NetworkRejected});
                 record.state = WqeState::AwaitingOrderedRetirement;
-                retireReadyWqes();
+                commitRetirements(std::move(retirement_plan));
                 ++changes;
                 continue;
             }
@@ -318,7 +377,7 @@ public:
         default:
             throw std::invalid_argument("invalid RNIC network event kind");
         }
-        observeTime(event.event_time_ps);
+        validateTime(event.event_time_ps);
         const auto inflight_it = inflight_.find(event.token);
         if (inflight_it == inflight_.end()) {
             throw std::logic_error("unknown or duplicate RNIC network token");
@@ -333,16 +392,29 @@ public:
                 < *record.timeline.network_accepted_at_ps) {
             throw std::logic_error("RNIC network event predates acceptance");
         }
+        CompletionStatus status = CompletionStatus::Success;
+        if (event.kind == NetworkEventKind::Dropped) {
+            status = CompletionStatus::TransportError;
+        }
+        const CandidateOutcome candidate{
+            record.wqe_id, PendingOutcome{event, status}};
+        RetirementPlan retirement_plan = planRetirements(&candidate);
+        if (event.kind == NetworkEventKind::Dropped) {
+            evidence_.reserve(evidence_.size() + 1);
+        }
+        const auto inserted = pending_outcomes_.emplace(
+            candidate.wqe_id, candidate.outcome);
+        if (!inserted.second) {
+            throw std::logic_error("duplicate RNIC WQE network outcome");
+        }
+        last_observed_time_ps_ = event.event_time_ps;
         inflight_.erase(inflight_it);
         record.timeline.network_outcome_at_ps = event.event_time_ps;
         record.state = WqeState::AwaitingOrderedRetirement;
         record.ecn_marked = record.ecn_marked || event.ecn_marked;
-
-        CompletionStatus status = CompletionStatus::Success;
         if (event.kind == NetworkEventKind::Delivered) {
             ++counters_.network_delivered;
         } else {
-            status = CompletionStatus::TransportError;
             ++counters_.network_dropped;
             evidence_.push_back(EvidenceEvent{
                 EvidenceTier::Controlled,
@@ -354,12 +426,7 @@ public:
                 event.drop_reason,
             });
         }
-        const auto inserted = pending_outcomes_.emplace(
-            record.wqe_id, PendingOutcome{event, status});
-        if (!inserted.second) {
-            throw std::logic_error("duplicate RNIC WQE network outcome");
-        }
-        retireReadyWqes();
+        commitRetirements(std::move(retirement_plan));
     }
 
     std::vector<CompletionEntry> pollCompletionQueue(
@@ -459,6 +526,61 @@ public:
             throw std::logic_error("RNIC posted counter disagrees with records");
         }
 
+        std::vector<std::size_t> owner_counts(records_.size(), 0);
+        const auto mark_owned = [this, &owner_counts](
+                                    WqeId wqe_id,
+                                    WqeState expected_state) {
+            const WqeRecord& record = wqe(wqe_id);
+            if (record.state != expected_state) {
+                throw std::logic_error(
+                    "RNIC WQE state disagrees with its owner container");
+            }
+            std::size_t& count = owner_counts[static_cast<std::size_t>(
+                wqe_id - 1)];
+            ++count;
+            if (count != 1) {
+                throw std::logic_error(
+                    "RNIC WQE appears in multiple owner containers");
+            }
+        };
+        for (const WqeId wqe_id : unpublished_) {
+            mark_owned(wqe_id, WqeState::Posted);
+        }
+        for (const WqeId wqe_id : ready_) {
+            mark_owned(wqe_id, WqeState::Doorbelled);
+        }
+        for (const auto& token_and_wqe : inflight_) {
+            const WqeRecord& record = wqe(token_and_wqe.second);
+            if (!record.network_token.has_value()
+                || *record.network_token != token_and_wqe.first) {
+                throw std::logic_error(
+                    "RNIC in-flight token accounting mismatch");
+            }
+            mark_owned(token_and_wqe.second, WqeState::InFlight);
+        }
+        for (const auto& wqe_and_outcome : pending_outcomes_) {
+            if (wqe_and_outcome.first
+                != wqe_and_outcome.second.event.wqe_id) {
+                throw std::logic_error(
+                    "RNIC pending outcome/WQE identity mismatch");
+            }
+            mark_owned(
+                wqe_and_outcome.first,
+                WqeState::AwaitingOrderedRetirement);
+        }
+        for (const auto& key_and_entry : pending_cqes_) {
+            const CompletionEntry& entry = key_and_entry.second;
+            if (key_and_entry.first.first != entry.visible_at_ps
+                || key_and_entry.first.second != entry.cqe_sequence) {
+                throw std::logic_error(
+                    "RNIC pending CQE key disagrees with its entry");
+            }
+            mark_owned(entry.wqe_id, WqeState::CompletionPending);
+        }
+        for (const CompletionEntry& entry : cq_) {
+            mark_owned(entry.wqe_id, WqeState::CqeVisible);
+        }
+
         std::size_t unreclaimed = 0;
         std::size_t reclaimed = 0;
         for (std::size_t index = 0; index < records_.size(); ++index) {
@@ -473,6 +595,28 @@ public:
                 }
             } else {
                 ++unreclaimed;
+            }
+            bool needs_owner = false;
+            switch (record.state) {
+            case WqeState::Posted:
+            case WqeState::Doorbelled:
+            case WqeState::InFlight:
+            case WqeState::AwaitingOrderedRetirement:
+            case WqeState::CompletionPending:
+            case WqeState::CqeVisible:
+                needs_owner = true;
+                break;
+            case WqeState::RetiredUnsignaled:
+            case WqeState::Reclaimed:
+            case WqeState::Completed:
+            case WqeState::Error:
+                break;
+            default:
+                throw std::logic_error("invalid RNIC WQE state");
+            }
+            if (owner_counts[index] != (needs_owner ? 1U : 0U)) {
+                throw std::logic_error(
+                    "RNIC WQE owner-container conservation failed");
             }
         }
         if (unreclaimed != occupied_sq_entries_
@@ -494,14 +638,6 @@ public:
                 throw std::logic_error("RNIC reclaimed its first lost CQE");
             }
         }
-        for (const auto& token_and_wqe : inflight_) {
-            const WqeRecord& record = wqe(token_and_wqe.second);
-            if (!record.network_token.has_value()
-                || *record.network_token != token_and_wqe.first
-                || record.state != WqeState::InFlight) {
-                throw std::logic_error("RNIC in-flight token accounting mismatch");
-            }
-        }
     }
 
 private:
@@ -512,10 +648,35 @@ private:
 
     using PendingCqeKey = std::pair<Picoseconds, std::uint64_t>;
 
-    void observeTime(Picoseconds now_ps) {
+    struct CandidateOutcome {
+        WqeId wqe_id{0};
+        PendingOutcome outcome;
+    };
+
+    struct PlannedRetirement {
+        WqeId wqe_id{0};
+        Picoseconds retired_at_ps{0};
+        CompletionStatus status{CompletionStatus::Success};
+        bool completion_pending{false};
+    };
+
+    struct RetirementPlan {
+        std::vector<PlannedRetirement> retirements;
+        std::map<PendingCqeKey, CompletionEntry> pending_cqes;
+        Picoseconds retirement_cursor_ps{0};
+        Picoseconds cqe_write_cursor_ps{0};
+        std::uint64_t next_cqe_sequence{1};
+        std::uint64_t next_retire_sequence{1};
+    };
+
+    void validateTime(Picoseconds now_ps) const {
         if (now_ps < last_observed_time_ps_) {
             throw std::logic_error("RNIC model time regressed");
         }
+    }
+
+    void observeTime(Picoseconds now_ps) {
+        validateTime(now_ps);
         last_observed_time_ps_ = now_ps;
     }
 
@@ -523,45 +684,14 @@ private:
         return const_cast<WqeRecord&>(wqe(wqe_id));
     }
 
-    void retireReadyWqes() {
-        while (next_retire_sequence_ <= records_.size()) {
-            WqeRecord& record = records_[next_retire_sequence_ - 1];
-            const auto outcome_it = pending_outcomes_.find(record.wqe_id);
-            if (outcome_it == pending_outcomes_.end()) {
-                break;
-            }
-            const PendingOutcome outcome = outcome_it->second;
-            pending_outcomes_.erase(outcome_it);
-
-            if (!record.timeline.network_outcome_at_ps.has_value()
-                || *record.timeline.network_outcome_at_ps
-                    != outcome.event.event_time_ps) {
-                throw std::logic_error(
-                    "RNIC retirement lacks its recorded network outcome");
-            }
-            const Picoseconds retired_at =
-                std::max(outcome.event.event_time_ps, retirement_cursor_ps_);
-            retirement_cursor_ps_ = retired_at;
-            record.timeline.transport_retired_at_ps = retired_at;
-            record.completion_status = outcome.status;
-
-            if (record.request.signaled
-                || outcome.status != CompletionStatus::Success) {
-                scheduleCqe(record, outcome.status, retired_at);
-                record.state = WqeState::CompletionPending;
-            } else {
-                record.state = WqeState::RetiredUnsignaled;
-            }
-            ++next_retire_sequence_;
-        }
-    }
-
-    void scheduleCqe(
-        WqeRecord& record,
+    CompletionEntry makeCqe(
+        const WqeRecord& record,
         CompletionStatus status,
-        Picoseconds retired_at_ps) {
+        Picoseconds retired_at_ps,
+        Picoseconds cqe_write_cursor_ps,
+        std::uint64_t cqe_sequence) const {
         CompletionEntry entry;
-        entry.cqe_sequence = next_cqe_sequence_++;
+        entry.cqe_sequence = cqe_sequence;
         entry.wr_id = record.request.wr_id;
         entry.wqe_id = record.wqe_id;
         entry.sq_sequence = record.sq_sequence;
@@ -579,12 +709,114 @@ private:
             entry.vendor_syndrome = 2;
         }
         const Picoseconds write_begin =
-            std::max(retired_at_ps, cqe_write_cursor_ps_);
+            std::max(retired_at_ps, cqe_write_cursor_ps);
         entry.visible_at_ps =
             checkedAdd(write_begin, config_.cqe_write_service_ps);
-        cqe_write_cursor_ps_ = entry.visible_at_ps;
-        pending_cqes_.emplace(
-            PendingCqeKey{entry.visible_at_ps, entry.cqe_sequence}, entry);
+        return entry;
+    }
+
+    RetirementPlan planRetirements(
+        const CandidateOutcome* candidate = nullptr) const {
+        RetirementPlan plan;
+        plan.retirement_cursor_ps = retirement_cursor_ps_;
+        plan.cqe_write_cursor_ps = cqe_write_cursor_ps_;
+        plan.next_cqe_sequence = next_cqe_sequence_;
+        plan.next_retire_sequence = next_retire_sequence_;
+        if (next_retire_sequence_ <= records_.size()) {
+            plan.retirements.reserve(
+                records_.size()
+                - static_cast<std::size_t>(next_retire_sequence_) + 1);
+        }
+
+        while (plan.next_retire_sequence <= records_.size()) {
+            const WqeRecord& record =
+                records_[plan.next_retire_sequence - 1];
+            const PendingOutcome* outcome = nullptr;
+            const bool is_candidate =
+                candidate != nullptr && candidate->wqe_id == record.wqe_id;
+            if (is_candidate) {
+                if (pending_outcomes_.count(record.wqe_id) != 0) {
+                    throw std::logic_error(
+                        "duplicate RNIC WQE network outcome");
+                }
+                outcome = &candidate->outcome;
+            } else {
+                const auto outcome_it =
+                    pending_outcomes_.find(record.wqe_id);
+                if (outcome_it == pending_outcomes_.end()) {
+                    break;
+                }
+                outcome = &outcome_it->second;
+            }
+
+            if (is_candidate) {
+                if (record.timeline.network_outcome_at_ps.has_value()) {
+                    throw std::logic_error(
+                        "candidate RNIC retirement already has an outcome");
+                }
+            } else if (record.state
+                           != WqeState::AwaitingOrderedRetirement
+                       || !record.timeline.network_outcome_at_ps.has_value()
+                       || *record.timeline.network_outcome_at_ps
+                           != outcome->event.event_time_ps) {
+                throw std::logic_error(
+                    "RNIC retirement lacks its recorded network outcome");
+            }
+
+            const Picoseconds retired_at = std::max(
+                outcome->event.event_time_ps,
+                plan.retirement_cursor_ps);
+            const bool completion_pending = record.request.signaled
+                || outcome->status != CompletionStatus::Success;
+            if (completion_pending) {
+                if (plan.next_cqe_sequence
+                    == std::numeric_limits<std::uint64_t>::max()) {
+                    throw std::overflow_error(
+                        "RNIC CQE sequence overflow");
+                }
+                CompletionEntry entry = makeCqe(
+                    record,
+                    outcome->status,
+                    retired_at,
+                    plan.cqe_write_cursor_ps,
+                    plan.next_cqe_sequence);
+                const PendingCqeKey key{
+                    entry.visible_at_ps, entry.cqe_sequence};
+                if (pending_cqes_.count(key) != 0
+                    || !plan.pending_cqes.emplace(key, entry).second) {
+                    throw std::logic_error(
+                        "duplicate RNIC pending CQE key");
+                }
+                plan.cqe_write_cursor_ps = entry.visible_at_ps;
+                ++plan.next_cqe_sequence;
+            }
+            plan.retirement_cursor_ps = retired_at;
+            plan.retirements.push_back(PlannedRetirement{
+                record.wqe_id,
+                retired_at,
+                outcome->status,
+                completion_pending,
+            });
+            ++plan.next_retire_sequence;
+        }
+        return plan;
+    }
+
+    void commitRetirements(RetirementPlan&& plan) {
+        pending_cqes_.merge(plan.pending_cqes);
+        for (const PlannedRetirement& item : plan.retirements) {
+            pending_outcomes_.erase(item.wqe_id);
+            WqeRecord& record = mutableWqe(item.wqe_id);
+            record.timeline.transport_retired_at_ps = item.retired_at_ps;
+            record.completion_status = item.status;
+            record.state = item.completion_pending
+                ? WqeState::CompletionPending
+                : WqeState::RetiredUnsignaled;
+        }
+        retirement_cursor_ps_ = plan.retirement_cursor_ps;
+        cqe_write_cursor_ps_ = plan.cqe_write_cursor_ps;
+        next_cqe_sequence_ = plan.next_cqe_sequence;
+        next_retire_sequence_ = plan.next_retire_sequence;
     }
 
     std::size_t publishCqes(

--- a/simllm/backends/rnic/src/work_queue.cpp
+++ b/simllm/backends/rnic/src/work_queue.cpp
@@ -1,0 +1,786 @@
+#include "simllm/rnic/work_queue.h"
+
+#include <algorithm>
+#include <deque>
+#include <limits>
+#include <map>
+#include <stdexcept>
+#include <utility>
+
+namespace simllm::rnic {
+namespace {
+
+Picoseconds checkedAdd(Picoseconds lhs, Picoseconds rhs) {
+    if (rhs > std::numeric_limits<Picoseconds>::max() - lhs) {
+        throw std::overflow_error("RNIC timestamp overflow");
+    }
+    return lhs + rhs;
+}
+
+bool validDropLocation(DropLocation location) {
+    switch (location) {
+    case DropLocation::None:
+    case DropLocation::TxPort:
+    case DropLocation::Fabric:
+    case DropLocation::RxPort:
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool validDropReason(DropReason reason) {
+    switch (reason) {
+    case DropReason::None:
+    case DropReason::Injected:
+    case DropReason::QueueOverflow:
+    case DropReason::LinkDown:
+    case DropReason::PolicyRejected:
+        return true;
+    default:
+        return false;
+    }
+}
+
+}  // namespace
+
+class WorkQueue::Impl {
+public:
+    Impl(WorkQueueConfig config, NetworkPort& network_port)
+        : config_(std::move(config)), network_port_(network_port) {
+        if (config_.version != kWorkQueueConfigVersion) {
+            throw std::invalid_argument("unsupported RNIC work-queue config version");
+        }
+        if (config_.sq_depth == 0 || config_.cq_depth == 0) {
+            throw std::invalid_argument("RNIC SQ and CQ depths must be positive");
+        }
+        if (config_.qpn == 0) {
+            throw std::invalid_argument("RNIC QPN must be nonzero");
+        }
+        if (config_.policy_context_token == 0) {
+            throw std::invalid_argument(
+                "RNIC policy-context token must be nonzero");
+        }
+    }
+
+    PostResult postSend(const WorkRequest& request, Picoseconds now_ps) {
+        observeTime(now_ps);
+        if (fatal_) {
+            return PostResult{PostStatus::Fatal, 0, 0};
+        }
+        if (occupied_sq_entries_ == config_.sq_depth) {
+            ++counters_.sq_full_rejections;
+            evidence_.push_back(EvidenceEvent{
+                EvidenceTier::Controlled,
+                EvidenceKind::SqFull,
+                0,
+                request.wr_id,
+                now_ps,
+                DropLocation::None,
+                DropReason::QueueOverflow,
+            });
+            return PostResult{PostStatus::SqFull, 0, 0};
+        }
+
+        const WqeId wqe_id = next_wqe_id_++;
+        const std::uint64_t sq_sequence = next_sq_sequence_++;
+        WqeRecord record;
+        record.wqe_id = wqe_id;
+        record.sq_sequence = sq_sequence;
+        record.request = request;
+        record.timeline.posted_at_ps = now_ps;
+        records_.push_back(record);
+        unpublished_.push_back(wqe_id);
+
+        ++occupied_sq_entries_;
+        ++counters_.posted_wqes;
+        counters_.sq_high_watermark =
+            std::max(counters_.sq_high_watermark, occupied_sq_entries_);
+        return PostResult{PostStatus::Accepted, wqe_id, sq_sequence};
+    }
+
+    PostBatchResult postSendBatch(
+        const std::vector<WorkRequest>& requests,
+        Picoseconds now_ps) {
+        PostBatchResult batch;
+        batch.accepted.reserve(requests.size());
+        for (std::size_t index = 0; index < requests.size(); ++index) {
+            PostResult result = postSend(requests[index], now_ps);
+            if (result.status != PostStatus::Accepted) {
+                batch.status = result.status;
+                batch.bad_wr_index = index;
+                break;
+            }
+            batch.accepted.push_back(result);
+        }
+        return batch;
+    }
+
+    DoorbellBatch ringDoorbell(Picoseconds now_ps) {
+        observeTime(now_ps);
+        if (unpublished_.empty()) {
+            return DoorbellBatch{0, 0, now_ps, now_ps};
+        }
+        if (fatal_) {
+            throw std::logic_error("cannot ring RNIC doorbell after fatal error");
+        }
+
+        const std::uint64_t batch_id = next_batch_id_++;
+        const Picoseconds doorbell_base = std::max(now_ps, doorbell_cursor_ps_);
+        const Picoseconds observed_at =
+            checkedAdd(doorbell_base, config_.doorbell_service_ps);
+        doorbell_cursor_ps_ = observed_at;
+        const std::size_t count = unpublished_.size();
+
+        while (!unpublished_.empty()) {
+            const WqeId wqe_id = unpublished_.front();
+            unpublished_.pop_front();
+            WqeRecord& record = mutableWqe(wqe_id);
+            record.doorbell_batch_id = batch_id;
+            record.timeline.doorbelled_at_ps = now_ps;
+            record.timeline.doorbell_seen_at_ps = observed_at;
+
+            const Picoseconds fetch_begin =
+                std::max(observed_at, wqe_fetch_cursor_ps_);
+            const Picoseconds fetch_end =
+                checkedAdd(fetch_begin, config_.wqe_fetch_service_ps);
+            wqe_fetch_cursor_ps_ = fetch_end;
+            const Picoseconds qpc_ready =
+                checkedAdd(fetch_end, config_.qpc_lookup_service_ps);
+            const Picoseconds scheduler_begin =
+                std::max(qpc_ready, scheduler_cursor_ps_);
+            const Picoseconds admitted =
+                checkedAdd(scheduler_begin, config_.scheduler_service_ps);
+            scheduler_cursor_ps_ = admitted;
+
+            record.timeline.wqe_fetch_begin_at_ps = fetch_begin;
+            record.timeline.wqe_fetch_end_at_ps = fetch_end;
+            record.timeline.qpc_ready_at_ps = qpc_ready;
+            record.timeline.admitted_at_ps = admitted;
+            record.state = WqeState::Doorbelled;
+            ready_.push_back(wqe_id);
+        }
+
+        ++counters_.doorbells;
+        counters_.doorbelled_wqes += count;
+        return DoorbellBatch{batch_id, count, now_ps, observed_at};
+    }
+
+    std::size_t progress(Picoseconds now_ps) {
+        observeTime(now_ps);
+        if (fatal_) {
+            return 0;
+        }
+        std::size_t changes = publishDueCqes(now_ps);
+        if (fatal_) {
+            return changes;
+        }
+
+        if (network_blocked_) {
+            if (!network_retry_at_ps_.has_value()
+                || now_ps < *network_retry_at_ps_) {
+                return changes;
+            }
+            network_blocked_ = false;
+            network_retry_at_ps_.reset();
+        }
+
+        while (!ready_.empty()) {
+            WqeRecord& record = mutableWqe(ready_.front());
+            if (!record.timeline.admitted_at_ps.has_value()) {
+                throw std::logic_error("doorbelled WQE has no admission time");
+            }
+            if (*record.timeline.admitted_at_ps > now_ps) {
+                break;
+            }
+
+            NetworkTxDescriptor descriptor;
+            descriptor.wqe_id = record.wqe_id;
+            descriptor.wr_id = record.request.wr_id;
+            descriptor.flow_id = record.request.flow_id;
+            descriptor.flow_tag = record.request.flow_tag;
+            descriptor.policy_context_token = config_.policy_context_token;
+            descriptor.source = config_.source;
+            descriptor.destination = record.request.destination;
+            descriptor.qpn = config_.qpn;
+            descriptor.traffic_class = record.request.traffic_class;
+            descriptor.payload_bytes = record.request.payload_bytes;
+            descriptor.eligible_at_ps = *record.timeline.admitted_at_ps;
+
+            ++counters_.network_submit_attempts;
+            const NetworkSubmitResult result =
+                network_port_.trySubmit(descriptor, now_ps);
+            switch (result.status) {
+            case NetworkSubmitStatus::Busy:
+                if (!result.has_retry_time || result.retry_at_ps <= now_ps) {
+                    throw std::logic_error(
+                        "busy RNIC network port must provide a future retry time");
+                }
+                if (result.token != 0
+                    || result.rejection_location != DropLocation::None
+                    || result.rejection_reason != DropReason::None) {
+                    throw std::logic_error(
+                        "busy RNIC network result carries contradictory fields");
+                }
+                ++counters_.network_busy;
+                network_blocked_ = true;
+                network_retry_at_ps_ = result.retry_at_ps;
+                break;
+            case NetworkSubmitStatus::Accepted:
+                if (result.has_retry_time
+                    || result.rejection_location != DropLocation::None
+                    || result.rejection_reason != DropReason::None) {
+                    throw std::logic_error(
+                        "accepted RNIC network result carries contradictory fields");
+                }
+                if (result.token == 0 || inflight_.count(result.token) != 0) {
+                    throw std::logic_error(
+                        "RNIC network port returned an invalid or duplicate token");
+                }
+                ready_.pop_front();
+                record.network_token = result.token;
+                record.timeline.network_accepted_at_ps = now_ps;
+                record.state = WqeState::InFlight;
+                inflight_.emplace(result.token, record.wqe_id);
+                ++counters_.network_accepted;
+                ++changes;
+                continue;
+            case NetworkSubmitStatus::Rejected: {
+                if (result.token != 0 || result.has_retry_time
+                    || !validDropLocation(result.rejection_location)
+                    || !validDropReason(result.rejection_reason)
+                    || result.rejection_location == DropLocation::None
+                    || result.rejection_reason == DropReason::None) {
+                    throw std::logic_error(
+                        "rejected RNIC network result lacks controlled evidence");
+                }
+                ready_.pop_front();
+                ++counters_.network_rejected;
+                evidence_.push_back(EvidenceEvent{
+                    EvidenceTier::Controlled,
+                    EvidenceKind::NetworkRejected,
+                    record.wqe_id,
+                    record.request.wr_id,
+                    now_ps,
+                    result.rejection_location,
+                    result.rejection_reason,
+                });
+                NetworkEvent event;
+                event.kind = NetworkEventKind::Dropped;
+                event.wqe_id = record.wqe_id;
+                event.event_time_ps = now_ps;
+                event.drop_location = result.rejection_location;
+                event.drop_reason = result.rejection_reason;
+                record.timeline.network_outcome_at_ps = now_ps;
+                pending_outcomes_.emplace(
+                    record.wqe_id,
+                    PendingOutcome{event, CompletionStatus::NetworkRejected});
+                record.state = WqeState::AwaitingOrderedRetirement;
+                retireReadyWqes();
+                ++changes;
+                continue;
+            }
+            default:
+                throw std::logic_error("invalid RNIC network submit status");
+            }
+            // Busy retains the SQ head and ends this progress pass.
+            break;
+        }
+
+        changes += publishDueCqes(now_ps);
+        return changes;
+    }
+
+    void onNetworkEvent(const NetworkEvent& event) {
+        if (event.abi_version != kNetworkPortAbiVersion) {
+            throw std::invalid_argument("unsupported RNIC network event ABI");
+        }
+        if (!validDropLocation(event.drop_location)
+            || !validDropReason(event.drop_reason)) {
+            throw std::invalid_argument(
+                "RNIC network event carries an invalid drop enum");
+        }
+        switch (event.kind) {
+        case NetworkEventKind::Delivered:
+            if (event.drop_location != DropLocation::None
+                || event.drop_reason != DropReason::None) {
+                throw std::invalid_argument(
+                    "delivered RNIC network event carries drop evidence");
+            }
+            break;
+        case NetworkEventKind::Dropped:
+            if (event.drop_location == DropLocation::None
+                || event.drop_reason == DropReason::None) {
+                throw std::invalid_argument(
+                    "dropped RNIC network event lacks controlled evidence");
+            }
+            break;
+        default:
+            throw std::invalid_argument("invalid RNIC network event kind");
+        }
+        observeTime(event.event_time_ps);
+        const auto inflight_it = inflight_.find(event.token);
+        if (inflight_it == inflight_.end()) {
+            throw std::logic_error("unknown or duplicate RNIC network token");
+        }
+        if (event.wqe_id != inflight_it->second) {
+            throw std::logic_error("RNIC network token/WQE mismatch");
+        }
+
+        WqeRecord& record = mutableWqe(event.wqe_id);
+        if (!record.timeline.network_accepted_at_ps.has_value()
+            || event.event_time_ps
+                < *record.timeline.network_accepted_at_ps) {
+            throw std::logic_error("RNIC network event predates acceptance");
+        }
+        inflight_.erase(inflight_it);
+        record.timeline.network_outcome_at_ps = event.event_time_ps;
+        record.state = WqeState::AwaitingOrderedRetirement;
+        record.ecn_marked = record.ecn_marked || event.ecn_marked;
+
+        CompletionStatus status = CompletionStatus::Success;
+        if (event.kind == NetworkEventKind::Delivered) {
+            ++counters_.network_delivered;
+        } else {
+            status = CompletionStatus::TransportError;
+            ++counters_.network_dropped;
+            evidence_.push_back(EvidenceEvent{
+                EvidenceTier::Controlled,
+                EvidenceKind::NetworkDrop,
+                record.wqe_id,
+                record.request.wr_id,
+                event.event_time_ps,
+                event.drop_location,
+                event.drop_reason,
+            });
+        }
+        const auto inserted = pending_outcomes_.emplace(
+            record.wqe_id, PendingOutcome{event, status});
+        if (!inserted.second) {
+            throw std::logic_error("duplicate RNIC WQE network outcome");
+        }
+        retireReadyWqes();
+    }
+
+    std::vector<CompletionEntry> pollCompletionQueue(
+        std::size_t max_entries,
+        Picoseconds now_ps) {
+        observeTime(now_ps);
+        if (!fatal_) {
+            publishCqesBefore(now_ps);
+        }
+        std::vector<CompletionEntry> result;
+        result.reserve(std::min(max_entries, cq_.size()));
+        while (result.size() < max_entries && !cq_.empty()) {
+            CompletionEntry entry = cq_.front();
+            cq_.pop_front();
+            entry.polled_at_ps = now_ps;
+            WqeRecord& record = mutableWqe(entry.wqe_id);
+            record.timeline.polled_at_ps = now_ps;
+            record.state = WqeState::Completed;
+            reclaimThrough(entry.sq_sequence, now_ps);
+            ++counters_.cqes_polled;
+            result.push_back(entry);
+        }
+        return result;
+    }
+
+    std::optional<Picoseconds> nextEventTime() const {
+        if (fatal_) {
+            return std::nullopt;
+        }
+        std::optional<Picoseconds> next;
+        if (!pending_cqes_.empty()) {
+            next = std::max(
+                pending_cqes_.begin()->first.first,
+                last_observed_time_ps_);
+        }
+        if (!ready_.empty()) {
+            const WqeRecord& record = wqe(ready_.front());
+            if (!record.timeline.admitted_at_ps.has_value()) {
+                throw std::logic_error("ready RNIC WQE has no admission time");
+            }
+            Picoseconds ready_at = std::max(
+                *record.timeline.admitted_at_ps,
+                last_observed_time_ps_);
+            if (network_blocked_) {
+                if (!network_retry_at_ps_.has_value()) {
+                    return next;
+                }
+                ready_at = std::max(ready_at, *network_retry_at_ps_);
+            }
+            if (!next.has_value() || ready_at < *next) {
+                next = ready_at;
+            }
+        }
+        return next;
+    }
+
+    bool hasPendingPhysicalWork() const noexcept {
+        return fatal_ || !unpublished_.empty() || !ready_.empty()
+            || !inflight_.empty() || !pending_outcomes_.empty()
+            || !pending_cqes_.empty() || !cq_.empty();
+    }
+
+    bool fatal() const noexcept { return fatal_; }
+    std::size_t occupiedSqEntries() const noexcept {
+        return occupied_sq_entries_;
+    }
+    std::size_t completionQueueDepth() const noexcept { return cq_.size(); }
+    std::size_t unpublishedWqeCount() const noexcept {
+        return unpublished_.size();
+    }
+    const WorkQueueConfig& config() const noexcept { return config_; }
+    const WorkQueueCounters& counters() const noexcept { return counters_; }
+    const std::vector<WqeRecord>& records() const noexcept { return records_; }
+    const std::vector<EvidenceEvent>& evidence() const noexcept {
+        return evidence_;
+    }
+
+    const WqeRecord& wqe(WqeId wqe_id) const {
+        if (wqe_id == 0 || wqe_id > records_.size()) {
+            throw std::out_of_range("unknown RNIC WQE ID");
+        }
+        const WqeRecord& record = records_[static_cast<std::size_t>(wqe_id - 1)];
+        if (record.wqe_id != wqe_id) {
+            throw std::logic_error("RNIC WQE index invariant failed");
+        }
+        return record;
+    }
+
+    void validateInvariants() const {
+        if (occupied_sq_entries_ > config_.sq_depth) {
+            throw std::logic_error("RNIC SQ occupancy exceeds depth");
+        }
+        if (cq_.size() > config_.cq_depth) {
+            throw std::logic_error("RNIC CQ occupancy exceeds depth");
+        }
+        if (counters_.posted_wqes != records_.size()) {
+            throw std::logic_error("RNIC posted counter disagrees with records");
+        }
+
+        std::size_t unreclaimed = 0;
+        std::size_t reclaimed = 0;
+        for (std::size_t index = 0; index < records_.size(); ++index) {
+            const WqeRecord& record = records_[index];
+            if (record.wqe_id != index + 1 || record.sq_sequence != index + 1) {
+                throw std::logic_error("RNIC WQE identity/sequence is not monotonic");
+            }
+            if (record.timeline.sq_reclaimed_at_ps.has_value()) {
+                ++reclaimed;
+                if (!record.timeline.transport_retired_at_ps.has_value()) {
+                    throw std::logic_error("RNIC reclaimed an unretired WQE");
+                }
+            } else {
+                ++unreclaimed;
+            }
+        }
+        if (unreclaimed != occupied_sq_entries_
+            || reclaimed != counters_.sq_reclaimed_wqes) {
+            throw std::logic_error("RNIC SQ reclaim accounting mismatch");
+        }
+        if (counters_.cqes_visible < counters_.cqes_polled
+            || counters_.cqes_visible - counters_.cqes_polled != cq_.size()) {
+            throw std::logic_error("RNIC CQ producer/consumer accounting mismatch");
+        }
+        if (fatal_ != fatal_lost_sq_sequence_.has_value()) {
+            throw std::logic_error("RNIC fatal CQ-overrun accounting mismatch");
+        }
+        if (fatal_lost_sq_sequence_.has_value()) {
+            const WqeRecord& lost =
+                wqe(static_cast<WqeId>(*fatal_lost_sq_sequence_));
+            if (lost.state != WqeState::Error
+                || lost.timeline.sq_reclaimed_at_ps.has_value()) {
+                throw std::logic_error("RNIC reclaimed its first lost CQE");
+            }
+        }
+        for (const auto& token_and_wqe : inflight_) {
+            const WqeRecord& record = wqe(token_and_wqe.second);
+            if (!record.network_token.has_value()
+                || *record.network_token != token_and_wqe.first
+                || record.state != WqeState::InFlight) {
+                throw std::logic_error("RNIC in-flight token accounting mismatch");
+            }
+        }
+    }
+
+private:
+    struct PendingOutcome {
+        NetworkEvent event;
+        CompletionStatus status{CompletionStatus::Success};
+    };
+
+    using PendingCqeKey = std::pair<Picoseconds, std::uint64_t>;
+
+    void observeTime(Picoseconds now_ps) {
+        if (now_ps < last_observed_time_ps_) {
+            throw std::logic_error("RNIC model time regressed");
+        }
+        last_observed_time_ps_ = now_ps;
+    }
+
+    WqeRecord& mutableWqe(WqeId wqe_id) {
+        return const_cast<WqeRecord&>(wqe(wqe_id));
+    }
+
+    void retireReadyWqes() {
+        while (next_retire_sequence_ <= records_.size()) {
+            WqeRecord& record = records_[next_retire_sequence_ - 1];
+            const auto outcome_it = pending_outcomes_.find(record.wqe_id);
+            if (outcome_it == pending_outcomes_.end()) {
+                break;
+            }
+            const PendingOutcome outcome = outcome_it->second;
+            pending_outcomes_.erase(outcome_it);
+
+            if (!record.timeline.network_outcome_at_ps.has_value()
+                || *record.timeline.network_outcome_at_ps
+                    != outcome.event.event_time_ps) {
+                throw std::logic_error(
+                    "RNIC retirement lacks its recorded network outcome");
+            }
+            const Picoseconds retired_at =
+                std::max(outcome.event.event_time_ps, retirement_cursor_ps_);
+            retirement_cursor_ps_ = retired_at;
+            record.timeline.transport_retired_at_ps = retired_at;
+            record.completion_status = outcome.status;
+
+            if (record.request.signaled
+                || outcome.status != CompletionStatus::Success) {
+                scheduleCqe(record, outcome.status, retired_at);
+                record.state = WqeState::CompletionPending;
+            } else {
+                record.state = WqeState::RetiredUnsignaled;
+            }
+            ++next_retire_sequence_;
+        }
+    }
+
+    void scheduleCqe(
+        WqeRecord& record,
+        CompletionStatus status,
+        Picoseconds retired_at_ps) {
+        CompletionEntry entry;
+        entry.cqe_sequence = next_cqe_sequence_++;
+        entry.wr_id = record.request.wr_id;
+        entry.wqe_id = record.wqe_id;
+        entry.sq_sequence = record.sq_sequence;
+        entry.qpn = config_.qpn;
+        entry.opcode = record.request.opcode;
+        entry.status = status;
+        entry.valid_fields = kCqeValidWrId | kCqeValidQpn
+            | kCqeValidOpcode | kCqeValidStatus | kCqeValidVendorSyndrome;
+        // SEND byte count is not a valid raw CQE field. Keep it zero and do
+        // not set kCqeValidByteCount; payload size remains in the WQE record.
+        entry.byte_count = 0;
+        if (status == CompletionStatus::TransportError) {
+            entry.vendor_syndrome = 1;
+        } else if (status == CompletionStatus::NetworkRejected) {
+            entry.vendor_syndrome = 2;
+        }
+        const Picoseconds write_begin =
+            std::max(retired_at_ps, cqe_write_cursor_ps_);
+        entry.visible_at_ps =
+            checkedAdd(write_begin, config_.cqe_write_service_ps);
+        cqe_write_cursor_ps_ = entry.visible_at_ps;
+        pending_cqes_.emplace(
+            PendingCqeKey{entry.visible_at_ps, entry.cqe_sequence}, entry);
+    }
+
+    std::size_t publishCqes(
+        Picoseconds boundary_ps,
+        bool include_boundary) {
+        std::size_t published = 0;
+        while (!pending_cqes_.empty()) {
+            const Picoseconds visible_at =
+                pending_cqes_.begin()->first.first;
+            if (visible_at > boundary_ps
+                || (!include_boundary && visible_at == boundary_ps)) {
+                break;
+            }
+            CompletionEntry entry = pending_cqes_.begin()->second;
+            pending_cqes_.erase(pending_cqes_.begin());
+            WqeRecord& record = mutableWqe(entry.wqe_id);
+            if (cq_.size() == config_.cq_depth) {
+                fatal_ = true;
+                fatal_lost_sq_sequence_ = entry.sq_sequence;
+                ++counters_.cq_overruns;
+                evidence_.push_back(EvidenceEvent{
+                    EvidenceTier::Controlled,
+                    EvidenceKind::CqOverrun,
+                    record.wqe_id,
+                    record.request.wr_id,
+                    entry.visible_at_ps,
+                    DropLocation::None,
+                    DropReason::QueueOverflow,
+                });
+                record.state = WqeState::Error;
+                break;
+            }
+
+            entry.cq_producer_index = counters_.cqes_visible;
+            entry.cq_slot = static_cast<std::size_t>(
+                entry.cq_producer_index % config_.cq_depth);
+            entry.owner_generation = static_cast<std::uint8_t>(
+                (entry.cq_producer_index / config_.cq_depth) & 1U);
+            record.timeline.cqe_visible_at_ps = entry.visible_at_ps;
+            record.state = WqeState::CqeVisible;
+            cq_.push_back(entry);
+            ++counters_.cqes_visible;
+            counters_.cq_high_watermark =
+                std::max(counters_.cq_high_watermark, cq_.size());
+            ++published;
+        }
+        return published;
+    }
+
+    std::size_t publishDueCqes(Picoseconds now_ps) {
+        return publishCqes(now_ps, true);
+    }
+
+    std::size_t publishCqesBefore(Picoseconds now_ps) {
+        return publishCqes(now_ps, false);
+    }
+
+    void reclaimThrough(std::uint64_t sq_sequence, Picoseconds now_ps) {
+        if (sq_sequence < sq_reclaimed_through_) {
+            throw std::logic_error("RNIC SQ reclaim sequence regressed");
+        }
+        if (fatal_lost_sq_sequence_.has_value()
+            && sq_sequence >= *fatal_lost_sq_sequence_) {
+            throw std::logic_error(
+                "RNIC CQ poll cannot reclaim through a lost CQE");
+        }
+        while (sq_reclaimed_through_ < sq_sequence) {
+            WqeRecord& record = records_[sq_reclaimed_through_];
+            if (!record.timeline.transport_retired_at_ps.has_value()) {
+                throw std::logic_error("RNIC CQE attempted to reclaim live WQE");
+            }
+            if (!record.timeline.sq_reclaimed_at_ps.has_value()) {
+                record.timeline.sq_reclaimed_at_ps = now_ps;
+                if (record.state != WqeState::Completed) {
+                    record.state = WqeState::Reclaimed;
+                }
+                --occupied_sq_entries_;
+                ++counters_.sq_reclaimed_wqes;
+            }
+            ++sq_reclaimed_through_;
+        }
+    }
+
+    WorkQueueConfig config_;
+    NetworkPort& network_port_;
+    WorkQueueCounters counters_;
+    std::vector<WqeRecord> records_;
+    std::vector<EvidenceEvent> evidence_;
+    std::deque<WqeId> unpublished_;
+    std::deque<WqeId> ready_;
+    std::map<NetworkToken, WqeId> inflight_;
+    std::map<WqeId, PendingOutcome> pending_outcomes_;
+    std::map<PendingCqeKey, CompletionEntry> pending_cqes_;
+    std::deque<CompletionEntry> cq_;
+
+    WqeId next_wqe_id_{1};
+    std::uint64_t next_sq_sequence_{1};
+    std::uint64_t next_batch_id_{1};
+    std::uint64_t next_cqe_sequence_{1};
+    std::uint64_t next_retire_sequence_{1};
+    std::uint64_t sq_reclaimed_through_{0};
+    std::size_t occupied_sq_entries_{0};
+
+    Picoseconds last_observed_time_ps_{0};
+    Picoseconds doorbell_cursor_ps_{0};
+    Picoseconds wqe_fetch_cursor_ps_{0};
+    Picoseconds scheduler_cursor_ps_{0};
+    Picoseconds retirement_cursor_ps_{0};
+    Picoseconds cqe_write_cursor_ps_{0};
+    bool network_blocked_{false};
+    std::optional<Picoseconds> network_retry_at_ps_;
+    bool fatal_{false};
+    std::optional<std::uint64_t> fatal_lost_sq_sequence_;
+};
+
+WorkQueue::WorkQueue(WorkQueueConfig config, NetworkPort& network_port)
+    : impl_(std::make_unique<Impl>(std::move(config), network_port)) {}
+
+WorkQueue::~WorkQueue() = default;
+WorkQueue::WorkQueue(WorkQueue&&) noexcept = default;
+WorkQueue& WorkQueue::operator=(WorkQueue&&) noexcept = default;
+
+PostResult WorkQueue::postSend(
+    const WorkRequest& request,
+    Picoseconds now_ps) {
+    return impl_->postSend(request, now_ps);
+}
+
+PostBatchResult WorkQueue::postSendBatch(
+    const std::vector<WorkRequest>& requests,
+    Picoseconds now_ps) {
+    return impl_->postSendBatch(requests, now_ps);
+}
+
+DoorbellBatch WorkQueue::ringDoorbell(Picoseconds now_ps) {
+    return impl_->ringDoorbell(now_ps);
+}
+
+std::size_t WorkQueue::progress(Picoseconds now_ps) {
+    return impl_->progress(now_ps);
+}
+
+void WorkQueue::onNetworkEvent(const NetworkEvent& event) {
+    impl_->onNetworkEvent(event);
+}
+
+std::vector<CompletionEntry> WorkQueue::pollCompletionQueue(
+    std::size_t max_entries,
+    Picoseconds now_ps) {
+    return impl_->pollCompletionQueue(max_entries, now_ps);
+}
+
+std::optional<Picoseconds> WorkQueue::nextEventTime() const {
+    return impl_->nextEventTime();
+}
+
+bool WorkQueue::hasPendingPhysicalWork() const noexcept {
+    return impl_->hasPendingPhysicalWork();
+}
+
+bool WorkQueue::fatal() const noexcept { return impl_->fatal(); }
+
+std::size_t WorkQueue::occupiedSqEntries() const noexcept {
+    return impl_->occupiedSqEntries();
+}
+
+std::size_t WorkQueue::completionQueueDepth() const noexcept {
+    return impl_->completionQueueDepth();
+}
+
+std::size_t WorkQueue::unpublishedWqeCount() const noexcept {
+    return impl_->unpublishedWqeCount();
+}
+
+const WorkQueueConfig& WorkQueue::config() const noexcept {
+    return impl_->config();
+}
+
+const WorkQueueCounters& WorkQueue::counters() const noexcept {
+    return impl_->counters();
+}
+
+const std::vector<WqeRecord>& WorkQueue::records() const noexcept {
+    return impl_->records();
+}
+
+const std::vector<EvidenceEvent>& WorkQueue::evidence() const noexcept {
+    return impl_->evidence();
+}
+
+const WqeRecord& WorkQueue::wqe(WqeId wqe_id) const {
+    return impl_->wqe(wqe_id);
+}
+
+void WorkQueue::validateInvariants() const {
+    impl_->validateInvariants();
+}
+
+}  // namespace simllm::rnic

--- a/simllm/backends/rnic/tests/fake_network.h
+++ b/simllm/backends/rnic/tests/fake_network.h
@@ -1,0 +1,153 @@
+#ifndef SIMLLM_RNIC_TESTS_FAKE_NETWORK_H
+#define SIMLLM_RNIC_TESTS_FAKE_NETWORK_H
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <map>
+#include <optional>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+#include "simllm/rnic/network_port.h"
+
+namespace simllm::rnic::testing {
+
+struct FakeSubmission {
+    NetworkToken token{0};
+    NetworkTxDescriptor descriptor;
+    Picoseconds submitted_at_ps{0};
+    Picoseconds completion_at_ps{0};
+};
+
+class FakeNetworkPort final : public NetworkPort {
+public:
+    FakeNetworkPort(std::size_t capacity, Picoseconds latency_ps)
+        : capacity_(capacity), latency_ps_(latency_ps) {
+        if (capacity_ == 0) {
+            throw std::invalid_argument("fake network capacity must be positive");
+        }
+    }
+
+    NetworkSubmitResult trySubmit(
+        const NetworkTxDescriptor& descriptor,
+        Picoseconds now_ps) override {
+        if (descriptor.abi_version != kNetworkPortAbiVersion) {
+            return NetworkSubmitResult::rejected();
+        }
+        if (forced_busy_until_ps_.has_value()) {
+            if (now_ps < *forced_busy_until_ps_) {
+                return NetworkSubmitResult::busy(*forced_busy_until_ps_);
+            }
+            forced_busy_until_ps_.reset();
+        }
+        if (reject_next_) {
+            reject_next_ = false;
+            return NetworkSubmitResult::rejected(
+                DropLocation::TxPort, DropReason::PolicyRejected);
+        }
+        if (inflight_.size() == capacity_) {
+            const Picoseconds retry_at = nextCompletionTime().value();
+            if (retry_at <= now_ps) {
+                throw std::logic_error(
+                    "fake network does not support zero-latency "
+                    "oversubscription; dispatch due completions first");
+            }
+            return NetworkSubmitResult::busy(retry_at);
+        }
+        if (latency_ps_ > std::numeric_limits<Picoseconds>::max() - now_ps) {
+            throw std::overflow_error("fake network timestamp overflow");
+        }
+        const NetworkToken token = next_token_++;
+        const Picoseconds completion_at = now_ps + latency_ps_;
+        FakeSubmission submission{token, descriptor, now_ps, completion_at};
+        inflight_.emplace(token, submission);
+        history_.push_back(submission);
+        return NetworkSubmitResult::accepted(token);
+    }
+
+    void rejectNext() noexcept { reject_next_ = true; }
+    void forceBusyUntil(Picoseconds retry_at_ps) {
+        forced_busy_until_ps_ = retry_at_ps;
+    }
+
+    std::optional<Picoseconds> nextCompletionTime() const {
+        std::optional<Picoseconds> result;
+        for (const auto& item : inflight_) {
+            if (!result.has_value()
+                || item.second.completion_at_ps < *result) {
+                result = item.second.completion_at_ps;
+            }
+        }
+        return result;
+    }
+
+    std::vector<NetworkEvent> takeDue(Picoseconds now_ps) {
+        std::vector<std::pair<Picoseconds, NetworkToken>> due;
+        for (const auto& item : inflight_) {
+            if (item.second.completion_at_ps <= now_ps) {
+                due.emplace_back(item.second.completion_at_ps, item.first);
+            }
+        }
+        std::sort(due.begin(), due.end());
+        std::vector<NetworkEvent> events;
+        events.reserve(due.size());
+        for (const auto& time_and_token : due) {
+            events.push_back(take(
+                time_and_token.second,
+                NetworkEventKind::Delivered,
+                time_and_token.first));
+        }
+        return events;
+    }
+
+    NetworkEvent take(
+        NetworkToken token,
+        NetworkEventKind kind,
+        Picoseconds event_time_ps,
+        DropLocation location = DropLocation::None,
+        DropReason reason = DropReason::None) {
+        const auto item = inflight_.find(token);
+        if (item == inflight_.end()) {
+            throw std::out_of_range("unknown fake network token");
+        }
+        NetworkEvent event;
+        event.kind = kind;
+        event.token = token;
+        event.wqe_id = item->second.descriptor.wqe_id;
+        event.event_time_ps = event_time_ps;
+        event.drop_location = location;
+        event.drop_reason = reason;
+        inflight_.erase(item);
+        return event;
+    }
+
+    NetworkToken tokenForWqe(WqeId wqe_id) const {
+        for (const auto& item : inflight_) {
+            if (item.second.descriptor.wqe_id == wqe_id) {
+                return item.first;
+            }
+        }
+        throw std::out_of_range("WQE has no fake network token");
+    }
+
+    std::size_t inflightCount() const noexcept { return inflight_.size(); }
+    const std::vector<FakeSubmission>& history() const noexcept {
+        return history_;
+    }
+
+private:
+    std::size_t capacity_;
+    Picoseconds latency_ps_;
+    NetworkToken next_token_{1};
+    bool reject_next_{false};
+    std::optional<Picoseconds> forced_busy_until_ps_;
+    std::map<NetworkToken, FakeSubmission> inflight_;
+    std::vector<FakeSubmission> history_;
+};
+
+}  // namespace simllm::rnic::testing
+
+#endif  // SIMLLM_RNIC_TESTS_FAKE_NETWORK_H

--- a/simllm/backends/rnic/tests/work_queue_test.cpp
+++ b/simllm/backends/rnic/tests/work_queue_test.cpp
@@ -1,0 +1,522 @@
+#include "fake_network.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <iostream>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include "simllm/rnic/work_queue.h"
+
+namespace {
+
+using simllm::rnic::CompletionStatus;
+using simllm::rnic::DropLocation;
+using simllm::rnic::DropReason;
+using simllm::rnic::EvidenceKind;
+using simllm::rnic::NetworkEventKind;
+using simllm::rnic::PostStatus;
+using simllm::rnic::WorkQueue;
+using simllm::rnic::WorkQueueConfig;
+using simllm::rnic::WorkRequest;
+using simllm::rnic::testing::FakeNetworkPort;
+
+class TestRunner {
+public:
+    void check(bool condition, const std::string& message) {
+        if (!condition) {
+            ++failures_;
+            std::cerr << "FAIL: " << message << '\n';
+        }
+    }
+
+    template <typename Callable>
+    void expectThrow(Callable&& callable, const std::string& message) {
+        try {
+            callable();
+            check(false, message);
+        } catch (const std::exception&) {
+            check(true, message);
+        }
+    }
+
+    int failures() const noexcept { return failures_; }
+
+private:
+    int failures_{0};
+};
+
+WorkRequest request(
+    std::uint64_t wr_id,
+    bool signaled,
+    std::uint64_t payload_bytes = 4096) {
+    WorkRequest result;
+    result.wr_id = wr_id;
+    result.flow_id = wr_id + 1000;
+    result.flow_tag = 7;
+    result.destination = 1;
+    result.payload_bytes = payload_bytes;
+    result.signaled = signaled;
+    return result;
+}
+
+WorkQueueConfig config(std::size_t sq_depth, std::size_t cq_depth) {
+    WorkQueueConfig result;
+    result.sq_depth = sq_depth;
+    result.cq_depth = cq_depth;
+    result.source = 0;
+    result.qpn = 17;
+    result.policy_context_token = 9001;
+    return result;
+}
+
+void testAcceptedPrefixAndDoorbell(TestRunner& test) {
+    FakeNetworkPort network(2, 100);
+    WorkQueueConfig cfg = config(2, 2);
+    cfg.doorbell_service_ps = 10;
+    cfg.wqe_fetch_service_ps = 3;
+    WorkQueue queue(cfg, network);
+
+    const std::vector<WorkRequest> requests{
+        request(101, true), request(102, true), request(103, true)};
+    const auto posted = queue.postSendBatch(requests, 0);
+    test.check(posted.status == PostStatus::SqFull,
+               "three-WR batch reports SQ full");
+    test.check(posted.accepted.size() == 2,
+               "accepted prefix contains exactly two WQEs");
+    test.check(posted.bad_wr_index.has_value() && *posted.bad_wr_index == 2,
+               "bad WR index identifies the first unaccepted WR");
+    test.check(queue.counters().sq_full_rejections == 1,
+               "SQ full has one controlled rejection counter");
+    test.check(queue.evidence().size() == 1
+                   && queue.evidence()[0].kind == EvidenceKind::SqFull
+                   && queue.evidence()[0].wr_id == 103,
+               "SQ-full evidence identifies the rejected WR");
+
+    const auto doorbell = queue.ringDoorbell(0);
+    test.check(doorbell.wqe_count == 2 && doorbell.observed_at_ps == 10,
+               "one doorbell publishes the accepted prefix");
+    test.check(queue.wqe(1).timeline.admitted_at_ps == 13,
+               "first WQE records fetch/admission timing");
+    test.check(queue.wqe(2).timeline.admitted_at_ps == 16,
+               "second WQE serializes behind the first fetch");
+    queue.validateInvariants();
+}
+
+void testUnsignaledOrderedRetirement(TestRunner& test) {
+    FakeNetworkPort network(2, 100);
+    WorkQueueConfig cfg = config(4, 4);
+    cfg.doorbell_service_ps = 10;
+    WorkQueue queue(cfg, network);
+
+    const auto posted = queue.postSendBatch(
+        {request(201, false), request(202, true)}, 0);
+    queue.ringDoorbell(0);
+    queue.progress(10);
+    test.check(posted.accepted.size() == 2 && network.inflightCount() == 2,
+               "two WQEs enter the fake network");
+    test.check(network.history()[0].descriptor.flow_id == 1201
+                   && network.history()[0].descriptor.flow_tag == 7
+                   && network.history()[0].descriptor.policy_context_token
+                       == 9001,
+               "network boundary preserves flow and opaque policy identity");
+
+    const auto second_token = network.tokenForWqe(2);
+    queue.onNetworkEvent(network.take(
+        second_token, NetworkEventKind::Delivered, 50));
+    test.check(queue.wqe(2).timeline.network_outcome_at_ps == 50
+                   && !queue.wqe(2)
+                           .timeline.transport_retired_at_ps.has_value(),
+               "network outcome is observable before ordered retirement");
+    queue.progress(50);
+    test.check(queue.completionQueueDepth() == 0,
+               "later network callback waits for SQ retirement order");
+
+    const auto first_token = network.tokenForWqe(1);
+    queue.onNetworkEvent(network.take(
+        first_token, NetworkEventKind::Delivered, 60));
+    queue.progress(60);
+    test.check(queue.completionQueueDepth() == 1,
+               "one signaled CQE covers the ordered prefix");
+    test.check(queue.occupiedSqEntries() == 2,
+               "transport retirement alone does not reclaim SQ slots");
+
+    const auto cqes = queue.pollCompletionQueue(8, 60);
+    test.check(cqes.size() == 1 && cqes[0].wqe_id == 2,
+               "only the signaled WQE produces a CQE");
+    test.check(cqes[0].byte_count == 0
+                   && (cqes[0].valid_fields
+                       & simllm::rnic::kCqeValidByteCount) == 0,
+               "SEND CQE does not invent a valid byte-count field");
+    test.check(queue.occupiedSqEntries() == 0,
+               "polling the signaled CQE reclaims both SQ slots");
+    test.check(queue.wqe(1).timeline.transport_retired_at_ps == 60
+                   && queue.wqe(2).timeline.transport_retired_at_ps == 60,
+               "out-of-order callbacks retire in SQ order");
+    queue.validateInvariants();
+}
+
+void testAllUnsignaledExhaustsSq(TestRunner& test) {
+    FakeNetworkPort network(2, 10);
+    WorkQueue queue(config(2, 2), network);
+    queue.postSend(request(301, false), 0);
+    queue.postSend(request(302, false), 0);
+    queue.ringDoorbell(0);
+    queue.progress(0);
+    for (const auto& event : network.takeDue(10)) {
+        queue.onNetworkEvent(event);
+    }
+    queue.progress(10);
+
+    test.check(!queue.hasPendingPhysicalWork(),
+               "retired unsignaled WQEs leave no physical work");
+    test.check(queue.occupiedSqEntries() == 2,
+               "retired unsignaled WQEs remain unreclaimed");
+    test.check(queue.postSend(request(303, true), 10).status == PostStatus::SqFull,
+               "all-unsignaled stream reaches the SQ capacity boundary");
+    queue.validateInvariants();
+}
+
+void testNetworkBusyPreservesHeadOrder(TestRunner& test) {
+    FakeNetworkPort network(1, 100);
+    WorkQueueConfig cfg = config(4, 4);
+    cfg.wqe_fetch_service_ps = 10;
+    WorkQueue queue(cfg, network);
+    queue.postSendBatch({request(401, true), request(402, true)}, 0);
+    queue.ringDoorbell(0);
+
+    queue.progress(10);
+    queue.progress(20);
+    test.check(queue.counters().network_busy == 1,
+               "second WQE records one network-busy stall");
+    test.check(network.history().size() == 1
+                   && network.history()[0].descriptor.wqe_id == 1,
+               "busy port does not bypass the SQ head");
+
+    for (const auto& event : network.takeDue(110)) {
+        queue.onNetworkEvent(event);
+    }
+    queue.progress(110);
+    test.check(network.history().size() == 2
+                   && network.history()[1].descriptor.wqe_id == 2
+                   && network.history()[1].submitted_at_ps == 110,
+               "blocked SQ head retries at the advertised time");
+    for (const auto& event : network.takeDue(210)) {
+        queue.onNetworkEvent(event);
+    }
+    queue.progress(210);
+    const auto cqes = queue.pollCompletionQueue(8, 210);
+    test.check(cqes.size() == 2 && cqes[0].wqe_id == 1
+                   && cqes[1].wqe_id == 2,
+               "busy/retry path preserves completion order");
+    queue.validateInvariants();
+}
+
+void testBusyRetrySurvivesUnrelatedCompletion(TestRunner& test) {
+    FakeNetworkPort network(1, 100);
+    WorkQueueConfig cfg = config(4, 4);
+    cfg.wqe_fetch_service_ps = 10;
+    WorkQueue queue(cfg, network);
+    queue.postSendBatch({request(451, true), request(452, true)}, 0);
+    queue.ringDoorbell(0);
+
+    queue.progress(10);
+    network.forceBusyUntil(1000);
+    queue.progress(20);
+    test.check(queue.nextEventTime() == 1000,
+               "busy result publishes its advertised retry time");
+
+    const auto first = network.tokenForWqe(1);
+    queue.onNetworkEvent(network.take(
+        first, NetworkEventKind::Delivered, 110));
+    queue.progress(110);
+    test.check(network.history().size() == 1
+                   && queue.nextEventTime() == 1000,
+               "unrelated completion does not revoke a policy retry gate");
+
+    queue.progress(1000);
+    test.check(network.history().size() == 2
+                   && network.history()[1].submitted_at_ps == 1000,
+               "blocked WQE retries exactly at the advertised time");
+    queue.validateInvariants();
+}
+
+void testDropProducesControlledErrorCqe(TestRunner& test) {
+    FakeNetworkPort network(1, 100);
+    WorkQueue queue(config(2, 2), network);
+    const auto posted = queue.postSend(request(501, false), 0);
+    queue.ringDoorbell(0);
+    queue.progress(0);
+    const auto token = network.tokenForWqe(posted.wqe_id);
+    queue.onNetworkEvent(network.take(
+        token,
+        NetworkEventKind::Dropped,
+        10,
+        DropLocation::RxPort,
+        DropReason::Injected));
+    queue.progress(10);
+    const auto cqes = queue.pollCompletionQueue(1, 10);
+
+    test.check(cqes.size() == 1
+                   && cqes[0].status == CompletionStatus::TransportError,
+               "unsignaled dropped WQE produces an error CQE");
+    test.check(queue.evidence().size() == 1
+                   && queue.evidence()[0].kind == EvidenceKind::NetworkDrop
+                   && queue.evidence()[0].drop_location == DropLocation::RxPort
+                   && queue.evidence()[0].drop_reason == DropReason::Injected,
+               "drop evidence preserves controlled location and reason");
+    test.check(queue.occupiedSqEntries() == 0,
+               "polling error CQE reclaims the failed WQE");
+    test.check(queue.wqe(posted.wqe_id).timeline.network_accepted_at_ps == 0
+                   && queue.wqe(posted.wqe_id).timeline.network_outcome_at_ps
+                       == 10
+                   && !queue.wqe(posted.wqe_id)
+                           .timeline.first_packet_at_ps.has_value()
+                   && !queue.wqe(posted.wqe_id)
+                           .timeline.last_packet_at_ps.has_value(),
+               "flow port does not fabricate packet issue timestamps");
+    queue.validateInvariants();
+}
+
+void testCqOverrunIsFatalAndAccounted(TestRunner& test) {
+    FakeNetworkPort network(3, 100);
+    WorkQueue queue(config(4, 1), network);
+    queue.postSendBatch(
+        {request(601, true), request(602, true), request(603, true)}, 0);
+    queue.ringDoorbell(0);
+    queue.progress(0);
+    const auto first = network.tokenForWqe(1);
+    const auto second = network.tokenForWqe(2);
+    const auto third = network.tokenForWqe(3);
+    queue.onNetworkEvent(network.take(
+        first, NetworkEventKind::Delivered, 10));
+    queue.onNetworkEvent(network.take(
+        second, NetworkEventKind::Delivered, 10));
+    queue.progress(10);
+
+    test.check(queue.fatal() && queue.counters().cq_overruns == 1,
+               "second CQE causes one fatal CQ overrun");
+    test.check(queue.evidence().size() == 1
+                   && queue.evidence()[0].kind == EvidenceKind::CqOverrun
+                   && queue.evidence()[0].wqe_id == 2,
+               "CQ-overrun evidence identifies the first lost CQE");
+    queue.onNetworkEvent(network.take(
+        third, NetworkEventKind::Delivered, 20));
+    queue.progress(20);
+    const auto cqes = queue.pollCompletionQueue(2, 20);
+    test.check(cqes.size() == 1 && cqes[0].wqe_id == 1,
+               "CQ overrun never overwrites the owned entry");
+    test.check(queue.occupiedSqEntries() == 2
+                   && queue.wqe(2).state == simllm::rnic::WqeState::Error
+                   && !queue.wqe(2).timeline.sq_reclaimed_at_ps.has_value()
+                   && queue.wqe(3).state
+                       == simllm::rnic::WqeState::CompletionPending,
+               "fatal overrun freezes later CQ publication and reclamation");
+    test.check(queue.counters().cqes_visible == 1
+                   && queue.counters().cq_overruns == 1,
+               "fatal overrun remains the unique first failure");
+    test.check(queue.hasPendingPhysicalWork()
+                   && !queue.nextEventTime().has_value(),
+               "fatal queue reports non-quiescence without a schedulable event");
+    queue.validateInvariants();
+}
+
+void testSerializedCqeWritesAndExplicitEventPriority(TestRunner& test) {
+    FakeNetworkPort network(2, 0);
+    WorkQueueConfig cfg = config(2, 1);
+    cfg.cqe_write_service_ps = 10;
+    WorkQueue queue(cfg, network);
+    queue.postSendBatch({request(651, true), request(652, true)}, 0);
+    queue.ringDoorbell(0);
+    queue.progress(0);
+    const auto first = network.tokenForWqe(1);
+    const auto second = network.tokenForWqe(2);
+    queue.onNetworkEvent(network.take(
+        first, NetworkEventKind::Delivered, 0));
+    queue.onNetworkEvent(network.take(
+        second, NetworkEventKind::Delivered, 0));
+
+    queue.progress(10);
+    test.check(queue.completionQueueDepth() == 1
+                   && queue.wqe(1).timeline.cqe_visible_at_ps == 10
+                   && !queue.wqe(2).timeline.cqe_visible_at_ps.has_value(),
+               "CQE writes serialize on the configured service resource");
+
+    const auto first_cqe = queue.pollCompletionQueue(1, 20);
+    queue.progress(20);
+    const auto second_cqe = queue.pollCompletionQueue(1, 20);
+    test.check(first_cqe.size() == 1 && second_cqe.size() == 1
+                   && second_cqe[0].visible_at_ps == 20 && !queue.fatal(),
+               "host-first polling at a timestamp frees space before progress");
+    queue.validateInvariants();
+}
+
+void testPollPublishesStrictlyOlderCqe(TestRunner& test) {
+    FakeNetworkPort network(1, 0);
+    WorkQueueConfig cfg = config(1, 1);
+    cfg.cqe_write_service_ps = 10;
+    WorkQueue queue(cfg, network);
+    queue.postSend(request(656, true), 0);
+    queue.ringDoorbell(0);
+    queue.progress(0);
+    queue.onNetworkEvent(network.take(
+        network.tokenForWqe(1), NetworkEventKind::Delivered, 0));
+
+    const auto cqes = queue.pollCompletionQueue(1, 20);
+    test.check(cqes.size() == 1 && cqes[0].visible_at_ps == 10
+                   && cqes[0].polled_at_ps == 20,
+               "late host poll cannot skip a strictly older CQE event");
+    queue.validateInvariants();
+}
+
+void testRejectedAndMalformedNetworkOutcomes(TestRunner& test) {
+    FakeNetworkPort rejecting(1, 0);
+    WorkQueue rejected_queue(config(1, 1), rejecting);
+    rejecting.rejectNext();
+    const auto rejected = rejected_queue.postSend(request(661, false), 0);
+    rejected_queue.ringDoorbell(0);
+    rejected_queue.progress(0);
+    const auto rejected_cqe = rejected_queue.pollCompletionQueue(1, 0);
+    test.check(rejected_cqe.size() == 1
+                   && rejected_cqe[0].status
+                       == CompletionStatus::NetworkRejected
+                   && !rejected_queue.wqe(rejected.wqe_id)
+                           .timeline.network_accepted_at_ps.has_value()
+                   && rejected_queue.wqe(rejected.wqe_id)
+                           .timeline.network_outcome_at_ps == 0,
+               "immediate rejection has an outcome but no packet acceptance");
+    rejected_queue.validateInvariants();
+
+    FakeNetworkPort network(1, 0);
+    WorkQueue queue(config(1, 1), network);
+    const auto posted = queue.postSend(request(662, true), 0);
+    queue.ringDoorbell(0);
+    queue.progress(0);
+    auto malformed = network.take(
+        network.tokenForWqe(posted.wqe_id),
+        NetworkEventKind::Delivered,
+        1,
+        DropLocation::RxPort,
+        DropReason::Injected);
+    malformed.kind = NetworkEventKind::Dropped;
+    malformed.drop_location = static_cast<DropLocation>(99);
+    test.expectThrow(
+        [&queue, &malformed]() { queue.onNetworkEvent(malformed); },
+        "unknown drop-location enum is not controlled evidence");
+    malformed.drop_location = DropLocation::RxPort;
+    malformed.drop_reason = static_cast<DropReason>(99);
+    test.expectThrow(
+        [&queue, &malformed]() { queue.onNetworkEvent(malformed); },
+        "unknown drop-reason enum is not controlled evidence");
+    malformed.kind = NetworkEventKind::Delivered;
+    malformed.drop_reason = DropReason::Injected;
+    test.expectThrow(
+        [&queue, &malformed]() { queue.onNetworkEvent(malformed); },
+        "delivered event with drop evidence is rejected before accounting");
+    test.check(queue.counters().network_delivered == 0,
+               "malformed event does not mutate delivery counters");
+    malformed.drop_location = DropLocation::None;
+    malformed.drop_reason = DropReason::None;
+    queue.onNetworkEvent(malformed);
+    queue.progress(1);
+    queue.pollCompletionQueue(1, 1);
+    queue.validateInvariants();
+}
+
+void testZeroLatencyOversubscriptionIsExplicitlyUnsupported(
+    TestRunner& test) {
+    FakeNetworkPort network(1, 0);
+    WorkQueue queue(config(2, 2), network);
+    queue.postSendBatch({request(666, true), request(667, true)}, 0);
+    queue.ringDoorbell(0);
+    test.expectThrow(
+        [&queue]() { queue.progress(0); },
+        "fake port rejects zero-latency oversubscription explicitly");
+}
+
+void testFakeNetworkTimestampOverflow(TestRunner& test) {
+    FakeNetworkPort network(
+        1, std::numeric_limits<simllm::rnic::Picoseconds>::max());
+    WorkQueue queue(config(1, 1), network);
+    queue.postSend(request(671, true), 1);
+    queue.ringDoorbell(1);
+    test.expectThrow(
+        [&queue]() { queue.progress(1); },
+        "fake network rejects timestamp overflow instead of wrapping");
+}
+
+void testCqWrapOwnerGeneration(TestRunner& test) {
+    FakeNetworkPort network(2, 0);
+    WorkQueue queue(config(2, 2), network);
+    std::vector<simllm::rnic::CompletionEntry> all;
+
+    for (std::uint64_t wave = 0; wave < 2; ++wave) {
+        queue.postSendBatch(
+            {request(700 + wave * 2, true),
+             request(701 + wave * 2, true)},
+            wave * 10);
+        queue.ringDoorbell(wave * 10);
+        queue.progress(wave * 10);
+        const auto first = network.tokenForWqe(wave * 2 + 1);
+        const auto second = network.tokenForWqe(wave * 2 + 2);
+        const auto completion_time = wave * 10 + 1;
+        queue.onNetworkEvent(network.take(
+            first, NetworkEventKind::Delivered, completion_time));
+        queue.onNetworkEvent(network.take(
+            second, NetworkEventKind::Delivered, completion_time));
+        queue.progress(completion_time);
+        auto cqes = queue.pollCompletionQueue(2, completion_time);
+        all.insert(all.end(), cqes.begin(), cqes.end());
+    }
+
+    test.check(all.size() == 4,
+               "two CQ waves return four completions");
+    test.check(all[0].cq_slot == 0 && all[1].cq_slot == 1
+                   && all[2].cq_slot == 0 && all[3].cq_slot == 1,
+               "CQ slots wrap modulo depth");
+    test.check(all[0].owner_generation == 0 && all[1].owner_generation == 0
+                   && all[2].owner_generation == 1
+                   && all[3].owner_generation == 1,
+               "CQ owner generation toggles on wrap");
+    queue.validateInvariants();
+}
+
+void testUnknownNetworkTokenThrows(TestRunner& test) {
+    FakeNetworkPort network(1, 0);
+    WorkQueue queue(config(1, 1), network);
+    simllm::rnic::NetworkEvent event;
+    event.token = 999;
+    event.wqe_id = 1;
+    event.event_time_ps = 0;
+    test.expectThrow(
+        [&queue, &event]() { queue.onNetworkEvent(event); },
+        "unknown network token is an asserted programming failure");
+}
+
+}  // namespace
+
+int main() {
+    TestRunner test;
+    testAcceptedPrefixAndDoorbell(test);
+    testUnsignaledOrderedRetirement(test);
+    testAllUnsignaledExhaustsSq(test);
+    testNetworkBusyPreservesHeadOrder(test);
+    testBusyRetrySurvivesUnrelatedCompletion(test);
+    testDropProducesControlledErrorCqe(test);
+    testCqOverrunIsFatalAndAccounted(test);
+    testSerializedCqeWritesAndExplicitEventPriority(test);
+    testPollPublishesStrictlyOlderCqe(test);
+    testRejectedAndMalformedNetworkOutcomes(test);
+    testZeroLatencyOversubscriptionIsExplicitlyUnsupported(test);
+    testFakeNetworkTimestampOverflow(test);
+    testCqWrapOwnerGeneration(test);
+    testUnknownNetworkTokenThrows(test);
+    if (test.failures() != 0) {
+        std::cerr << test.failures() << " RNIC WQ checks failed\n";
+        return 1;
+    }
+    std::cout << "all RNIC WQ checks passed\n";
+    return 0;
+}

--- a/simllm/backends/rnic/tests/work_queue_test.cpp
+++ b/simllm/backends/rnic/tests/work_queue_test.cpp
@@ -17,10 +17,12 @@ using simllm::rnic::DropLocation;
 using simllm::rnic::DropReason;
 using simllm::rnic::EvidenceKind;
 using simllm::rnic::NetworkEventKind;
+using simllm::rnic::Picoseconds;
 using simllm::rnic::PostStatus;
 using simllm::rnic::WorkQueue;
 using simllm::rnic::WorkQueueConfig;
 using simllm::rnic::WorkRequest;
+using simllm::rnic::WqeState;
 using simllm::rnic::testing::FakeNetworkPort;
 
 class TestRunner {
@@ -39,6 +41,22 @@ public:
             check(false, message);
         } catch (const std::exception&) {
             check(true, message);
+        }
+    }
+
+    template <typename Expected, typename Callable>
+    void expectThrowAs(Callable&& callable, const std::string& message) {
+        try {
+            callable();
+            check(false, message);
+        } catch (const Expected&) {
+            check(true, message);
+        } catch (const std::exception& error) {
+            check(
+                false,
+                message + "; wrong exception type: " + error.what());
+        } catch (...) {
+            check(false, message + "; wrong non-standard exception type");
         }
     }
 
@@ -70,6 +88,193 @@ WorkQueueConfig config(std::size_t sq_depth, std::size_t cq_depth) {
     result.qpn = 17;
     result.policy_context_token = 9001;
     return result;
+}
+
+void testServiceTimeValidation(TestRunner& test) {
+    FakeNetworkPort network(1, 0);
+    struct ServiceField {
+        Picoseconds WorkQueueConfig::* member;
+        const char* name;
+    };
+    const ServiceField fields[]{
+        {&WorkQueueConfig::doorbell_service_ps, "doorbell service"},
+        {&WorkQueueConfig::wqe_fetch_service_ps, "WQE-fetch service"},
+        {&WorkQueueConfig::qpc_lookup_service_ps, "QPC-lookup service"},
+        {&WorkQueueConfig::scheduler_service_ps, "scheduler service"},
+        {&WorkQueueConfig::cqe_write_service_ps, "CQE-write service"},
+    };
+    const Picoseconds wrapped_negative = static_cast<Picoseconds>(-1);
+    for (const ServiceField& field : fields) {
+        WorkQueueConfig invalid = config(1, 1);
+        invalid.*field.member = wrapped_negative;
+        test.expectThrowAs<std::invalid_argument>(
+            [&network, invalid]() {
+                WorkQueue queue(invalid, network);
+                (void)queue;
+            },
+            std::string(field.name)
+                + " rejects a signed negative wrapped into uint64");
+    }
+
+    WorkQueueConfig boundary = config(1, 1);
+    const Picoseconds max_valid = static_cast<Picoseconds>(
+        std::numeric_limits<std::int64_t>::max());
+    boundary.doorbell_service_ps = max_valid;
+    boundary.wqe_fetch_service_ps = max_valid;
+    boundary.qpc_lookup_service_ps = max_valid;
+    boundary.scheduler_service_ps = max_valid;
+    boundary.cqe_write_service_ps = max_valid;
+    WorkQueue boundary_queue(boundary, network);
+    test.check(
+        boundary_queue.config().cqe_write_service_ps == max_valid,
+        "INT64_MAX remains a valid configured service duration");
+}
+
+void testDoorbellTimestampOverflowIsAtomic(TestRunner& test) {
+    FakeNetworkPort network(1, 0);
+    WorkQueueConfig cfg = config(1, 1);
+    cfg.doorbell_service_ps = 1;
+    WorkQueue queue(cfg, network);
+    const auto posted = queue.postSend(request(91, true), 0);
+    const Picoseconds max_time = std::numeric_limits<Picoseconds>::max();
+
+    test.expectThrowAs<std::overflow_error>(
+        [&queue, max_time]() { queue.ringDoorbell(max_time); },
+        "doorbell timestamp overflow has the exact asserted error type");
+    const auto& record = queue.wqe(posted.wqe_id);
+    test.check(
+        queue.unpublishedWqeCount() == 1
+            && queue.occupiedSqEntries() == 1
+            && record.state == WqeState::Posted
+            && record.doorbell_batch_id == 0
+            && !record.timeline.doorbelled_at_ps.has_value()
+            && !record.timeline.wqe_fetch_begin_at_ps.has_value()
+            && queue.counters().doorbells == 0
+            && queue.counters().doorbelled_wqes == 0,
+        "failed doorbell leaves its WQE, timeline and counters untouched");
+    queue.validateInvariants();
+
+    const auto retry = queue.ringDoorbell(0);
+    test.check(
+        retry.batch_id == 1 && retry.wqe_count == 1
+            && retry.observed_at_ps == 1,
+        "failed doorbell consumes neither model time nor batch identity");
+    queue.validateInvariants();
+}
+
+void testMidBatchFetchOverflowIsAtomic(TestRunner& test) {
+    FakeNetworkPort network(2, 0);
+    WorkQueueConfig cfg = config(2, 2);
+    cfg.wqe_fetch_service_ps = 1;
+    WorkQueue queue(cfg, network);
+    const Picoseconds near_max =
+        std::numeric_limits<Picoseconds>::max() - 1;
+    queue.postSendBatch(
+        {request(92, true), request(93, true)}, near_max);
+
+    test.expectThrowAs<std::overflow_error>(
+        [&queue, near_max]() { queue.ringDoorbell(near_max); },
+        "second-WQE fetch overflow aborts the complete doorbell batch");
+    test.check(
+        queue.unpublishedWqeCount() == 2
+            && queue.occupiedSqEntries() == 2
+            && queue.counters().doorbells == 0
+            && queue.counters().doorbelled_wqes == 0
+            && !queue.nextEventTime().has_value(),
+        "mid-batch overflow publishes no WQE or service event");
+    for (const auto& record : queue.records()) {
+        test.check(
+            record.state == WqeState::Posted
+                && record.doorbell_batch_id == 0
+                && !record.timeline.doorbelled_at_ps.has_value()
+                && !record.timeline.wqe_fetch_end_at_ps.has_value()
+                && !record.timeline.admitted_at_ps.has_value(),
+            "mid-batch overflow preserves each Posted WQE exactly");
+    }
+    queue.validateInvariants();
+}
+
+void testCqeTimestampOverflowIsAtomic(TestRunner& test) {
+    FakeNetworkPort network(1, 0);
+    WorkQueueConfig cfg = config(1, 1);
+    cfg.cqe_write_service_ps = 1;
+    WorkQueue queue(cfg, network);
+    const auto posted = queue.postSend(request(94, true), 0);
+    queue.ringDoorbell(0);
+    queue.progress(0);
+    const auto token = network.tokenForWqe(posted.wqe_id);
+
+    simllm::rnic::NetworkEvent overflow_event;
+    overflow_event.kind = NetworkEventKind::Delivered;
+    overflow_event.token = token;
+    overflow_event.wqe_id = posted.wqe_id;
+    overflow_event.event_time_ps =
+        std::numeric_limits<Picoseconds>::max();
+    test.expectThrowAs<std::overflow_error>(
+        [&queue, &overflow_event]() {
+            queue.onNetworkEvent(overflow_event);
+        },
+        "CQE timestamp overflow has the exact asserted error type");
+
+    const auto& failed = queue.wqe(posted.wqe_id);
+    test.check(
+        failed.state == WqeState::InFlight
+            && failed.network_token == token
+            && !failed.timeline.network_outcome_at_ps.has_value()
+            && !failed.timeline.transport_retired_at_ps.has_value()
+            && !failed.completion_status.has_value()
+            && queue.counters().network_delivered == 0
+            && queue.counters().cqes_visible == 0
+            && queue.completionQueueDepth() == 0,
+        "failed CQE plan consumes no token, outcome, counter or timestamp");
+    queue.validateInvariants();
+
+    queue.onNetworkEvent(network.take(
+        token, NetworkEventKind::Delivered, 0));
+    queue.progress(1);
+    const auto cqes = queue.pollCompletionQueue(1, 1);
+    test.check(
+        cqes.size() == 1 && cqes[0].wqe_id == posted.wqe_id
+            && cqes[0].cqe_sequence == 1
+            && queue.occupiedSqEntries() == 0,
+        "CQE-overflow rollback preserves a successful retry and CQE identity");
+    queue.validateInvariants();
+}
+
+void testRetirementPrefixOverflowIsAtomic(TestRunner& test) {
+    FakeNetworkPort network(2, 0);
+    WorkQueueConfig cfg = config(2, 2);
+    cfg.cqe_write_service_ps = 1;
+    WorkQueue queue(cfg, network);
+    queue.postSendBatch({request(95, true), request(96, true)}, 0);
+    queue.ringDoorbell(0);
+    queue.progress(0);
+    const auto first = network.tokenForWqe(1);
+    const auto second = network.tokenForWqe(2);
+    const Picoseconds near_max =
+        std::numeric_limits<Picoseconds>::max() - 1;
+    queue.onNetworkEvent(network.take(
+        second, NetworkEventKind::Delivered, near_max));
+
+    simllm::rnic::NetworkEvent first_event;
+    first_event.kind = NetworkEventKind::Delivered;
+    first_event.token = first;
+    first_event.wqe_id = 1;
+    first_event.event_time_ps = near_max;
+    test.expectThrowAs<std::overflow_error>(
+        [&queue, &first_event]() { queue.onNetworkEvent(first_event); },
+        "overflow on CQE two aborts the entire newly unlocked prefix");
+    test.check(
+        queue.wqe(1).state == WqeState::InFlight
+            && !queue.wqe(1).timeline.network_outcome_at_ps.has_value()
+            && queue.wqe(2).state
+                == WqeState::AwaitingOrderedRetirement
+            && !queue.wqe(2).timeline.transport_retired_at_ps.has_value()
+            && queue.counters().network_delivered == 1
+            && queue.counters().cqes_visible == 0
+            && queue.completionQueueDepth() == 0,
+        "prefix overflow commits neither the head callback nor any retirement");
+    queue.validateInvariants();
 }
 
 void testAcceptedPrefixAndDoorbell(TestRunner& test) {
@@ -499,6 +704,11 @@ void testUnknownNetworkTokenThrows(TestRunner& test) {
 
 int main() {
     TestRunner test;
+    testServiceTimeValidation(test);
+    testDoorbellTimestampOverflowIsAtomic(test);
+    testMidBatchFetchOverflowIsAtomic(test);
+    testCqeTimestampOverflowIsAtomic(test);
+    testRetirementPrefixOverflowIsAtomic(test);
     testAcceptedPrefixAndDoorbell(test);
     testUnsignaledOrderedRetirement(test);
     testAllUnsignaledExhaustsSq(test);

--- a/simllm/backends/rnic/tools/wq_probe.cpp
+++ b/simllm/backends/rnic/tools/wq_probe.cpp
@@ -1,6 +1,7 @@
 #include "fake_network.h"
 
 #include <algorithm>
+#include <charconv>
 #include <cstddef>
 #include <cstdint>
 #include <exception>
@@ -34,10 +35,17 @@ struct Options {
 };
 
 std::uint64_t parseUnsigned(const std::string& text, const char* option) {
-    std::size_t consumed = 0;
-    const std::uint64_t value = std::stoull(text, &consumed, 10);
-    if (consumed != text.size()) {
-        throw std::invalid_argument(std::string(option) + " is not an integer");
+    std::uint64_t value = 0;
+    const auto parsed = std::from_chars(
+        text.data(), text.data() + text.size(), value, 10);
+    if (parsed.ec == std::errc::result_out_of_range) {
+        throw std::out_of_range(
+            std::string(option) + " is outside the uint64 range");
+    }
+    if (text.empty() || parsed.ec != std::errc{}
+        || parsed.ptr != text.data() + text.size()) {
+        throw std::invalid_argument(
+            std::string(option) + " must be an unsigned integer");
     }
     return value;
 }
@@ -79,6 +87,13 @@ Options parseOptions(int argc, char** argv) {
     }
     if (options.wqes > options.sq_depth) {
         throw std::invalid_argument("RNIC probe requires SQ depth >= WQE count");
+    }
+    constexpr std::uint64_t max_size =
+        static_cast<std::uint64_t>(std::numeric_limits<std::size_t>::max());
+    if (options.wqes > max_size || options.network_capacity > max_size
+        || options.sq_depth > max_size || options.cq_depth > max_size) {
+        throw std::out_of_range(
+            "RNIC probe size exceeds the platform size_t range");
     }
     return options;
 }

--- a/simllm/backends/rnic/tools/wq_probe.cpp
+++ b/simllm/backends/rnic/tools/wq_probe.cpp
@@ -1,0 +1,195 @@
+#include "fake_network.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <iostream>
+#include <limits>
+#include <optional>
+#include <stdexcept>
+#include <string>
+
+#include "simllm/rnic/work_queue.h"
+
+namespace {
+
+using simllm::rnic::Picoseconds;
+using simllm::rnic::PostStatus;
+using simllm::rnic::WorkQueue;
+using simllm::rnic::WorkQueueConfig;
+using simllm::rnic::WorkRequest;
+using simllm::rnic::testing::FakeNetworkPort;
+
+struct Options {
+    std::uint64_t wqes{32};
+    std::uint64_t doorbell_batch{1};
+    std::uint64_t signal_every{1};
+    std::uint64_t network_capacity{32};
+    std::uint64_t network_latency_ps{0};
+    std::uint64_t doorbell_service_ps{1000};
+    std::uint64_t fetch_service_ps{10};
+    std::uint64_t sq_depth{64};
+    std::uint64_t cq_depth{64};
+};
+
+std::uint64_t parseUnsigned(const std::string& text, const char* option) {
+    std::size_t consumed = 0;
+    const std::uint64_t value = std::stoull(text, &consumed, 10);
+    if (consumed != text.size()) {
+        throw std::invalid_argument(std::string(option) + " is not an integer");
+    }
+    return value;
+}
+
+Options parseOptions(int argc, char** argv) {
+    Options options;
+    for (int index = 1; index < argc; index += 2) {
+        if (index + 1 >= argc) {
+            throw std::invalid_argument("every RNIC probe option needs a value");
+        }
+        const std::string option = argv[index];
+        const std::uint64_t value = parseUnsigned(argv[index + 1], argv[index]);
+        if (option == "--wqes") {
+            options.wqes = value;
+        } else if (option == "--doorbell-batch") {
+            options.doorbell_batch = value;
+        } else if (option == "--signal-every") {
+            options.signal_every = value;
+        } else if (option == "--network-capacity") {
+            options.network_capacity = value;
+        } else if (option == "--network-latency-ps") {
+            options.network_latency_ps = value;
+        } else if (option == "--doorbell-service-ps") {
+            options.doorbell_service_ps = value;
+        } else if (option == "--fetch-service-ps") {
+            options.fetch_service_ps = value;
+        } else if (option == "--sq-depth") {
+            options.sq_depth = value;
+        } else if (option == "--cq-depth") {
+            options.cq_depth = value;
+        } else {
+            throw std::invalid_argument("unknown RNIC probe option: " + option);
+        }
+    }
+    if (options.wqes == 0 || options.doorbell_batch == 0
+        || options.signal_every == 0 || options.network_capacity == 0
+        || options.sq_depth == 0 || options.cq_depth == 0) {
+        throw std::invalid_argument("RNIC probe sizes and capacities must be positive");
+    }
+    if (options.wqes > options.sq_depth) {
+        throw std::invalid_argument("RNIC probe requires SQ depth >= WQE count");
+    }
+    return options;
+}
+
+std::optional<Picoseconds> earlier(
+    std::optional<Picoseconds> lhs,
+    std::optional<Picoseconds> rhs) {
+    if (!lhs.has_value()) {
+        return rhs;
+    }
+    if (!rhs.has_value()) {
+        return lhs;
+    }
+    return std::min(*lhs, *rhs);
+}
+
+int run(const Options& options) {
+    FakeNetworkPort network(
+        static_cast<std::size_t>(options.network_capacity),
+        options.network_latency_ps);
+    WorkQueueConfig config;
+    config.sq_depth = static_cast<std::size_t>(options.sq_depth);
+    config.cq_depth = static_cast<std::size_t>(options.cq_depth);
+    config.source = 0;
+    config.qpn = 1;
+    config.doorbell_service_ps = options.doorbell_service_ps;
+    config.wqe_fetch_service_ps = options.fetch_service_ps;
+    WorkQueue queue(config, network);
+
+    for (std::uint64_t index = 1; index <= options.wqes; ++index) {
+        WorkRequest request;
+        request.wr_id = index;
+        request.destination = 1;
+        request.payload_bytes = 4096;
+        request.signaled = index % options.signal_every == 0
+            || index == options.wqes;
+        const auto posted = queue.postSend(request, 0);
+        if (posted.status != PostStatus::Accepted) {
+            throw std::runtime_error("RNIC probe unexpectedly rejected a WQE");
+        }
+        if (index % options.doorbell_batch == 0 || index == options.wqes) {
+            queue.ringDoorbell(0);
+        }
+    }
+
+    Picoseconds now_ps = 0;
+    Picoseconds jct_ps = 0;
+    std::uint64_t polled_cqes = 0;
+    std::uint64_t iterations = 0;
+    while (queue.hasPendingPhysicalWork()) {
+        if (++iterations > 1'000'000) {
+            throw std::runtime_error("RNIC probe event loop did not converge");
+        }
+        const auto next = earlier(queue.nextEventTime(), network.nextCompletionTime());
+        if (!next.has_value()) {
+            throw std::runtime_error("RNIC probe has pending work without an event");
+        }
+        if (*next < now_ps) {
+            throw std::runtime_error("RNIC probe event time regressed");
+        }
+        now_ps = *next;
+        for (const auto& event : network.takeDue(now_ps)) {
+            queue.onNetworkEvent(event);
+        }
+        queue.progress(now_ps);
+        const auto cqes = queue.pollCompletionQueue(
+            std::numeric_limits<std::size_t>::max(), now_ps);
+        polled_cqes += cqes.size();
+        if (!cqes.empty()) {
+            jct_ps = now_ps;
+        }
+    }
+    queue.validateInvariants();
+    if (queue.occupiedSqEntries() != 0 || queue.fatal()
+        || !queue.evidence().empty()) {
+        throw std::runtime_error("RNIC probe did not drain cleanly");
+    }
+
+    const auto& counters = queue.counters();
+    std::cout
+        << "wqes,doorbell_batch,signal_every,network_capacity,"
+           "network_latency_ps,doorbell_service_ps,fetch_service_ps,"
+           "doorbells,cqes,network_busy,jct_ps,posted,delivered,reclaimed,"
+           "sq_high_watermark,cq_high_watermark,evidence_count\n"
+        << options.wqes << ','
+        << options.doorbell_batch << ','
+        << options.signal_every << ','
+        << options.network_capacity << ','
+        << options.network_latency_ps << ','
+        << options.doorbell_service_ps << ','
+        << options.fetch_service_ps << ','
+        << counters.doorbells << ','
+        << polled_cqes << ','
+        << counters.network_busy << ','
+        << jct_ps << ','
+        << counters.posted_wqes << ','
+        << counters.network_delivered << ','
+        << counters.sq_reclaimed_wqes << ','
+        << counters.sq_high_watermark << ','
+        << counters.cq_high_watermark << ','
+        << queue.evidence().size() << '\n';
+    return 0;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    try {
+        return run(parseOptions(argc, argv));
+    } catch (const std::exception& error) {
+        std::cerr << "simllm_rnic_wq_probe: " << error.what() << '\n';
+        return 2;
+    }
+}


### PR DESCRIPTION
## Summary

- point SimLLM clone and project URLs at `openfabric-systems/simllm`
- add a dependency-free C++17 RNIC work-queue model with finite SQ/CQ state, accepted-prefix WR posting, doorbells, serialized fetch and completion service, ordered retirement, signaling, polling, owner wrap, and controlled queue failures
- add a versioned `NetworkPort` boundary that keeps SimLLM RNIC hardware separate from htsim transport and congestion-control policies
- add the first pre-registered native RNIC study, CMake/CTest coverage, CI wiring, source-package data, and the BACK/HTSIM task split for later RQ, QPC, PCIe/DMA, TX/RX, CX-7 calibration, and htsim composition
- make complete doorbell batches, network callbacks, and ordered-retirement prefixes transactional when timestamp arithmetic fails; reject wrapped negative service durations and require one-to-one WQE state/container ownership

## Why

The existing backend WQE ledger is timing-neutral and cannot represent the host submission path, device queue service, CQ visibility, or network-credit backpressure. This slice establishes a narrow hardware boundary before coupling the model to packet-level htsim policies such as DCQCN and rnic-cn.

The design keeps GOAL flow/tag identity, WR/WQE identity, transport policy context, and network-owned completion tokens distinct. It also keeps acceptance and outcome timestamps separate from first-packet and last-packet timestamps so later packet-level adapters do not collapse observable lifecycle stages.

## Registered results

- all 11 doorbell, signaling, and network-credit sweep cells match their closed forms exactly
- batching reduces 32 doorbells to 2 without changing the signaling count
- signaling reduces 32 CQEs to 2 without changing the doorbell count
- four network credits reduce the registered JCT from 16,110 ps to 4,140 ps
- native boundary tests cover SQ full, network busy, TX/RX drop, CQ overrun, owner wrap, ordered retirement, invalid input rejection, and atomic rollback at doorbell and CQE timestamp boundaries

## Validation

- `.venv/bin/ruff check .`
- `.venv/bin/pytest -q`: 294 passed, 3 skipped
- Debug and multi-config Release CMake builds and CTest: 2/2 passed
- Release `examples/rnic_wq_v1/run_rnic_wq_v1.py --check`: 11/11 exact
- ASan/UBSan native CTest: 2/2 passed with leak detection disabled because LeakSanitizer cannot run under the container ptrace wrapper
- extracted source distribution reproduced the Release study during packaging review
