### PR TITLE
Restructure the roadmap around modular RNIC composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,9 +187,16 @@ transport/CC policy. The analytical fluid baseline keeps an explicit hardware
 bypass so closed-form validation remains available.
 The native WQ and PCIe slices are currently standalone component models: the
 live packet and TTFT/TPOT path still uses htsim's timing-neutral compatibility
-ledger until BACK-8 and HTSIM-9 link the native hardware session into the
-directly invoked simulator, CORE-4 invokes that composition from the execution
-graph, and CORE-5 reduces its completion into `StepResult` and TTFT/TPOT.
+ledger until BACK-8, BACK-18 and HTSIM-9 link the native hardware session
+into the directly invoked simulator, CORE-4 invokes that composition from
+the execution graph, and CORE-5 reduces its completion into `StepResult` and
+TTFT/TPOT.
+The RNIC device itself is built from modules behind one construction entry
+point: the work-queue core plus optional DMA (PCIe), QPC (connection and
+context) and network transport modules
+([BACK-18](docs/modules/backends.md)). Disabling a module keeps the same
+interface, with its parameters inert or explicitly rejected, so one entry
+point serves everything from a bare work queue to the full device.
 
 #### RNIC hardware
 
@@ -197,7 +204,8 @@ graph, and CORE-5 reduces its completion into `StepResult` and TTFT/TPOT.
 |---|---|---|
 | RDMA Work Queue | partial, first native slice available ([study](examples/rnic_wq_v1/RESULTS.md), [BACK-8/9](docs/modules/backends.md)) | SimLLM C++ now models one finite SQ/CQ pair, WR-prefix posting, doorbell batches, ordered retirement, signaling, polling, owner wrap, network backpressure and controlled queue failures; RQ/SRQ, shared CQs and mlx5 encoding remain planned |
 | PCIe, MMIO and DMA | available, deterministic transaction slice ([study](examples/rnic_pcie_v1/RESULTS.md), [BACK-16/17](docs/modules/backends.md)) | Shared host-store, MWr/MRd/CplD scheduling with finite credits, tags and buffers, class ledgers and analytical path profiles; measured calibration and optional BlueFlame, ATS/ATC and MSI-X remain planned |
-| QP, QPC and context memory | planned ([BACK-11](docs/modules/backends.md)) | QP pairing and state transitions plus QPC, MTT/MPT and WQE-cache residency in a measured device-cache and host-ICM hierarchy |
+| QP, QPC and context memory | planned ([BACK-11/19](docs/modules/backends.md)) | QP pairing and state transitions plus QPC, MTT/MPT and WQE-cache residency in a measured device-cache and host-ICM hierarchy; connection setup registers the QP context in an explicitly tracked model of host memory |
+| Host and GPU submission | planned ([BACK-20](docs/modules/backends.md)) | Who submits work and consumes completions: a host CPU driver ringing doorbells, a CPU proxy fed from GPU queues, or GPU-initiated rings (the GPU posts its own network work) with a GPU-owned completion queue |
 | TX/RX hardware pipelines | planned ([BACK-12](docs/modules/backends.md)) | Packetization, schedulers, port buffers, ACK/NAK/RNR/retry, CQE completion, PFC gates and location-specific fault injection |
 | CX-7 observable state | planned ([BACK-13/14/15](docs/modules/backends.md)) | Versioned driver-visible registers, counters and traces, verbs capture/replay, and Collie-seeded boundary calibration; undocumented internals stay explicit calibrated abstractions |
 
@@ -240,7 +248,9 @@ Planned on this axis: explicit KV-lifecycle capture
 ([CORE-3](docs/modules/core.md), [VLLM-11](docs/modules/adapters-vllm.md),
 [SGL-9](docs/modules/adapters-sglang.md)), device-schedule capture
 ([VLLM-12](docs/modules/adapters-vllm.md),
-[SGL-10](docs/modules/adapters-sglang.md)), and PD-disaggregation /
+[SGL-10](docs/modules/adapters-sglang.md)), coupling at the vLLM model
+runner under a real GPU worker, matching where the SGLang adapter already
+sits ([VLLM-13](docs/modules/adapters-vllm.md)), and PD-disaggregation /
 KV-transfer traffic (M6).
 
 ## Modules
@@ -271,9 +281,12 @@ fidelity plan).
 - [x] M1: standalone core (workload to GOAL to `htsim_rnic` to metrics)
 - [x] M2: vLLM adapter, pinned to v0.26.0, no fork
 - [x] M3: SGLang adapter, plugin entry point, no fork
-- [ ] M4 (in progress): closed loop and the execution/resource runtime
+- [ ] M4 (in progress): the closed loop, the execution/resource runtime
+      and the composed native RNIC path driving TTFT/TPOT
 - [ ] M5 (in progress): MoE all-to-all studies + SASS compute calibration
 - [ ] M6: PD-disaggregation and KV-transfer traffic modeling
+- [ ] M7: the full RNIC module set (QPC, DMA, transport), the vLLM
+      model-runner seam and GPU-initiated networking
 
 Everything deeper lives in the developer guide
 [docs/README.md](docs/README.md): the open task registry, the full

--- a/docs/README.md
+++ b/docs/README.md
@@ -126,7 +126,8 @@ linked task IDs own the detail.
    native RNIC timing with htsim; CORE-4 invokes that path from the graph and
    CORE-5 reduces its completion into `ExecutionResult`, `StepResult` and
    TTFT/TPOT before further native precision work can close. BACK-9 through
-   BACK-12 complete the RNIC mechanisms behind that path.
+   BACK-12 complete the RNIC mechanisms behind that path, and BACK-18
+   assembles them behind one modular composition entry point.
 5. **Dependency-driven overlap.** Replace the serial step chain only
    after KV and resource queues exist; framework lowering declares
    dependencies, runtime arbitration determines realized overlap:
@@ -136,6 +137,18 @@ linked task IDs own the detail.
    stages; the largest attributed residual selects the next fidelity
    investment: [VLLM-4](modules/adapters-vllm.md#open-tasks),
    [SGL-4](modules/adapters-sglang.md#open-tasks).
+7. **Model-runner coupling and GPU-initiated networking.** Move the vLLM
+   seam from the executor RPC surface to the model runner under a real GPU
+   worker (the SGLang adapter already couples at that boundary), let the
+   simulated GPU launch the NCCL work, and select host-driven or GPU-driven
+   submission and CQ consumption per queue, with the QPC and the rings
+   registered in the tracked host-memory model:
+   [VLLM-13](modules/adapters-vllm.md#open-tasks),
+   [BACK-19](modules/backends.md#open-tasks),
+   [BACK-20](modules/backends.md#open-tasks),
+   [COMP-11](modules/compute.md#open-tasks). This deepens the visibility
+   available to the stage 6 comparisons; the executor-level mode stays the
+   GPU-less path.
 
 ## Module status
 
@@ -149,8 +162,8 @@ One line per module; the linked doc is the source of truth.
 | [placement](modules/placement.md) | Implemented: placement manifest round trip, declared placements, gpu-rank mapping, vLLM extraction; fabric manifest design-only | PLACE-1/2/3 |
 | [traffic](modules/traffic.md) | Implemented: collective patterns, TP step mapping, MoE all-to-all, GOAL renderers for steps and execution graphs | TRAF-2/3/4/5/6/7/8/9/10 |
 | [goal](modules/goal.md) | Implemented: GOAL trace + txt2bin helper | none |
-| [backends](modules/backends.md) | Implemented: htsim invocation/parsing plus native C++ RNIC SQ/CQ, network-port and shared PCIe transaction slices; htsim composition remains open | BACK-2/5-9/11-17; backend-repo HTSIM-1/2/4-9, ATLAHS-1 |
-| [adapters-vllm](modules/adapters-vllm.md) | Implemented: SimExecutor on pinned v0.26.0, full RPC surface, step-record streaming, placement exporter, live tp=8 closed loop | VLLM-3 through VLLM-12 |
+| [backends](modules/backends.md) | Implemented: htsim invocation/parsing plus native C++ RNIC SQ/CQ, network-port and shared PCIe transaction slices; htsim composition and the modular device entry point remain open | BACK-2/5-9/11-20; backend-repo HTSIM-1/2/4-9, ATLAHS-1 |
+| [adapters-vllm](modules/adapters-vllm.md) | Implemented: SimExecutor on pinned v0.26.0, full RPC surface, step-record streaming, placement exporter, live tp=8 closed loop | VLLM-3 through VLLM-13 |
 | [adapters-sglang](modules/adapters-sglang.md) | Implemented: SimTpModelWorker via plugin entry point at pinned commit, live CPU-engine smoke | SGL-3 through SGL-10 |
 
 ## Study index
@@ -204,8 +217,11 @@ Reproduce with
   vLLM tp=8 run at 0 ps residual ([m4](../examples/m4/RESULTS.md)),
   and the execution/completion boundary (stage 1 above) with
   [core2_lowering](../examples/core2_lowering/RESULTS.md). Remaining:
+  the composed native RNIC and htsim session (BACK-8, BACK-18, HTSIM-9;
+  pre-run expectations frozen in
+  [examples/rnic_live_v1](../examples/rnic_live_v1/expectations.md)),
   the persistent co-simulator (BRIDGE-1), KV lifecycle and the resource
-  runtime (CORE-3 through CORE-5), calibration against real captures.
+  runtime (CORE-3 through CORE-5), and calibration against real captures.
   General fabric manifests (PLACE-1/2) stay deferred behind the fixed
   eight-GPU profile with one 400G RNIC per GPU.
 - **M5 (in progress).** All-to-all traffic studies (MoE expert
@@ -218,3 +234,16 @@ Reproduce with
   follow-up only).
 - **M6 (not started).** PD-disaggregation and KV-transfer traffic
   modeling.
+- **M7 (not started).** Deep coupling: the full modular RNIC device and
+  GPU-initiated networking. The M4 composition entry point (BACK-18) is
+  populated with the DMA, QPC and network modules; QP link building
+  registers the QPC in the tracked virtual host-memory model, where the
+  WQE rings and data buffers are reached through tracked pages and the
+  QPC itself is not (BACK-11, BACK-19); and the submission source becomes
+  explicit per queue: a host CPU driver, a CPU proxy fed from GPU
+  descriptor queues, or GPU-initiated rings with a GPU-owned CQ (BACK-20).
+  On the framework side the vLLM seam moves from the executor RPC surface
+  to the model runner under a real GPU worker (VLLM-13; the SGLang
+  adapter already couples at that boundary), so the simulated GPU
+  launches the NCCL work and completion returns to the model runner
+  through the declared CQ consumer.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -332,10 +332,12 @@ RNIC hardware extension under `simllm/backends/rnic/`: RDMA WQ/CQ, QP/QPC,
 MMIO/PCIe/DMA and TX/RX hardware. htsim owns selectable transport/CC policies
 and the packet fabric. A versioned C++ adapter passes opaque packet or flow
 tokens and feedback events between them; no QP, queue, context or DMA object
-crosses that boundary. BACK-8 and HTSIM-9 will link the SimLLM static library
-into the directly invoked htsim binaries and present the composition through
-the existing `AtlahsFlowRuntime` interface. There is no Python callback in the
-packet event loop.
+crosses that boundary. BACK-8, BACK-18 and HTSIM-9 will link the SimLLM
+static library into the directly invoked htsim binaries and present the
+composition through the existing `AtlahsFlowRuntime` interface; BACK-18 owns
+the modular construction entry point through which the work-queue core and
+the optional QPC, DMA and network modules are assembled. There is no Python
+callback in the packet event loop.
 
 That composition is not live today. The wheel carries the CMake files and C++
 sources but builds no Python extension, and the current `htsim_rnic` binaries
@@ -346,8 +348,9 @@ FCT, `ExecutionResult`, `StepResult` or TTFT/TPOT. The descriptor carries GOAL
 flow/tag identity and a separate policy-context token, while completion uses a
 network-owned token. It does not equate flow acceptance or delivery with
 first/last packet issue. The standalone slice is validated in
-[examples/rnic_wq_v1](../examples/rnic_wq_v1/RESULTS.md); its live wrapper and
-packet-level adapter remain BACK-8 and HTSIM-9. The detailed evidence and
+[examples/rnic_wq_v1](../examples/rnic_wq_v1/RESULTS.md); its live wrapper,
+composition entry point and packet-level adapter remain BACK-8, BACK-18 and
+HTSIM-9. The detailed evidence and
 calibration plan is
 [papers/rnic-hardware-calibration.md](papers/rnic-hardware-calibration.md).
 

--- a/docs/modules/adapters-vllm.md
+++ b/docs/modules/adapters-vllm.md
@@ -2,7 +2,9 @@
 
 vLLM frontend adapter, pinned to **vLLM v0.26.0**. No fork required: the v1
 engine resolves its executor class from a dotted import path, and injects an
-arbitrary worker-extension class for the capture side.
+arbitrary worker-extension class for the capture side. The engine also
+resolves the worker class itself from a dotted path, which is the seam for
+the planned model-runner-level coupling mode (VLLM-13).
 
 ## Interface
 
@@ -217,3 +219,27 @@ row-for-row.
   NCCL launch/chunk boundaries and synchronous/asynchronous completion points.
   The simulated executor binds step shapes and framework KV events to this
   template; it does not invent concurrency from aggregate phase timings.
+- VLLM-13 (Completeness; P1; L): couple at the model-runner boundary under a
+  real GPU worker. The verified v0.26.0 seam is the worker class itself:
+  `parallel_config.worker_cls` is resolved as a dotted path
+  (`vllm/v1/worker/worker_base.py:250`), so a subclass of
+  `vllm.v1.worker.gpu_worker.Worker` can run the stock `init_device`
+  (real `torch.distributed` init, `GroupCoordinator` construction, NCCL
+  communicator creation, memory snapshot) and then rebind
+  `self.model_runner`, which the stock worker constructs at the end of
+  `init_device` (`gpu_worker.py:401`; v0.26.0 exposes no model-runner class
+  knob, only the binary V1/V2 stock-runner selector, which the subclass
+  must respect). Every worker RPC reaches the runner through
+  `self.model_runner.*`, so one rebind intercepts the whole per-step
+  surface while the worker's distributed structure stays live. This mirrors
+  the SGLang adapter's `SimTpModelWorker` overriding `_init_model_runner`,
+  so both adapters end up coupled at the model-runner boundary. This mode
+  runs only with GPUs present, since `init_device` and the stock runner
+  require CUDA; the executor-level `SimExecutor` remains the GPU-less mode
+  and its accepted behavior must not change. The sim model runner couples to the simulated
+  GPU service model, which launches the NCCL work and, in GPU-initiated
+  mode, drives the BACK-20 submission path; the run declares which agent
+  consumes each CQ and how completion reaches the model runner (BACK-20,
+  CORE-5). Under data parallelism above one, the runner-internal DP
+  coordination collective must be served or emulated. VLLM-12's
+  device-schedule capture uses the same seam.

--- a/docs/modules/backends.md
+++ b/docs/modules/backends.md
@@ -132,6 +132,22 @@ State ownership is explicit:
   watermarks that originate PFC and the paused priority state that consumes
   it.
 
+### Modular construction
+
+The native device is assembled from modules behind one composition entry
+point (BACK-18): the work-queue core, a DMA module (the shared PCIe fabric
+and its binding), a QPC module (QP lifecycle, pairing and context residency;
+BACK-11 backed by the BACK-19 host-memory model) and the network module (the
+htsim transport/CC policy and fabric behind the versioned `NetworkPort`;
+HTSIM-9). Every probe, study and composed binary constructs through the same
+entry point. A disabled module keeps the interface identical: its parameters
+are inert or rejected, never silently rescoped; its timeline stages report
+`not_applicable`; and its off state preserves the accepted baseline
+artifacts byte for byte. When the DMA module is present, the configuration
+also selects who produces each queue's submissions (host CPU driver, CPU
+proxy fed from GPU descriptor queues, or GPU-initiated rings) and which
+agent consumes each CQ (BACK-20).
+
 ### WQE authority and projection contract
 
 One session has one mutable WQE authority. Accounting records are projections
@@ -393,8 +409,9 @@ is difficult.
   authority is active.
   The standalone C++17 library, opaque flow-level `NetworkPort`, strict native
   build and deterministic fake adapter are complete. Remaining SimLLM scope is
-  the native session composition entry point and port binding, run records,
-  configuration hash, sole-authority projection and bypass equivalence.
+  run records, configuration hash, sole-authority projection and bypass
+  equivalence; the modular composition entry point and port binding are
+  BACK-18.
   HTSIM-9 owns the outer `AtlahsFlowRuntime` wrapper and htsim-side adapter;
   CORE-4 and CORE-5 own graph invocation and completion reduction.
 - BACK-9 (Completeness; P1; L): replace the timing-neutral WQE ledger with
@@ -453,7 +470,9 @@ is difficult.
   ledger without breaking its reader. Pair two RNIC endpoints explicitly;
   model TCP connect and attribute exchange, CM events and QP firmware-command
   time as control-path events. Model QPC, WQE-cache and MTT/MPT locality
-  separately.
+  separately. QPC registration, ring page lists and data-region registration
+  land in the BACK-19 host-memory model; QPC fetch never takes a per-access
+  MKey/MTT translation while WQE rings and data buffers do.
 - BACK-12 (Completeness; P1; L): implement the TX/RX hardware pipelines and
   cross-layer fault
   boundary. Include WQE decode, context/translation lookup, opcode-specific
@@ -481,6 +500,69 @@ is difficult.
   BACK-11 and BACK-12 own when semantic lookup, DMA, CQE and fault events
   occur; BACK-17 only lowers still-unconnected events into their shared-fabric
   PCIe service classes.
+- BACK-18 (Completeness; P1; M): give the native RNIC one modular composition
+  entry point. A single versioned device configuration assembles the session
+  from the work-queue core plus optional QPC (BACK-11, BACK-19), DMA
+  (`PcieFabric` and its work-queue binding) and network (HTSIM-9 port)
+  modules, and every probe, study and composed binary constructs through it.
+  Disabling a module keeps the same interface: its parameters are inert or
+  rejected, never silently rescoped; its timeline stages report
+  `not_applicable`; and each module's off state preserves the accepted
+  baselines byte for byte (DMA off reproduces the accepted rnic_wq_v1 scalar
+  rows, the standalone fabric reproduces the accepted rnic_pcie_v1 rows).
+  The composer owns the cross-module rules the current constructors enforce
+  pairwise: scalar service and fabric-charged stages stay mutually exclusive
+  so no stage is double-charged; one caller-driven clock and the documented
+  same-timestamp call order apply device-wide; with DMA enabled the
+  work-queue doorbell, fetch and CQE cursors are read-only mirrors of fabric
+  results, never a second scheduler; device identity (QP number, policy
+  context token) stays at device level so a disabled QPC module never erases
+  identity; ordering domains are namespaced when several devices share one
+  fabric; and the fabric's stable-address lifetime and two-phase plan/commit
+  atomicity are preserved. BACK-8 keeps run records, configuration hash,
+  sole-authority projection and bypass equivalence; this task owns only the
+  construction surface and port binding.
+- BACK-19 (Completeness; P1; L): add the virtual host-memory model that the
+  QPC and DMA modules register into. Track every device-visible host object
+  explicitly: QPC/ICM regions, SQ/RQ/CQ rings, doorbell records and data
+  memory regions, each with owner, endpoint kind (host-pinned or GPU
+  memory), page geometry and registration and teardown events, so BACK-11
+  link building registers the QPC as a tracked allocation rather than a
+  scalar lookup latency. Encode the translation asymmetry: QPC fetch is a
+  context read on the QPC/ICM service class over device-managed ICM pages
+  and never takes a per-access MKey/MPT/MTT translation; WQE rings are
+  reached through the per-queue page list recorded in the QPC at creation;
+  data buffers take the full MKey to MPT to MTT path. Translation and
+  ATS/ATC events (BACK-16, BACK-17) therefore apply to rings and data but
+  never to the QPC itself. The doorbell record is a located host-memory
+  object whose address is registered at queue creation. Grounding: the
+  public ConnectX PRM ICM and posting chapters, the upstream mlx5 QPC
+  layout and the device-cache taxonomy recorded in
+  [the RNIC hardware calibration plan](../papers/rnic-hardware-calibration.md).
+  BACK-11 keeps QP lifecycle, pairing and cache residency; this model gives
+  those caches their backing store and miss targets.
+- BACK-20 (Completeness; P1; L): model the WQE submission source and the CQ
+  consumer when the DMA module is enabled. Three producer shapes, selected
+  per queue: a host CPU driver thread that writes WQEs into host-pinned
+  rings, updates the doorbell record and rings the UAR register (the landed
+  BACK-10 path); a CPU proxy fed by GPU-written descriptor queues in
+  host-visible memory (the classic NCCL shape: the GPU never touches the
+  NIC and completions return through host-mapped counters); and
+  GPU-initiated submission (NCCL GIN, GDAKI/IBGDA), where GPU threads write
+  WQEs and the doorbell record into GPU-memory rings, ring the GPU-mapped
+  UAR register, and the NIC fetches WQEs and data through GPUDirect reads
+  and writes CQEs into GPU memory. Every CQ names exactly one owning
+  consumer, host driver or GPU, and the completion callback into the model
+  runner is charged on that owner's path (VLLM-13 and CORE-5 consume the
+  decision). Requires relaxing the current host-pinned-only endpoint
+  validation for the SQ, CQ and doorbell-record paths to GPU memory,
+  attributing initiator identity separately from the QP number, and driving
+  the GPU-side producer as an explicitly submitted GPU task through the
+  compute model's concurrent service, the same shape as its NCCL egress
+  kernels (COMP-11 deepens that surrounding NCCL/NVLink model but does not
+  own this producer). The QPC stays host ICM in every mode. COMP-2's fixed
+  CPU-proxy versus GPU-initiated constants remain the analytical fallback
+  while this structural path is disabled.
 
 ## Backend-repo follow-ups (tracked here, executed in their repos)
 

--- a/examples/rnic_live_v1/expectations.md
+++ b/examples/rnic_live_v1/expectations.md
@@ -3,10 +3,20 @@
 ## Freeze status
 
 This file is the expectations-only record for the first composed native RNIC
-and htsim run. It is written before implementation, before the SimLLM RNIC
-library is linked into an htsim driver, and before any run of this study. It
-contains no measured values. The results must cite both the original freeze
-commit and the final pre-run expectations commit.
+and htsim run. It was first written before implementation, before the SimLLM
+RNIC library was linked into an htsim driver, and before any run of this study.
+This amendment incorporates an independent pre-implementation review and still
+contains no measured values. The results must cite the original freeze commit
+and the final pre-run expectations commit.
+
+This freeze has two acceptance tiers. Tier A covers the BACK-8 and HTSIM-9
+composed binary plus the existing `HtsimStepSink` replay. Tier B is the
+repository live-reachability gate owned by CORE-4 and CORE-5. This study does
+not create, synthesize or score `CompletionEvent` or `ExecutionResult`. Tier B
+requires a separately frozen `ExecutionGraph -> DeviceRuntime ->
+CompletionEvent -> ExecutionResult -> StepResult -> TTFT/TPOT` run. Until Tier
+B passes, the native composition is component and step-sink evidence and
+BACK-8 remains open.
 
 ## Authority and modes
 
@@ -29,48 +39,107 @@ Use one signaled SEND on an otherwise idle two-endpoint fixture and sweep:
 - hardware mode: structural and bypass.
 
 All other native service times, propagation and congestion are zero in the
-exact fixture. A second two-WQE case uses equal release times to exercise one
-SQ's FIFO serialization. The same frozen GOAL and request replay is used for
-the `ExecutionGraph`, `StepResult`, TTFT and TPOT checks.
+exact fixture. Packet wire serialization remains active. The same frozen GOAL
+and request replay is used for the direct binary, `HtsimStepSink`, `StepResult`,
+TTFT and TPOT checks.
 
-## Expected relations
+The FIFO fixture posts two signaled 4 KiB SEND WQEs, W0 then W1, to one SQ at
+`submitted_at_ps = 0`, publishes both in one doorbell and uses one capacity-one
+egress service lane. All other service and propagation delays are zero. Let D
+be doorbell service and L(R) be the independently calculated one-WQE network
+service at link rate R. The exact timeline is:
+
+```text
+first_packet(W0) = D
+completed(W0)    = D + L(R)
+first_packet(W1) = D + L(R)
+completed(W1)    = D + 2 * L(R)
+```
+
+W1 queue wait is exactly L(R), completion order is W0 then W1, and JCT is
+`D + 2 * L(R)`. Increasing D adds exactly 1,000 ps to all four absolute
+boundaries. `L(200) = 2 * L(400)` for this exact rational fixture. No later WQE
+may bypass W0.
+
+## Expected behavioral relations
 
 1. In structural mode, increasing doorbell service by 1,000 ps shifts WQE
    fetch eligibility, first-packet issue, CQE visibility, CQ poll, flow
-   completion, `ExecutionResult.completed_at_ps`, `StepResult.completed_at_ps`
-   and the dependent live request boundary by exactly 1,000 ps in the isolated
-   fixture. It does not change serialized payload service.
-2. Doubling link rate halves only the serialized wire term. The 1,000 ps
-   native shift remains additive and unchanged at both payload sizes.
+   completion, direct-run JCT, `StepResult.completed_at_ps` and the dependent
+   replay request boundary by exactly 1,000 ps in the isolated fixture. It does
+   not change serialized payload service.
+2. Doubling link rate halves only the independently calculated serialized wire
+   term. The 1,000 ps native shift remains additive and unchanged at both
+   payload sizes.
 3. The composed htsim completion is the one result boundary. `StepResult` must
    not add standalone RNIC probe JCT or any second WQE-start constant.
-4. In bypass mode, changing native service parameters changes no command,
-   completion row, FCT, JCT, `ExecutionResult`, `StepResult`, TTFT or TPOT.
-   Accepted bypass artifacts remain byte-identical.
-5. Full `rnic-nn`, `rnic-cn` and DCQCN rows for one hardware fixture carry the
-   same hardware-configuration hash. Only transport-policy identity and its
-   consequences may differ.
-6. Every accepted native post maps to exactly one session-stable WQE key. Each
-   logical network extent maps to one WQE key and extent index. Every wire
-   attempt has a distinct attempt index and opaque token and terminates in one
-   delivery or drop event. A dropped attempt may create a later retry while
-   preserving the WQE and logical-extent keys. Native records, all attempt
-   terminals, projected rows and public object references reconcile exactly at
-   quiescence.
-7. A send WQE names its local SQ and send CQ, never a fabricated remote RQ. A
+4. The native FIFO fixture follows the four equations above at both rates and
+   both D values.
+5. Full `rnic-nn`, `rnic-cn` and DCQCN structural rows for one hardware fixture
+   carry the same hardware-configuration hash. Only transport-policy identity
+   and its consequences may differ.
+
+## Bypass reference and artifact identity
+
+The frozen bypass reference is HTSim commit
+`8c3f8b231a6a9311ffc1e7969a003dcba724b50d`, invoked with the same GOAL bytes,
+topology bytes, profile, seed and baseline argv. For every retained bypass
+profile, compare these behavioral artifacts byte for byte:
+
+- completion CSV;
+- canonical parsed completion rows and final JCT record;
+- `StepResult` tuple sequence; and
+- replay TTFT and TPOT summary.
+
+GOAL text and binary are input-identity guards. The new configuration and run
+audit record is excluded from byte comparison because it must declare
+`hardware_mode=bypass` and `authority=AtlahsWqeLedger`; those fields are checked
+structurally. Paths, build IDs, elapsed wall time and command spelling are
+diagnostic and excluded. Default bypass emits no new legacy stdout line. Native
+only knobs are rejected in bypass mode or omitted from the command, never
+silently accepted as active behavior.
+
+## Fatal unscored invariants
+
+1. Structural mode reports `native_session_constructed=1`, `native_posts=N`,
+   `legacy_ledger_constructed=0` and `legacy_mutations=0`.
+2. Bypass mode reports `native_session_constructed=0`, `native_posts=0`,
+   `legacy_ledger_constructed=1` and `legacy_posts=N`.
+3. Every accepted native post maps to one stable WQE key. Every extent key is
+   unique within that WQE. Every attempt token is issued once and terminates in
+   exactly one delivery or drop. Unknown, duplicate and cross-WQE terminals are
+   rejected before state mutation. Quiescence leaves zero live tokens. A retry
+   changes only its attempt index and token.
+4. Native terminal records, WQ and CQ producer/consumer sequences, projected
+   rows and timestamps reconcile exactly at quiescence.
+5. A send WQE names its local SQ and send CQ, never a fabricated remote RQ. A
    receive WQE names exactly one RQ or SRQ and its receive CQ. RX matching is a
    later relation. One-sided operations consume no receive WQE.
-8. For a signaled WQE, application-visible completion occurs at CQ poll. An
-   unsignaled successful WQE produces no fabricated CQE or CQ completion; its
-   SQ reclamation follows a later signaled completion or an explicit modeled
-   drain or teardown rule.
-9. `first_packet_at_ps` is the native NIC-start timestamp. Network acceptance
+6. A signaled WQE completes at CQ poll. An unsignaled successful WQE produces
+   no fabricated CQE; reclamation follows a later signaled completion or an
+   explicit modeled drain or teardown rule.
+7. `first_packet_at_ps` is an explicit packet-issue event. Network acceptance
    and whole-flow delivery are not substitutes for first or last packet issue.
 
-## Reported metrics
+The following negative controls must fail before lifecycle, counter or time
+mutation: structural mode with the native library unlinked; structural mode
+with the legacy authority also enabled; duplicate, unknown or cross-WQE token
+terminal; live token at quiescence; mismatched hardware hash across
+`rnic-nn`, `rnic-cn` and DCQCN; and a wrapper-bypass control presented to the
+D-additivity checker. A controlled htsim drop must produce the modeled error
+completion and must never produce a success CQE.
 
-Report the complete native WQE timeline, raw per-flow FCT, phase JCT,
-`ExecutionResult` and `StepResult` boundaries, and the fixed replay's TTFT and
-TPOT. Keep exact rows, behavioral relations, reconciliation invariants and
-native executable tests as separate evidence classes. Probe-only JCT is a
-component metric and cannot satisfy the live-reachability gate.
+## Evidence and reported metrics
+
+Report run configurations without scoring them. Score these behavioral
+relation families separately: D-additivity over payload by rate, inverse-rate
+serialization over payload by D, and two-WQE FIFO over rate by D. Report exact
+oracle rows separately. Authority, token conservation, reconciliation,
+quiescence, inactive-stage and by-construction zero checks are fatal but
+unscored. Native executable tests are component evidence and are not added to
+a behavioral pass count.
+
+Tier A reports the complete native WQE timeline, raw per-flow FCT, phase JCT,
+`StepResult` boundaries and fixed-replay TTFT and TPOT. Probe-only JCT remains a
+component metric. No `CompletionEvent`, `ExecutionResult` or Tier B claim may
+appear until CORE-4 and CORE-5 provide and validate that path.


### PR DESCRIPTION
## Summary

- The native RNIC device becomes constructable by modules behind one composition entry point: the work-queue core plus optional QPC, DMA (PCIe) and network transport modules. A disabled module keeps the same interface with its parameters inert or explicitly rejected, and each module's off state must preserve the accepted baselines byte for byte (new BACK-18, carved out of BACK-8's remaining scope).
- New BACK-19: a virtual host-memory model tracking QPC/ICM regions, WQE rings, doorbell records and data buffers, encoding the translation asymmetry: QPC fetch takes no per-access MKey/MPT/MTT translation, WQE rings are reached through the per-queue page list recorded in the QPC, and data buffers take the full MKey to MPT to MTT path.
- New BACK-20: the WQE submission source and CQ consumer become explicit per queue: a host CPU driver ringing doorbells, a CPU proxy fed from GPU descriptor queues (the classic NCCL shape), or GPU-initiated rings (NCCL GIN, GDAKI/IBGDA) with a GPU-owned CQ; the completion callback into the model runner is charged on the owner's path.
- New VLLM-13: couple at the model-runner boundary under a real GPU worker through the verified v0.26.0 worker-cls seam (worker_base.py:250 resolves the dotted path; the stock worker constructs the runner at gpu_worker.py:401), matching where the SGLang adapter already couples. The executor-level SimExecutor stays the GPU-less mode.
- Roadmap layers per the two-layer rule: the top README stays big-stroke (an M7 checklist line, one modular-construction sentence, one hardware-table row); docs/README.md carries the M7 milestone, fidelity stage 7 and the updated stage 4; architecture.md and the module docs carry the detail. M4 adds BACK-18 to the composed-session scope since the entry point is needed there.

## Checks

ruff clean; 301 passed, 3 skipped.