### PR TITLE
Detail the communication stack and add the pre-play oracle

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Network-faithful simulation of LLM serving and training deployments
 </h3>
 
 <p align="center">
-| <a href="#about"><b>About</b></a> | <a href="#architecture"><b>Architecture</b></a> | <a href="#getting-started"><b>Getting Started</b></a> | <a href="#demo"><b>Demo</b></a> | <a href="#models"><b>Models</b></a> | <a href="#modules"><b>Modules</b></a> | <a href="#development"><b>Development</b></a> | <a href="#contributing"><b>Contributing</b></a> |
+| <a href="#about"><b>About</b></a> | <a href="#architecture"><b>Architecture</b></a> | <a href="#getting-started"><b>Getting Started</b></a> | <a href="#demo"><b>Demo</b></a> | <a href="#models"><b>Models</b></a> | <a href="#modules"><b>Modules</b></a> | <a href="#development"><b>Development</b></a> | <a href="#contributing"><b>Contributing</b></a> | <a href="docs/README_PRO.md"><b>Pro Guide</b></a> |
 </p>
 
 ## About
@@ -84,7 +84,7 @@ design, including the exact vLLM/SGLang integration
 seams, the manifest schemas and the GOAL trace format, is in
 [docs/architecture.md](docs/architecture.md). The developer map
 (module status, contracts, open tasks, development process) is in
-[docs/README.md](docs/README.md).
+[docs/README_PRO.md](docs/README_PRO.md).
 
 ## Getting Started
 
@@ -249,7 +249,7 @@ Planned on this axis: explicit KV-lifecycle capture
 [SGL-9](docs/modules/adapters-sglang.md)), device-schedule capture
 ([VLLM-12](docs/modules/adapters-vllm.md),
 [SGL-10](docs/modules/adapters-sglang.md)), coupling at the vLLM model
-runner under a real GPU worker, matching where the SGLang adapter already
+runner, matching where the SGLang adapter already
 sits ([VLLM-13](docs/modules/adapters-vllm.md)), and PD-disaggregation /
 KV-transfer traffic (M6).
 
@@ -274,7 +274,7 @@ status and numbered open tasks; the README stays a map.
 
 SimLLM is built in validated stages; every stage ships with
 pre-registered studies whose numbers are defended in the open (see
-[docs/README.md](docs/README.md) for the process and the stage-by-stage
+[docs/README_PRO.md](docs/README_PRO.md) for the process and the stage-by-stage
 fidelity plan).
 
 - [x] M0: repo scaffold, backend submodules, CI, per-module docs
@@ -289,7 +289,7 @@ fidelity plan).
       model-runner seam and GPU-initiated networking
 
 Everything deeper lives in the developer guide
-[docs/README.md](docs/README.md): the open task registry, the full
+[docs/README_PRO.md](docs/README_PRO.md): the open task registry, the full
 roadmap and milestone detail, the execution-fidelity order, and the
 development workflow (pre-registered studies, audited results, numbered
 deferrals).

--- a/README.md
+++ b/README.md
@@ -250,7 +250,10 @@ Planned on this axis: explicit KV-lifecycle capture
 ([VLLM-12](docs/modules/adapters-vllm.md),
 [SGL-10](docs/modules/adapters-sglang.md)), coupling at the vLLM model
 runner, matching where the SGLang adapter already
-sits ([VLLM-13](docs/modules/adapters-vllm.md)), and PD-disaggregation /
+sits ([VLLM-13](docs/modules/adapters-vllm.md)), an offline CPU pre-play
+oracle that runs the real model slowly to fix each request's output
+length and expert routing, then replays them with outcomes predefined
+([preplay](docs/modules/preplay.md)), and PD-disaggregation /
 KV-transfer traffic (M6).
 
 ## Modules
@@ -266,6 +269,7 @@ status and numbered open tasks; the README stays a map.
 | `simllm/placement` | **The mapper**: placement + fabric manifests, rank-to-endpoint/GOAL-rank resolution | [placement](docs/modules/placement.md) |
 | `simllm/traffic` | Semantic collectives to physical flows | [traffic](docs/modules/traffic.md) |
 | `simllm/goal` | GOAL dependency-graph trace emission | [goal](docs/modules/goal.md) |
+| `simllm/preplay` (design) | Offline CPU inference oracle: pre-computes each request's true output and expert routing for replay | [preplay](docs/modules/preplay.md) |
 | `simllm/backends` | htsim / LogGOPSim invocation + result parsing, submodule pins | [backends](docs/modules/backends.md) |
 | `simllm/adapters/vllm` | `SimExecutor` (pluggable, no fork) + placement exporter | [adapters-vllm](docs/modules/adapters-vllm.md) |
 | `simllm/adapters/sglang` | `SimTpModelWorker` + placement exporter | [adapters-sglang](docs/modules/adapters-sglang.md) |
@@ -283,7 +287,8 @@ fidelity plan).
 - [x] M3: SGLang adapter, plugin entry point, no fork
 - [ ] M4 (in progress): the closed loop, the execution/resource runtime
       and the composed native RNIC path driving TTFT/TPOT
-- [ ] M5 (in progress): MoE all-to-all studies + SASS compute calibration
+- [ ] M5 (in progress): MoE all-to-all studies + offline calibration
+      (SASS compute, CPU pre-play oracle)
 - [ ] M6: PD-disaggregation and KV-transfer traffic modeling
 - [ ] M7: the full RNIC module set (QPC, DMA, transport), the vLLM
       model-runner seam and GPU-initiated networking

--- a/docs/README_PRO.md
+++ b/docs/README_PRO.md
@@ -13,7 +13,7 @@ status and open tasks; nothing here overrides them.
 | Layer | Where | What it holds |
 |---|---|---|
 | Beginner map | [../README.md](../README.md) | About, quick start, demo studies, model inventory, milestones |
-| Developer map | this file | Process, fidelity order, module status, study index |
+| Developer map | this file | Process, fidelity order, simulated communication stack, module status, study index |
 | Full design | [architecture.md](architecture.md) | Components, vLLM/SGLang integration seams, manifest schemas, execution/resource boundary, GOAL trace format, coupling modes, metrics |
 | Module truth | [modules/*.md](modules/) | Per-module design, current status, numbered open tasks |
 | Calibration sources | [papers/](papers/) | Literature anchors and evidence plans, including [message-size parameters](papers/msg-size-vs-bandwidth.md) and the [RNIC hardware/CX-7 boundary campaign](papers/rnic-hardware-calibration.md) |
@@ -138,17 +138,168 @@ linked task IDs own the detail.
    investment: [VLLM-4](modules/adapters-vllm.md#open-tasks),
    [SGL-4](modules/adapters-sglang.md#open-tasks).
 7. **Model-runner coupling and GPU-initiated networking.** Move the vLLM
-   seam from the executor RPC surface to the model runner under a real GPU
-   worker (the SGLang adapter already couples at that boundary), let the
+   seam from the executor RPC surface to the model runner, first as a
+   flagged skeleton and later under a real GPU worker (the SGLang adapter
+   already couples at that boundary), let the
    simulated GPU launch the NCCL work, and select host-driven or GPU-driven
    submission and CQ consumption per queue, with the QPC and the rings
-   registered in the tracked host-memory model:
+   registered in the tracked host-memory model. The framework communicators
+   and the NCCL stack are simulated behind their real interfaces, trimmed
+   to the main path with observability inserted (the stack graph below):
    [VLLM-13](modules/adapters-vllm.md#open-tasks),
+   [VLLM-14](modules/adapters-vllm.md#open-tasks),
+   [SGL-11](modules/adapters-sglang.md#open-tasks),
+   [COMP-15](modules/compute.md#open-tasks),
    [BACK-19](modules/backends.md#open-tasks),
    [BACK-20](modules/backends.md#open-tasks),
    [COMP-11](modules/compute.md#open-tasks). This deepens the visibility
    available to the stage 6 comparisons; the executor-level mode stays the
    GPU-less path.
+
+## Simulated communication stack
+
+The coupling modes reproduce the frameworks' real communication stack with
+the same functional names and interfaces, trimmed to the main path: the
+implementations are reduced, side calls off the main path are omitted or
+served inertly, and every boundary crossing emits an observability event on
+the virtual clock. Both frameworks get a simulated communicator layer: vLLM's
+`GroupCoordinator` ([VLLM-14](modules/adapters-vllm.md#open-tasks)) and
+SGLang's vendored `GroupCoordinator` with its device communicators
+([SGL-11](modules/adapters-sglang.md#open-tasks)). Both feed the
+interface-faithful NCCL stack model
+([COMP-15](modules/compute.md#open-tasks)): intra-node collectives run as
+NCCL collective kernels on the NVLink-class egress model and stay off the
+fabric, while inter-node transfers follow the proxy model down to the NIC
+([BACK-20](modules/backends.md#open-tasks) owns the submission source).
+
+```text
+vLLM model runner                    SGLang model runner
+  simulated GroupCoordinator           simulated vendored GroupCoordinator
+  (same interface, trimmed)            and device communicators
+               \                          /
+                v                        v
+          NCCL model (same functional names, trimmed)
+               |                            |
+   intra-node collective kernel   inter-node proxy
+   on the NVLink-class egress       -> ncclNet (isend, irecv, test)
+   model (stays off the fabric)     -> ibverbs (post send, poll CQ)
+                                    -> modular RNIC device
+                                       (WQ core + QPC + DMA/PCIe
+                                        + network port)
+                                    -> htsim transport/CC policy
+                                       and packet fabric
+```
+
+In GPU-initiated mode (BACK-20) the proxy leg is replaced by GPU-written
+rings behind the same upper interface, and the CQ consumer moves to the GPU.
+
+The first runnable slice is deliberately a skeleton: the complete mental
+model exists as name-mirrored empty function calls. A high-level entry flag
+tells the adapter it is simulating, so no physical GPU worker or GPU model
+runner is constructed; the adapter's copied Python path executes the same
+algorithm and call order with the deliberate computation left empty, and
+every timestamp is issued centrally by the simllm core virtual clock. The
+real communicator call path is also a study subject in its own right: the
+communication function itself (Python dispatch, custom-op indirection,
+synchronization stalls) can bottleneck vLLM and SGLang, so its measured
+cost is compared against the simulated path (VLLM-14, SGL-11).
+
+### Full call loop (default setup)
+
+The default setup is NCCL with a CPU-host proxy, not GPU-initiated
+networking. Placement is explicit: the proxy is fed by GPU-written
+descriptors and head counters in host-visible pinned memory (the BACK-20
+CPU-proxy shape), while the per-channel data FIFO (the net staging buffer)
+is hosted in GPU memory, registered so the NIC's payload DMA reads it
+directly over PCIe (GPUDirect-style); the tail counters and ready flags
+are host-visible as well. In the graph, "signal" is a proactive store
+by the producer and "poll" is a consumer that spins until the value
+changes. The lanes show how one upper-layer call from the worker side
+closes its full loop.
+
+```text
+CPU host lane                      GPU device lane                RNIC and fabric lane
+-------------                      ---------------                --------------------
+EngineCore.step()
+ Executor.execute_model()
+ Worker.execute_model()
+  GPUModelRunner.execute_model()
+   layer forward ................>  compute kernels on the
+   GroupCoordinator.all_reduce()    simulated GPU (SM scheduler,
+    pynccl.all_reduce()             HBM cursor, NVLink egress)
+     traffic planner:
+     logical channels, chunks
+     kernel launch .............>  NCCL collective kernel
+                                    intra-node share: NVLink
+                                    path only, no proxy
+                                    inter-node share: copy chunk
+                                    into the GPU-memory data
+                                    FIFO, then signal: store the
+                                    head counter to host memory
+ proxy loop: poll head <..........  (head counter is host-visible)
+  ncclNet.isend()
+  ibverbs post send,
+  ring doorbell ..................................................>  WQE fetch (DMA read),
+                                                                     payload DMA read from
+                                                                     the GPU-memory FIFO,
+                                                                     packets to the fabric
+ proxy loop: poll CQ <.............................................  CQE written at
+  ncclNet.test() done                                                completion
+  signal: store the tail
+  counter to host-mapped
+  memory .......................>  collective kernel: poll tail,
+                                   release the FIFO slot,
+                                   complete the kernel
+ stream event sync
+ (worker polls or waits) <........  kernel completion event
+ StepResult on the simllm
+ virtual clock
+```
+
+The SGLang lane is identical with `TpModelWorker.forward_batch_generation`
+and the vendored `GroupCoordinator` in place of the vLLM names. The GPU
+lane is served by the simulated GPU model in `simllm.compute` (CTA/SM
+scheduling, HBM cursor, NVLink egress; the collective kernel is an
+explicitly submitted GPU task).
+
+### Sizing plan
+
+The build-out is sized module by module and filled step by step. The
+numbers are planning estimates, not commitments; each slice lands with its
+own study per the development process.
+
+| Piece | Owner | First slice | Estimated size |
+|---|---|---|---|
+| vLLM adapter mirrored path (entry flag, no physical worker or runner) | [VLLM-13](modules/adapters-vllm.md#open-tasks) | empty calls, centralized timestamps | ~1,000 lines |
+| Simulated vLLM `GroupCoordinator` and device-communicator stubs | [VLLM-14](modules/adapters-vllm.md#open-tasks) | interface plus observability events | ~500 lines |
+| SGLang communicator half (shared base with vLLM's) | [SGL-11](modules/adapters-sglang.md#open-tasks) | interface plus observability events | ~400 lines |
+| NCCL model: communicator setup, logical channels, traffic planner | [COMP-15](modules/compute.md#open-tasks) | empty calls over the ring builder | ~800 lines |
+| GPU buffers and signals (data FIFO, flags, head/tail counters) | [COMP-15](modules/compute.md#open-tasks) | counters as events, no data contents | ~500 lines |
+| Proxy, `ncclNet`-shaped and ibverbs-shaped seams | [COMP-15](modules/compute.md#open-tasks), [BACK-20](modules/backends.md#open-tasks) | isend/irecv/test plus post/poll stubs | ~700 lines |
+| Observability and centralized timestamps in the core | [CORE-4](modules/core.md#open-tasks), [CORE-5](modules/core.md#open-tasks) | reuse the completion-event schema | ~300 lines |
+
+### Function inventory
+
+The living list of mirrored functions, their simulation status and the
+study that validated them (linked when performed). Statuses update as
+slices land.
+
+| Function (mirrored name) | Lane | Status | Owner | Study |
+|---|---|---|---|---|
+| vLLM `Executor.execute_model` RPC surface | CPU | implemented, executor-level `SimExecutor` | [adapters-vllm](modules/adapters-vllm.md) | [m4](../examples/m4/RESULTS.md) |
+| vLLM `Worker` init and step surface | CPU | served by `SimExecutor`; mirrored skeleton planned | [VLLM-13](modules/adapters-vllm.md#open-tasks) | [m4](../examples/m4/RESULTS.md) |
+| vLLM `GPUModelRunner.execute_model` | CPU | planned skeleton | [VLLM-13](modules/adapters-vllm.md#open-tasks) | none yet |
+| vLLM `GroupCoordinator.all_reduce` and peers | CPU | planned | [VLLM-14](modules/adapters-vllm.md#open-tasks) | none yet |
+| SGLang `TpModelWorker.forward_batch_generation` | CPU | implemented, `SimTpModelWorker` | [adapters-sglang](modules/adapters-sglang.md) | live CPU-engine smoke (module doc) |
+| SGLang vendored `GroupCoordinator` and device communicators | CPU | planned | [SGL-11](modules/adapters-sglang.md#open-tasks) | none yet |
+| `ncclCommInitRank` and channel setup | CPU | planned | [COMP-15](modules/compute.md#open-tasks) | none yet |
+| `ncclAllReduce` and the traffic planner | CPU | ring builder first cut; planner planned | [COMP-15](modules/compute.md#open-tasks) | [gpu_task_mix](../examples/gpu_task_mix/RESULTS.md) |
+| NCCL collective kernel (FIFO copy, counters) | GPU | egress half first cut; FIFO and signals planned | [COMP-15](modules/compute.md#open-tasks) | [gpu_task_mix](../examples/gpu_task_mix/RESULTS.md) |
+| Compute kernel service (SM, HBM, NVLink) | GPU | implemented bootstrap | [compute](modules/compute.md) | [gpu_service_model](../examples/gpu_service_model/RESULTS.md) |
+| Proxy progression loop | CPU | planned | [COMP-15](modules/compute.md#open-tasks), [BACK-20](modules/backends.md#open-tasks) | none yet |
+| `ncclNet` isend, irecv, test | CPU | planned | [COMP-15](modules/compute.md#open-tasks) | none yet |
+| ibverbs post send, poll CQ | CPU | native WQ/CQ slice, standalone | [BACK-9](modules/backends.md#open-tasks), [BACK-20](modules/backends.md#open-tasks) | [rnic_wq_v1](../examples/rnic_wq_v1/RESULTS.md) |
+| NIC WQE fetch, payload DMA, CQE write | NIC | PCIe transaction slice standalone; composition open | [BACK-8/18](modules/backends.md#open-tasks), [HTSIM-9](modules/backends.md#open-tasks) | [rnic_pcie_v1](../examples/rnic_pcie_v1/RESULTS.md) |
 
 ## Module status
 
@@ -158,13 +309,13 @@ One line per module; the linked doc is the source of truth.
 |---|---|---|
 | [core](modules/core.md) | Implemented: virtual clock, step records, execution-graph/completion/result/bookkeeping contracts with strict JSON, serial lowerer, graph-only replay | CORE-3/4/5/6/7/8/9/10, BRIDGE-1 |
 | [workload](modules/workload.md) | Partial: Poisson/trace arrivals, fixed/lognormal/trace lengths | WORK-1 (shared prefixes), WORK-2 (bursty/MMPP) |
-| [compute](modules/compute.md) | Implemented: roofline + profile tables, kernel families, dense/MoE geometry, host initiation model, trace-driven GPU service primitive with concurrent compute/memory/NCCL scheduling and A100/H100 bootstrap profiles | COMP-1/2/4/5/6/7/8/9/10/11/12/13/14 |
+| [compute](modules/compute.md) | Implemented: roofline + profile tables, kernel families, dense/MoE geometry, host initiation model, trace-driven GPU service primitive with concurrent compute/memory/NCCL scheduling and A100/H100 bootstrap profiles | COMP-1/2/4/5/6/7/8/9/10/11/12/13/14/15 |
 | [placement](modules/placement.md) | Implemented: placement manifest round trip, declared placements, gpu-rank mapping, vLLM extraction; fabric manifest design-only | PLACE-1/2/3 |
 | [traffic](modules/traffic.md) | Implemented: collective patterns, TP step mapping, MoE all-to-all, GOAL renderers for steps and execution graphs | TRAF-2/3/4/5/6/7/8/9/10 |
 | [goal](modules/goal.md) | Implemented: GOAL trace + txt2bin helper | none |
 | [backends](modules/backends.md) | Implemented: htsim invocation/parsing plus native C++ RNIC SQ/CQ, network-port and shared PCIe transaction slices; htsim composition and the modular device entry point remain open | BACK-2/5-9/11-20; backend-repo HTSIM-1/2/4-9, ATLAHS-1 |
-| [adapters-vllm](modules/adapters-vllm.md) | Implemented: SimExecutor on pinned v0.26.0, full RPC surface, step-record streaming, placement exporter, live tp=8 closed loop | VLLM-3 through VLLM-13 |
-| [adapters-sglang](modules/adapters-sglang.md) | Implemented: SimTpModelWorker via plugin entry point at pinned commit, live CPU-engine smoke | SGL-3 through SGL-10 |
+| [adapters-vllm](modules/adapters-vllm.md) | Implemented: SimExecutor on pinned v0.26.0, full RPC surface, step-record streaming, placement exporter, live tp=8 closed loop | VLLM-3 through VLLM-14 |
+| [adapters-sglang](modules/adapters-sglang.md) | Implemented: SimTpModelWorker via plugin entry point at pinned commit, live CPU-engine smoke | SGL-3 through SGL-11 |
 
 ## Study index
 
@@ -243,7 +394,10 @@ Reproduce with
   explicit per queue: a host CPU driver, a CPU proxy fed from GPU
   descriptor queues, or GPU-initiated rings with a GPU-owned CQ (BACK-20).
   On the framework side the vLLM seam moves from the executor RPC surface
-  to the model runner under a real GPU worker (VLLM-13; the SGLang
-  adapter already couples at that boundary), so the simulated GPU
-  launches the NCCL work and completion returns to the model runner
-  through the declared CQ consumer.
+  to the model runner, first as a flagged skeleton and later under a real
+  GPU worker (VLLM-13; the SGLang
+  adapter already couples at that boundary), the model runner talks to a
+  simulated communicator layer and an interface-faithful NCCL stack
+  (VLLM-14, SGL-11, COMP-15; the simulated communication stack section
+  above), and completion returns to the model runner through the declared
+  CQ consumer.

--- a/docs/README_PRO.md
+++ b/docs/README_PRO.md
@@ -52,7 +52,7 @@ Every behavioral change follows the same discipline:
    (a carve-out, a stubbed mode, a `NotImplementedError`), the same
    change adds a numbered task to the owning module doc using the
    module's stable prefix (CORE-, WORK-, COMP-, PLACE-, TRAF-, GOAL-,
-   BACK-, VLLM-, SGL-, BRIDGE-, and HTSIM-/ATLAHS- for backend-repo
+   PLAY-, BACK-, VLLM-, SGL-, BRIDGE-, and HTSIM-/ATLAHS- for backend-repo
    follow-ups). IDs are never renumbered or reused; the change that
    completes a task removes its entry. Nothing is deferred silently.
 6. **Backends are pinned, not edited here.** `third_party/atlahs` and
@@ -82,6 +82,7 @@ the task text:
 - [placement](modules/placement.md): PLACE-*
 - [traffic](modules/traffic.md): TRAF-*
 - [goal](modules/goal.md): GOAL-*
+- [preplay](modules/preplay.md): PLAY-*
 - [backends](modules/backends.md): BACK-*, plus backend-repo follow-ups
   HTSIM-* and ATLAHS-*
 - [adapters-vllm](modules/adapters-vllm.md): VLLM-*
@@ -202,7 +203,11 @@ every timestamp is issued centrally by the simllm core virtual clock. The
 real communicator call path is also a study subject in its own right: the
 communication function itself (Python dispatch, custom-op indirection,
 synchronization stalls) can bottleneck vLLM and SGLang, so its measured
-cost is compared against the simulated path (VLLM-14, SGL-11).
+cost is compared against the simulated path (VLLM-14, SGL-11). The
+skeleton's data-dependent outcomes (token ids, stop positions, expert
+routing) are planned to come predefined from the CPU pre-play oracle when
+a trace is joined ([preplay](modules/preplay.md), design-only today), so
+the empty calls still drive a real simulation.
 
 ### Full call loop (default setup)
 
@@ -313,6 +318,7 @@ One line per module; the linked doc is the source of truth.
 | [placement](modules/placement.md) | Implemented: placement manifest round trip, declared placements, gpu-rank mapping, vLLM extraction; fabric manifest design-only | PLACE-1/2/3 |
 | [traffic](modules/traffic.md) | Implemented: collective patterns, TP step mapping, MoE all-to-all, GOAL renderers for steps and execution graphs | TRAF-2/3/4/5/6/7/8/9/10 |
 | [goal](modules/goal.md) | Implemented: GOAL trace + txt2bin helper | none |
+| [preplay](modules/preplay.md) | Design-only: offline CPU inference oracle, trace artifact and replay join specified, no code yet | PLAY-1/2/3/4/5 |
 | [backends](modules/backends.md) | Implemented: htsim invocation/parsing plus native C++ RNIC SQ/CQ, network-port and shared PCIe transaction slices; htsim composition and the modular device entry point remain open | BACK-2/5-9/11-20; backend-repo HTSIM-1/2/4-9, ATLAHS-1 |
 | [adapters-vllm](modules/adapters-vllm.md) | Implemented: SimExecutor on pinned v0.26.0, full RPC surface, step-record streaming, placement exporter, live tp=8 closed loop | VLLM-3 through VLLM-14 |
 | [adapters-sglang](modules/adapters-sglang.md) | Implemented: SimTpModelWorker via plugin entry point at pinned commit, live CPU-engine smoke | SGL-3 through SGL-11 |
@@ -380,7 +386,13 @@ Reproduce with
   isolated-kernel and copy-service mechanisms plus A100/H100 bootstrap
   profiles are now available; production SASS calibration and populated
   profile tables remain blocked on capture hardware under COMP-5 (plan in
-  [modules/compute.md](modules/compute.md)). Training workloads are pending.
+  [modules/compute.md](modules/compute.md)). A second offline calibration
+  axis joins here: the CPU pre-play oracle
+  ([modules/preplay.md](modules/preplay.md), PLAY-1 through PLAY-5) runs
+  the real model slowly on CPU to fix each request's true output length,
+  stop reason and expert routing, then replays them against the workload
+  arrival model with every request's outcome pinned in the bookkeeping.
+  Training workloads are pending.
   Slingshot is out of simllm scope (`rnic-ss` remains a backend-repo
   follow-up only).
 - **M6 (not started).** PD-disaggregation and KV-transfer traffic

--- a/docs/modules/adapters-sglang.md
+++ b/docs/modules/adapters-sglang.md
@@ -155,6 +155,16 @@ sink seam is the same contract but has not driven htsim live yet (SGL-8).
   identity envelope as its compute table. Bind batch shapes, radix events and
   overlap-scheduler dependencies at runtime; never infer device concurrency
   from a single elapsed phase duration.
+- SGL-11 (Completeness; P1; L): simulate SGLang's communicator behavior
+  behind its own interface. SGLang vendors vLLM's `GroupCoordinator` design
+  (`sglang.srt.distributed.parallel_state`) with its own device-communicator
+  stack (pynccl and peers); keep those functional names and call signatures,
+  trim the implementation to the main path (no real NCCL, fast paths and
+  side calls omitted or served inertly), and emit the same observability
+  events as VLLM-14 so both adapters lower into one `CollectiveWork` stream
+  and the COMP-15 NCCL stack model. The VLLM-14 call-path bottleneck study
+  has an SGLang half here: the real communicator function's own cost is
+  measured and compared against the simulated path.
 
 Closed this milestone: SGL-1 (the worker, this module). SGL-2 (upstream
 worker-class selection flag) closed as moot 2026-08-04: SGLang's plugin

--- a/docs/modules/adapters-vllm.md
+++ b/docs/modules/adapters-vllm.md
@@ -219,8 +219,9 @@ row-for-row.
   NCCL launch/chunk boundaries and synchronous/asynchronous completion points.
   The simulated executor binds step shapes and framework KV events to this
   template; it does not invent concurrency from aggregate phase timings.
-- VLLM-13 (Completeness; P1; L): couple at the model-runner boundary under a
-  real GPU worker. The verified v0.26.0 seam is the worker class itself:
+- VLLM-13 (Completeness; P1; L): couple at the model-runner boundary, first
+  as a flagged skeleton, later under a real GPU worker. The verified
+  v0.26.0 seam is the worker class itself:
   `parallel_config.worker_cls` is resolved as a dotted path
   (`vllm/v1/worker/worker_base.py:250`), so a subclass of
   `vllm.v1.worker.gpu_worker.Worker` can run the stock `init_device`
@@ -233,13 +234,40 @@ row-for-row.
   `self.model_runner.*`, so one rebind intercepts the whole per-step
   surface while the worker's distributed structure stays live. This mirrors
   the SGLang adapter's `SimTpModelWorker` overriding `_init_model_runner`,
-  so both adapters end up coupled at the model-runner boundary. This mode
-  runs only with GPUs present, since `init_device` and the stock runner
-  require CUDA; the executor-level `SimExecutor` remains the GPU-less mode
-  and its accepted behavior must not change. The sim model runner couples to the simulated
+  so both adapters end up coupled at the model-runner boundary. The first
+  slice is a skeleton run behind a high-level entry flag, routed through
+  the same worker-cls seam: when the flag selects simulation, the subclass
+  skips the stock `init_device` entirely, so no physical GPU worker state
+  or GPU model runner is
+  constructed; the adapter's own copied Python path takes effect, mirroring
+  the original functions by name and keeping the same algorithm and call
+  order, with the deliberate computation left empty and every timestamp
+  issued centrally by the simllm core virtual clock. The GPUs-present
+  variant of the same seam (stock `init_device`, rebound runner) is the
+  later capture and validation mode, since the stock path requires CUDA;
+  the executor-level `SimExecutor` remains supported and its accepted
+  behavior must not change. The sim model runner couples to the simulated
   GPU service model, which launches the NCCL work and, in GPU-initiated
   mode, drives the BACK-20 submission path; the run declares which agent
   consumes each CQ and how completion reaches the model runner (BACK-20,
   CORE-5). Under data parallelism above one, the runner-internal DP
   coordination collective must be served or emulated. VLLM-12's
   device-schedule capture uses the same seam.
+- VLLM-14 (Completeness; P1; L): simulate the `GroupCoordinator` behavior
+  behind its own interface for the model-runner coupling mode. The simulated
+  coordinator keeps the real class's functional names and call signatures
+  (`all_reduce`, `all_gather`, `broadcast`, send and recv, and the rank and
+  group-membership surface the model layers and the runner read) and returns
+  shape-correct results, but the implementation is trimmed to the main path:
+  no real NCCL, no custom-allreduce or symmetric-memory fast paths, and side
+  calls off the main path are omitted or served inertly. Every call boundary
+  emits an observability event (operation, group, payload bytes, virtual
+  timestamps) that lowers into `CollectiveWork` and the COMP-15 NCCL stack
+  model. Beyond the trimmed simulation, study the effect of the actual
+  communication function on end-to-end performance: the real communicator
+  call path (Python dispatch, custom-op indirection, synchronization
+  stalls) can itself bottleneck vLLM and SGLang, so the study compares the
+  real call-path cost against the simulated one and folds the calibrated
+  cost into the model. SGL-11 is the SGLang half; the trimmed-interface
+  principle is shared, and the simulated communication stack section in
+  [docs/README_PRO.md](../README_PRO.md) shows where both sit.

--- a/docs/modules/compute.md
+++ b/docs/modules/compute.md
@@ -411,3 +411,31 @@ Strictly offline; the step loop never invokes a cycle-level simulator.
   explicit algorithm selection. The ring builder remains the identity
   baseline: selecting or omitting the default ring path must preserve every
   accepted ring timestamp, counter and task order exactly.
+- COMP-15 (Completeness; P1; L): model the NCCL software stack with the real
+  stack's functional names and interfaces, trimmed to the main path.
+  Intra-node collectives execute as NCCL collective kernels on the
+  NVLink-class egress model (the existing ring egress kernel, deepened by
+  COMP-11) and stay off the fabric. Inter-node transfers follow the proxy
+  model: the proxy progression loop calls a `ncclNet`-shaped plugin surface
+  (isend, irecv, test), which calls an ibverbs-shaped surface (post send,
+  poll CQ), which submits to the native RNIC session; this is the concrete
+  BACK-20 CPU-proxy producer shape, and CORE-4 owns the channel queues the
+  proxy drains. Function and interface names track the real stack so
+  captures and traces line up; the implementations are trimmed, side calls
+  off the main path are omitted or served inertly, and every boundary
+  crossing emits an observability event with virtual timestamps.
+  The model covers NCCL and its traffic planner together: communicator
+  setup, logical channel construction, chunking and channel assignment,
+  the creation and polling of the GPU-resident send and receive staging
+  buffers, and the interactions of the calls between layers. Both the data
+  path and the signal path are simulated: buffer bytes as data movement,
+  and the ready flags and head/tail counters as their own observable
+  events, so a consumer that polls and a producer that proactively signals
+  are distinguishable in the timeline.
+  GPU-initiated mode replaces the proxy leg with the BACK-20 GPU-initiated
+  path behind the same upper interface. The simulated framework
+  communicators (VLLM-14, SGL-11) are the callers of this stack. The first
+  slice is the complete mental model as name-mirrored empty function calls
+  with observability and centralized virtual timestamps; mechanisms fill
+  in step by step per the sizing plan in
+  [docs/README_PRO.md](../README_PRO.md).

--- a/docs/modules/preplay.md
+++ b/docs/modules/preplay.md
@@ -1,0 +1,119 @@
+# simllm.preplay (design)
+
+Offline CPU inference oracle, a separate module beside the simulator: run
+the actual model, slowly and exactly, to pre-compute each request's
+data-dependent outcome, then replay those outcomes so the fast simulation
+never has to fabricate them.
+
+## Why
+
+The simulation replaces model execution, so every decision the real model
+would make is otherwise fabricated: output token ids (today one fixed
+mid-vocabulary id), output length (today drawn from a workload
+distribution), and MoE expert routing (today uniform). Those decisions feed
+back into exactly the things the simulation promises to keep real: the stop
+position drives scheduler-visible completion and batch composition, token
+identity drives prefix-cache hits, and routing drives the all-to-all
+traffic shape. The pre-play oracle runs the real model once on CPU (very
+slow, but exact and GPU-free) and freezes those decisions per request.
+Replay then keeps the frameworks' real control behavior while every
+request's route, length and output are predefined, which is what lets the
+skeleton coupling mode (VLLM-13) run its name-mirrored virtual functions
+and still produce a real simulation.
+
+## Design (this module is design-only today; PLAY-1 lands the first slice)
+
+- **Runner.** Given the model identity (name, revision, dtype, tokenizer
+  hash) and a request set, run inference on CPU with greedy decoding or
+  seeded sampling. Capture per request: the output token ids, the output
+  length and stop reason, and per token, per MoE layer, the top-k expert
+  assignments.
+- **Artifact.** `simllm-preplay-trace-v1`: versioned and
+  provenance-carrying (model identity, sampling configuration and seed,
+  capture host, schema version), keyed by a stable request identity. Bulk
+  rows live off-repo, since large generated artifacts never live in this
+  repo; the repo carries the schema and small fixtures only.
+- **Join.** A workload arrival realization assigns each request its
+  arrival timestamp at the framework entry point. The join produces
+  per-request tracking records in the core bookkeeping (request identity,
+  arrival time, predefined route, length and output), so a replay run
+  knows every request's outcome up front without recomputing it.
+- **Replay.** The adapters serve the predefined token ids instead of a
+  fabricated token and honor the oracle's stop position, so the scheduler
+  sees the true completion step; the traffic layer consumes the captured
+  routing for non-uniform all-to-all.
+- **Honesty rule.** A CPU run is one realization, not the deployment's
+  exact token stream: CPU and GPU numerics differ, so sampled ids can
+  diverge between the oracle and silicon. Greedy or fixed-seed sampling is
+  the default and every trace records which was used. The claim is
+  structural realism (lengths, stop reasons, routing pattern, cache-hit
+  structure), never bit-exact parity with a GPU serve.
+
+Module rules: nothing in the simulator core imports this module; the heavy
+dependencies (torch, transformers or a framework CPU backend) import
+lazily and only here; adapters and traffic consume the artifact through
+versioned schemas rather than this module's internals, extending the core
+forms where a representation is missing (CORE-6 carries only per-pair
+sizes, so the per-token routing projection needs its own versioned form,
+defined by PLAY-2 and PLAY-4).
+
+## Status
+
+Design-only: this doc specifies the oracle, the trace artifact and the
+replay join. No code exists yet.
+
+## Open tasks
+
+Tags follow the legend in [backends.md](backends.md#open-tasks).
+
+- PLAY-1 (Completeness; P1; L): implement the CPU inference runner and the
+  `simllm-preplay-trace-v1` artifact. A transformers-backed CPU run with
+  greedy and seeded-sampling modes captures output token ids, stop reason
+  (EOS, length cap, stop string) and per-token per-MoE-layer top-k expert
+  ids; the writer streams rows to disk so a long request set never holds
+  the trace in memory (bulk rows live off-repo, since large generated
+  artifacts never live in this repo; the repo carries the schema and small
+  fixtures only), and the strict reader validates schema, provenance
+  and per-request completeness. Record the sampling mode, seed and model
+  identity in every trace. An optional framework-CPU-backend runner (the
+  same capture through vLLM or SGLang on CPU) is a later variant of this
+  task, valuable because it exercises the deployment's own sampler.
+- PLAY-2 (Completeness; P1; M): join arrivals with the trace into the core
+  bookkeeping. Given a workload arrival realization and a trace, emit
+  per-request tracking records (request identity, arrival timestamp at the
+  framework entry point, predefined output length, stop reason, token ids
+  and routing reference) into `RequestBookkeeper`, so the run's request
+  futures are pinned before the first scheduler step. Joining must fail
+  loudly on a request missing from the trace, and the run record names the
+  trace it replayed.
+- PLAY-3 (Completeness; P1; M): replay predefined outputs through the
+  adapters. `SimExecutor`, the skeleton coupling mode and
+  `SimTpModelWorker` serve the trace's token ids instead of the fabricated
+  mid-vocabulary token and stop each request at the oracle's stop
+  position, so scheduler-visible completion, batch composition and
+  prefix-cache content match the real model's behavior. The
+  fabricated-token baseline is the preserved off path: without a joined
+  trace, behavior stays byte-identical to today's accepted runs. With a
+  joined trace, plain generation no longer depends on a fabricated id; the
+  speculative-decoding and structured-output refusals (VLLM-8) stay in
+  place until their semantics are modeled explicitly.
+- PLAY-4 (Completeness; P1; M): supply captured routing to the traffic
+  half. Define the versioned per-token expert-assignment projection of the
+  trace and join it per request, in the form TRAF-2's expansion consumes.
+  The boundary is explicit: this task owns the capture-side supply, TRAF-2
+  keeps the traffic-side expansion that replaces uniform routing
+  (including its EPLB placement-epoch handling), CORE-6 owns the graph
+  representation of the resulting non-uniform per-pair sizes, and COMP-7
+  consumes the same assignments for routed-load compute imbalance.
+- PLAY-5 (Completeness; P1; M): pre-registered validation study. First,
+  oracle consistency: the same requests and seed through the PLAY-1 runner
+  and through an independent framework CPU run must agree on lengths, stop
+  reasons and routing, with every divergence classified and none silently
+  accepted; admissible causes are the recorded sampler difference and the
+  numerics divergence the honesty rule predicts (kernel fusion and
+  reduction order can flip a near-tie argmax, cascading into length and
+  routing changes). Second, replay end-to-end: a replayed run's
+  scheduler-visible completions must land exactly at the oracle lengths,
+  and its all-to-all sizes must match the captured routing; freeze the
+  expectations in their own commit before implementation per the
+  development process.


### PR DESCRIPTION
## Summary

Two commits on top of the merged roadmap restructure.

13b20e4, simulated communication stack:

- Both frameworks get a simulated communicator layer behind the real interfaces: vLLM GroupCoordinator (VLLM-14) and SGLang's vendored GroupCoordinator plus device communicators (SGL-11), including a study of the real communicator call path as a framework bottleneck.
- COMP-15 covers NCCL and the traffic planner together: logical channels, chunking, creation and polling of GPU-resident staging buffers, and both the data and the signal path (flags, head/tail counters) as observable events.
- VLLM-13 rescoped skeleton-first: a high-level entry flag routes the worker-cls seam to the adapter's copied Python path (name-mirrored empty calls, no physical GPU worker or model runner, centralized virtual timestamps); the GPUs-present variant becomes the later capture mode.
- The developer guide is renamed to docs/README_PRO.md, linked from the README top navigation, and gains the full call-loop graph for the default NCCL CPU-host proxy setup (explicit FIFO placement, poll versus signal labels closing one worker-side call), a per-module sizing plan, and a living function inventory with statuses and study links.

178fa1b, CPU pre-play oracle:

- New design-only module simllm.preplay (stable prefix PLAY-, tasks PLAY-1 through PLAY-5): run the actual model on CPU (slow, exact, GPU-free) to pre-compute each request's true output token ids, length and stop reason, and per-token per-MoE-layer expert routing into a versioned trace artifact.
- A workload arrival realization joins the trace into per-request tracking records in the core RequestBookkeeper, so replay has every request's route, length and output predefined and the skeleton mode's empty mirrored calls still drive a real simulation. The fabricated-token baseline stays the byte-identical off path.
- Boundaries drawn explicitly (PLAY-4 supplies routing; TRAF-2 keeps the traffic expansion, CORE-6 the graph form, COMP-7 the compute imbalance) and an honesty rule records that the oracle claims structural realism, never bit-exact parity with a GPU serve.
- Registered under M5 as the second offline calibration axis beside SASS compute.

## Checks

ruff clean; 301 passed, 3 skipped on both commits.