### PR TITLE
Make bookkeeping-ledger append validation incremental

### DIFF
--- a/docs/README_PRO.md
+++ b/docs/README_PRO.md
@@ -312,7 +312,7 @@ One line per module; the linked doc is the source of truth.
 
 | Module | Status | Open tasks |
 |---|---|---|
-| [core](modules/core.md) | Implemented: virtual clock, step records, execution-graph/completion/result/bookkeeping contracts with strict JSON, serial lowerer, graph-only replay | CORE-3/4/5/6/7/8/9/10, BRIDGE-1 |
+| [core](modules/core.md) | Implemented: virtual clock, step records, execution-graph/completion/result/bookkeeping contracts with strict JSON, serial lowerer, graph-only replay, incremental append validation with the full validator kept as the snapshot and wire reference | CORE-3/4/5/6/8/9/10, BRIDGE-1 |
 | [workload](modules/workload.md) | Partial: Poisson/trace arrivals, fixed/lognormal/trace lengths | WORK-1 (shared prefixes), WORK-2 (bursty/MMPP) |
 | [compute](modules/compute.md) | Implemented: roofline + profile tables, kernel families, dense/MoE geometry, host initiation model, trace-driven GPU service primitive with concurrent compute/memory/NCCL scheduling and A100/H100 bootstrap profiles | COMP-1/2/4/5/6/7/8/9/10/11/12/13/14/15/16 |
 | [placement](modules/placement.md) | Implemented: placement manifest round trip, declared placements, gpu-rank mapping, vLLM extraction; fabric manifest design-only | PLACE-1/2/3 |
@@ -346,6 +346,7 @@ Reproduce with
 | [rnic_wq_v1](../examples/rnic_wq_v1/RESULTS.md) | Native RNIC SQ/CQ structure, doorbell batching, signaling and network-credit backpressure | 11/11 post-specified cells exact; controlled SQ-full, drop and CQ-overrun boundaries pass in the native harness |
 | [rnic_pcie_v1](../examples/rnic_pcie_v1/RESULTS.md) | Shared PCIe transactions, finite credits/tags/buffers and deterministic analytical path penalties | 35/35 deterministic row oracles and 10/10 behavioral relation families over 18 instances pass; structural invariants are unscored, corrected link-queue accounting leaves JCT unchanged, and posted traffic fills the frozen blocked-read gap |
 | [step_sink_precision](../examples/step_sink_precision/RESULTS.md) | Step-sink precision: per-layer provider breakdown, exact sample attribution and the explicit GOAL-rank padding knob | 4/4 unequal-layer oracle rows exact; the registered 32,768 ps fused and 32,000 ps rendered deltas hold; the padding knob reproduces the historical workaround to 0 ps; the default path is locked byte-identical; the frozen fluid-plus-topology cell is disclosed as a pre-registration defect with post-specified replacements |
+| [core7_incremental](../examples/core7_incremental/RESULTS.md) | Incremental bookkeeping-ledger validation: equivalence with the reference validator and amortized append scaling | Seeded valid and invalid stream families match the reference on decisions, exception classes and final state; incremental quadrupling ratios stay near 4 within the frozen bound of 6 while the reproduced reference path grows about 16x, above the frozen quadratic bound of 8 |
 
 ## Milestones
 

--- a/docs/modules/core.md
+++ b/docs/modules/core.md
@@ -244,6 +244,17 @@ making the graph mutable. Its lineage rules distinguish causal parents from
 reusable resource references, allow batched request scopes to split, and reject
 request identities not supplied by a causal parent.
 
+CORE-7 is complete. `RequestBookkeeper.append` and `extend` validate only new
+facts against private object, subject-timestamp and terminal-WQE indexes.
+Atomic batches use a copy-on-write state overlay, so failed validation changes
+neither the ledger nor its indexes. The complete validator remains the
+independent authority for initial immutable ledgers and wire loads. The
+[incremental validation study](../../examples/core7_incremental/RESULTS.md)
+matched the full validator across all seeded valid and invalid families. A
+quadrupling from 1,000 to 4,000 and from 4,000 to 16,000 facts took at most
+4.38x on the incremental path, while the reproduced former path grew at least
+16.72x from 1,000 to 4,000 facts.
+
 The pre-registered
 [CORE-2 lowering study](../../examples/core2_lowering/RESULTS.md) compared the
 legacy sink, graph-only JSON replay and a frozen closed form over TP width
@@ -358,12 +369,6 @@ does not claim to produce these resource-contention measurements.
   the uniform scalar form must stay readable either way. Coordinate with the
   TRAF-2 capture half so traffic expansion and the renderer consume the same
   representation.
-- CORE-7: make `RequestBookkeeper.append` and `extend` validation
-  incremental. Every append currently revalidates the entire candidate
-  ledger, so N single-fact appends cost quadratic work; CORE-4 streams
-  per-WQE events for 64-rank runs and needs amortized constant-time appends
-  with unchanged invariants. The full-ledger validator remains the reference
-  implementation for snapshots and wire loads.
 - CORE-8 (Precision; P1; L): establish the cross-layer authority and
   queue-visit contract above before residual-driven calibration. Define one
   loss-checked projection from each authoritative runtime object into

--- a/docs/modules/core.md
+++ b/docs/modules/core.md
@@ -243,17 +243,20 @@ JSON form retain opaque framework objects and WQE-level runtime lineage without
 making the graph mutable. Its lineage rules distinguish causal parents from
 reusable resource references, allow batched request scopes to split, and reject
 request identities not supplied by a causal parent.
+`RequestBookkeeper` supports sequential use only: append and extend do not
+re-audit committed history, while snapshot validation and wire loads retain
+the full reference validator.
 
 CORE-7 is complete. `RequestBookkeeper.append` and `extend` validate only new
 facts against private object, subject-timestamp and terminal-WQE indexes.
 Atomic batches use a copy-on-write state overlay, so failed validation changes
 neither the ledger nor its indexes. The complete validator remains the
-independent authority for initial immutable ledgers and wire loads. The
+complete-scan authority for initial immutable ledgers and wire loads. The
 [incremental validation study](../../examples/core7_incremental/RESULTS.md)
 matched the full validator across all seeded valid and invalid families. A
 quadrupling from 1,000 to 4,000 and from 4,000 to 16,000 facts took at most
-4.38x on the incremental path, while the reproduced former path grew at least
-16.72x from 1,000 to 4,000 facts.
+4.27x on the incremental path, while the reproduced former path grew at least
+16.09x from 1,000 to 4,000 facts.
 
 The pre-registered
 [CORE-2 lowering study](../../examples/core2_lowering/RESULTS.md) compared the

--- a/examples/core7_incremental/RESULTS.md
+++ b/examples/core7_incremental/RESULTS.md
@@ -4,7 +4,8 @@ Date: 2026-08-10
 
 The study passed every expectation frozen before implementation and execution
 in [expectations.md](expectations.md) at commit `d487a69`. The implementation
-commit is `e18200d`.
+first landed at `e18200d`; integration review subsequently consolidated its
+rule engine before the rerun reported here.
 
 ## Reproduction
 
@@ -25,7 +26,7 @@ The scaling study is reproduced with:
 The raw file is
 `/data3/yifeng/simllm-dev/wave1-runs/core7_incremental_ledger/measurements.json`.
 Its SHA-256 digest for this run is
-`34ce226c6198c3326ff6fb39221f670311c7d97421cdf82b434a1d4a5efda6b4`.
+`5a7035c60ece0dfe54eb22fc30550df45cdcd2f27cced0071b29280e8e2a6d0b`.
 It contains 48 measured rows plus the configuration, host disclosure,
 medians, relation checks and structural guards. Raw timing data is not Git
 content.
@@ -38,6 +39,12 @@ seeded `extend` partitions, giving 36 valid stream-mode instances. Every
 accept decision, returned entry or tuple, and final snapshot matched a fresh
 full-candidate `validate_bookkeeping_ledger` call exactly.
 
+Protocol deviation: the frozen plan says batch widths are drawn from
+`{0, 1, 2, 7, 32}`. The harness draws each nonzero partition width from
+`(1, 2, 7, 32)` and exercises width 0 once deterministically before the
+partition loop. Every registered width is exercised, and this scheduling
+difference does not change any candidate, decision or acceptance relation.
+
 Each seed also exercised all 42 registered invalid mutation kinds through
 both modes, giving 504 invalid stream-mode instances. Invalid facts were
 injected at seed-selected positions. For every candidate prefix or atomic
@@ -49,9 +56,12 @@ scope and correlation rules, metadata, duplicate and malformed references,
 causal lineage and request narrowing, WQE queue and transport shape, stage
 references, completion subject scope and timestamp order, completion-queue
 identity, duplicate WQE completion and strict post-completion terminality.
-The focused command completed with `57 passed in 11.83s`; 25 of those tests
-are the new seeded and initialization cases, while the existing 32 tests keep
-the independent deterministic and wire sentinels.
+The integration audit added 20 direct parameterized cases for parent-field
+inheritance, duplicate parent and object refs, excessive WQE queue cardinality,
+blank identities and non-integer correlation fields. The focused command
+completed with `77 passed in 12.18s`; 45 of those tests are the new seeded,
+initialization and direct audit cases, while the existing 32 tests keep the
+deterministic and wire sentinels.
 
 This is the E1 behavioral relation family. Its instances are not added to the
 timing relations below.
@@ -67,8 +77,8 @@ The tables report medians, not exact cross-machine expectations.
 
 | fact mix | 1,000 facts ms | 4,000 facts ms | 16,000 facts ms | 4,000 / 1,000 | 16,000 / 4,000 |
 |---|---:|---:|---:|---:|---:|
-| stage | 3.824 | 15.056 | 65.849 | 3.938 | 4.373 |
-| WQE | 7.177 | 28.911 | 116.338 | 4.028 | 4.024 |
+| stage | 3.861 | 16.173 | 69.056 | 4.188 | 4.270 |
+| WQE | 7.504 | 30.480 | 122.503 | 4.062 | 4.019 |
 
 All four quadrupling relations passed the registered upper bound of 6. The
 observed ratios stay near the ideal linear value of 4 for both the stateless
@@ -78,8 +88,8 @@ stage mix and the cross-entry WQE mix.
 
 | fact mix | 1,000 facts s | 2,000 facts s | 4,000 facts s | 4,000 / 1,000 |
 |---|---:|---:|---:|---:|
-| stage | 1.044 | 4.352 | 20.045 | 19.192 |
-| WQE | 2.398 | 10.172 | 40.098 | 16.722 |
+| stage | 1.047 | 4.203 | 17.301 | 16.523 |
+| WQE | 2.509 | 10.593 | 40.379 | 16.092 |
 
 Both endpoint growth relations passed the registered lower bound of 8. The
 ratios expose the former quadratic trend and are not treated as stable speedup
@@ -89,16 +99,18 @@ claims.
 
 The by-construction guards all passed: both timing modes consumed the same
 immutable fact tuples, both complete generated streams passed the reference
-validator, every measured ledger reached the requested length, rejected
-equivalence cases retained their prior snapshots, and API-assigned sequences
-remained contiguous plain integers. The explicit malformed-initial-ledger
-test retained Boolean-sequence rejection through the full validator. These
-guards are fatal but unscored and do not increase either behavioral relation
-count.
+validator, generated stream lengths matched the requested maximum, every
+measured ledger reached the requested length, rejected equivalence cases
+retained their prior snapshots, and API-assigned sequences remained contiguous
+plain integers. The explicit malformed-initial-ledger test retained
+Boolean-sequence rejection through the full validator. These guards are fatal
+but unscored and do not increase either behavioral relation count.
 
 `RequestBookkeeper` now retains private indexes for object records, latest
 subject timestamps and terminal WQEs. Each `extend` call validates against a
 copy-on-write overlay and commits it only after the complete batch succeeds.
-The public ledger and v1 wire schema are unchanged. The original full-ledger
-validator remains the independent reference used for constructor inputs,
-explicit immutable-ledger validation and both wire directions.
+The full scan and incremental transaction both call one shared per-entry rule
+engine, so future invariant edits have one implementation. The public ledger
+and v1 wire schema are unchanged. The full-ledger validator remains the
+complete-scan reference used for constructor inputs, explicit immutable-ledger
+validation and both wire directions.

--- a/examples/core7_incremental/RESULTS.md
+++ b/examples/core7_incremental/RESULTS.md
@@ -1,0 +1,104 @@
+# CORE-7 incremental bookkeeping validation results
+
+Date: 2026-08-10
+
+The study passed every expectation frozen before implementation and execution
+in [expectations.md](expectations.md) at commit `d487a69`. The implementation
+commit is `e18200d`.
+
+## Reproduction
+
+The behavioral equivalence cases are part of the normal test suite:
+
+```bash
+.venv/bin/pytest -q tests/test_bookkeeping.py \
+  tests/test_bookkeeping_incremental.py
+```
+
+The scaling study is reproduced with:
+
+```bash
+.venv/bin/python -m examples.core7_incremental.run_study \
+  --out /data3/yifeng/simllm-dev/wave1-runs/core7_incremental_ledger
+```
+
+The raw file is
+`/data3/yifeng/simllm-dev/wave1-runs/core7_incremental_ledger/measurements.json`.
+Its SHA-256 digest for this run is
+`34ce226c6198c3326ff6fb39221f670311c7d97421cdf82b434a1d4a5efda6b4`.
+It contains 48 measured rows plus the configuration, host disclosure,
+medians, relation checks and structural guards. Raw timing data is not Git
+content.
+
+## E1: seeded behavioral equivalence
+
+All six registered seeds passed at valid stream lengths 8, 32 and 128. The 18
+valid streams were each exercised through individual `append` calls and
+seeded `extend` partitions, giving 36 valid stream-mode instances. Every
+accept decision, returned entry or tuple, and final snapshot matched a fresh
+full-candidate `validate_bookkeeping_ledger` call exactly.
+
+Each seed also exercised all 42 registered invalid mutation kinds through
+both modes, giving 504 invalid stream-mode instances. Invalid facts were
+injected at seed-selected positions. For every candidate prefix or atomic
+batch, the incremental path matched the reference accept or reject decision
+and exception class. Rejections retained the last accepted ledger exactly.
+
+The mutation catalog covered fact and timestamp types, enum and scalar types,
+scope and correlation rules, metadata, duplicate and malformed references,
+causal lineage and request narrowing, WQE queue and transport shape, stage
+references, completion subject scope and timestamp order, completion-queue
+identity, duplicate WQE completion and strict post-completion terminality.
+The focused command completed with `57 passed in 11.83s`; 25 of those tests
+are the new seeded and initialization cases, while the existing 32 tests keep
+the independent deterministic and wire sentinels.
+
+This is the E1 behavioral relation family. Its instances are not added to the
+timing relations below.
+
+## E2: append scaling
+
+The run used Python 3.12.12 on Linux 5.14 x86-64. Garbage collection was
+disabled only within each timed call. One complete warmup sweep preceded five
+recorded incremental repetitions and three recorded reference repetitions.
+The tables report medians, not exact cross-machine expectations.
+
+### Incremental path
+
+| fact mix | 1,000 facts ms | 4,000 facts ms | 16,000 facts ms | 4,000 / 1,000 | 16,000 / 4,000 |
+|---|---:|---:|---:|---:|---:|
+| stage | 3.824 | 15.056 | 65.849 | 3.938 | 4.373 |
+| WQE | 7.177 | 28.911 | 116.338 | 4.028 | 4.024 |
+
+All four quadrupling relations passed the registered upper bound of 6. The
+observed ratios stay near the ideal linear value of 4 for both the stateless
+stage mix and the cross-entry WQE mix.
+
+### Reproduced former full-candidate path
+
+| fact mix | 1,000 facts s | 2,000 facts s | 4,000 facts s | 4,000 / 1,000 |
+|---|---:|---:|---:|---:|
+| stage | 1.044 | 4.352 | 20.045 | 19.192 |
+| WQE | 2.398 | 10.172 | 40.098 | 16.722 |
+
+Both endpoint growth relations passed the registered lower bound of 8. The
+ratios expose the former quadratic trend and are not treated as stable speedup
+claims.
+
+## Structural guards and interpretation
+
+The by-construction guards all passed: both timing modes consumed the same
+immutable fact tuples, both complete generated streams passed the reference
+validator, every measured ledger reached the requested length, rejected
+equivalence cases retained their prior snapshots, and API-assigned sequences
+remained contiguous plain integers. The explicit malformed-initial-ledger
+test retained Boolean-sequence rejection through the full validator. These
+guards are fatal but unscored and do not increase either behavioral relation
+count.
+
+`RequestBookkeeper` now retains private indexes for object records, latest
+subject timestamps and terminal WQEs. Each `extend` call validates against a
+copy-on-write overlay and commits it only after the complete batch succeeds.
+The public ledger and v1 wire schema are unchanged. The original full-ledger
+validator remains the independent reference used for constructor inputs,
+explicit immutable-ledger validation and both wire directions.

--- a/examples/core7_incremental/expectations.md
+++ b/examples/core7_incremental/expectations.md
@@ -1,0 +1,130 @@
+# CORE-7 incremental bookkeeping validation expectations
+
+Written and frozen before the CORE-7 implementation and before any run of
+this study. The public ledger schema and accepted fact language stay unchanged.
+The full-ledger validator remains the reference for immutable ledgers and wire
+loads.
+
+## System under test
+
+`RequestBookkeeper.append` and `RequestBookkeeper.extend` will retain
+incremental auxiliary state for the three cross-entry relations enforced by
+the current validator:
+
+- created objects indexed by portable object ID;
+- the latest completion-event timestamp for each subject object;
+- the set of WQEs that have reached their terminal `COMPLETED` event.
+
+The auxiliary state is private. `BookkeepingLedger`, its v1 wire form, public
+method signatures and query results must not change. Initial ledgers, snapshots
+passed explicitly to `validate_bookkeeping_ledger`, and both wire directions
+continue to receive a complete reference validation.
+
+## E1: seeded behavioral equivalence
+
+The deterministic seeds are `{7001, 7002, 7003, 7004, 7005, 7006}`. Each seed
+generates valid object, stage and completion-event streams with sequence
+lengths drawn from `{8, 32, 128}`. The streams include causal request objects,
+batched execution-operation scopes that may narrow at their descendants,
+reusable queue references, transport-free and physical WQEs, subjectless
+events, subject timestamp progressions and terminal WQE completions.
+
+For the single-fact family, each candidate is applied to two independently
+maintained ledgers:
+
+1. The reference path forms the complete candidate `BookkeepingLedger` and
+   calls `validate_bookkeeping_ledger`.
+2. The incremental path calls `RequestBookkeeper.append`.
+
+For every candidate and every prefix, both paths must either accept or reject.
+If they reject, the raised exception classes must be identical and the
+incremental ledger must remain equal to the last accepted reference ledger. If
+they accept, the returned entry and complete incremental snapshot must equal
+the reference candidate exactly.
+
+For the atomic-batch family, the same comparison is repeated with batch widths
+drawn from `{0, 1, 2, 7, 32}`. The reference validates the whole candidate in
+one call and the incremental path uses `extend`. If any fact fails, both paths
+must reject with the same exception class and `extend` must retain its entire
+pre-call state. Accepted return tuples and final snapshots must be exactly
+equal.
+
+Each seed supplies both an unmodified valid stream and invalid streams with a
+mutation inserted at a seeded random position. Across the fixed seed set, the
+mutation catalog covers every existing full-validator rule family:
+
+- unsupported fact types and invalid fact timestamps;
+- invalid enum, scope, correlation, reference, metadata and scalar types,
+  including Boolean rejection for integer-only fields;
+- duplicate object IDs, self-parenting, unknown or wrong-typed parents,
+  child-before-parent time, causal-parent disagreement and request
+  introduction;
+- WQE queue cardinality, transport cardinality and `transport_kind` rules;
+- stage enum, scope, object-reference and stage-before-object rules;
+- completion field types, unknown subjects, subject scope mismatch,
+  completion-before-creation and decreasing subject timestamps;
+- WQE completion-queue identity, duplicate completion and strict terminality.
+
+Acceptance is exact. There is no tolerated decision, exception-class, entry,
+sequence or snapshot difference.
+
+## E2: append scaling
+
+Two valid fact mixes are measured so ledger size is not the only varied
+parameter:
+
+- `stage`: independent request-stage facts with no cross-object lookup;
+- `wqe`: reusable queue setup followed by repeated operation, NCCL, WQE and
+  subject-event chains, including one terminal completion per WQE.
+
+For the incremental implementation, total time for N individual `append`
+calls is measured at `N in {1000, 4000, 16000}`. The first complete sweep is a
+warmup. Five subsequent sweeps are recorded and the median for each cell is
+used for acceptance. Within each fact mix, both adjacent quadruplings must
+satisfy:
+
+```text
+T_incremental(4N) / T_incremental(N) <= 6
+```
+
+The direction claim is near-linear total work, not an exact wall-clock model.
+No exact duration or cross-machine comparison is registered.
+
+The former behavior is reproduced by constructing and fully validating the
+entire candidate ledger after every single fact. It is measured at
+`N in {1000, 2000, 4000}` with one warmup sweep and three recorded sweeps. For
+each fact mix, the endpoint relation must satisfy:
+
+```text
+T_reference(4000) / T_reference(1000) >= 8
+```
+
+The ideal quadratic ratio is 16. The looser lower bound registers only the
+expected superlinear direction in the presence of interpreter and host noise.
+The comparison demonstrates removal of the old trend; it does not claim a
+stable speedup factor.
+
+Raw per-repetition nanosecond measurements belong under
+`/data3/yifeng/simllm-dev/wave1-runs/core7_incremental_ledger/` and are not Git
+content.
+
+## Evidence classes and construction disclosures
+
+E1 is one behavioral relation family with seeded parameterized instances. E2
+is a separate complexity relation family with fact mix and ledger size as its
+parameters. Their instance counts are reported separately and are never added
+into one headline total.
+
+The following checks are fatal structural guards but unscored:
+
+- generated valid source streams pass the reference validator before mutation;
+- both timing paths receive the same immutable fact tuples;
+- appended sequence numbers are contiguous plain integers because the public
+  API assigns them, while explicit malformed initial ledgers retain the
+  reference validator's Boolean-sequence rejection test;
+- rejection leaves the prior snapshot unchanged;
+- benchmark processes finish with the expected ledger length and no validation
+  error.
+
+These construction-forced properties do not increase either behavioral pass
+denominator. Any failure still invalidates the study.

--- a/examples/core7_incremental/run_study.py
+++ b/examples/core7_incremental/run_study.py
@@ -319,15 +319,30 @@ def run(out_dir: Path) -> dict[str, Any]:
         "stage": _stage_facts(maximum_size),
         "wqe": _wqe_facts(maximum_size),
     }
-    for fact_mix, stream in fact_streams.items():
-        validate_bookkeeping_ledger(_ledger_from_facts(stream))
-        if len(stream) != maximum_size:
-            raise AssertionError(f"{fact_mix}: generated {len(stream)} facts")
+    generated_streams_reference_valid = True
+    generated_stream_lengths_match = True
+    for stream in fact_streams.values():
+        try:
+            validate_bookkeeping_ledger(_ledger_from_facts(stream))
+        except (TypeError, ValueError):
+            generated_streams_reference_valid = False
+        generated_stream_lengths_match &= len(stream) == maximum_size
+    if not generated_streams_reference_valid:
+        raise AssertionError("a generated timing stream failed reference validation")
+    if not generated_stream_lengths_match:
+        raise AssertionError("a generated timing stream has the wrong length")
+
+    incremental_fact_streams = fact_streams
+    reference_fact_streams = fact_streams
+    same_fact_tuples_used_by_both_modes = all(
+        incremental_fact_streams[fact_mix] is reference_fact_streams[fact_mix]
+        for fact_mix in fact_streams
+    )
 
     measurements = _run_sweep(
         mode="incremental",
         function=_append_incrementally,
-        fact_streams=fact_streams,
+        fact_streams=incremental_fact_streams,
         sizes=INCREMENTAL_SIZES,
         repetitions=INCREMENTAL_REPETITIONS,
     )
@@ -335,13 +350,22 @@ def run(out_dir: Path) -> dict[str, Any]:
         _run_sweep(
             mode="reference",
             function=_append_with_full_candidates,
-            fact_streams=fact_streams,
+            fact_streams=reference_fact_streams,
             sizes=REFERENCE_SIZES,
             repetitions=REFERENCE_REPETITIONS,
         )
     )
     medians = _median_rows(measurements)
     relations = _relations(medians)
+    all_ledger_lengths_equal_requested_size = all(
+        int(row["ledger_length"]) == int(row["size"]) for row in measurements
+    )
+    structural_checks = {
+        "generated_streams_reference_valid": generated_streams_reference_valid,
+        "generated_stream_lengths_match": generated_stream_lengths_match,
+        "same_fact_tuples_used_by_both_modes": same_fact_tuples_used_by_both_modes,
+        "all_ledger_lengths_equal_requested_size": all_ledger_lengths_equal_requested_size,
+    }
     report = {
         "expectations_commit": EXPECTATIONS_COMMIT,
         "clock": "time.perf_counter_ns",
@@ -361,12 +385,9 @@ def run(out_dir: Path) -> dict[str, Any]:
         "measurements": measurements,
         "medians": medians,
         "relations": relations,
-        "structural_checks": {
-            "generated_streams_reference_valid": True,
-            "same_fact_tuples_used_by_both_modes": True,
-            "all_ledger_lengths_equal_requested_size": True,
-        },
-        "passed": all(bool(relation["passed"]) for relation in relations),
+        "structural_checks": structural_checks,
+        "passed": all(bool(relation["passed"]) for relation in relations)
+        and all(structural_checks.values()),
     }
     out_dir.mkdir(parents=True, exist_ok=True)
     output_path = out_dir / "measurements.json"

--- a/examples/core7_incremental/run_study.py
+++ b/examples/core7_incremental/run_study.py
@@ -1,0 +1,400 @@
+"""Measure CORE-7 append scaling against the former full-ledger path."""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import platform
+import statistics
+import sys
+import time
+from collections.abc import Callable
+from itertools import pairwise
+from pathlib import Path
+from typing import Any
+
+from simllm.core.bookkeeping import (
+    BookkeepingEntry,
+    BookkeepingFact,
+    BookkeepingLedger,
+    BookkeepingScope,
+    CreatedObjectKind,
+    CreatedObjectRecord,
+    CreatedObjectRef,
+    ObjectOwner,
+    ProcessingStage,
+    RequestBookkeeper,
+    StagePhase,
+    StageRecord,
+    validate_bookkeeping_ledger,
+)
+from simllm.core.execution import (
+    CompletionEvent,
+    EventPhase,
+    OperationCorrelation,
+    ResourceKind,
+    ResourceRef,
+)
+
+EXPECTATIONS_COMMIT = "d487a69"
+INCREMENTAL_SIZES = (1_000, 4_000, 16_000)
+REFERENCE_SIZES = (1_000, 2_000, 4_000)
+INCREMENTAL_REPETITIONS = 5
+REFERENCE_REPETITIONS = 3
+
+
+def _stage_facts(count: int) -> tuple[BookkeepingFact, ...]:
+    return tuple(
+        StageRecord(
+            ProcessingStage.REQUEST,
+            StagePhase.ENTERED,
+            index,
+            BookkeepingScope(
+                correlation=OperationCorrelation(request_ids=(f"request:{index}",))
+            ),
+        )
+        for index in range(count)
+    )
+
+
+def _wqe_facts(count: int) -> tuple[BookkeepingFact, ...]:
+    sq = CreatedObjectRecord(
+        CreatedObjectRef(CreatedObjectKind.SEND_QUEUE, "sq:shared"),
+        ObjectOwner.DEVICE_RUNTIME,
+        0,
+    )
+    rq = CreatedObjectRecord(
+        CreatedObjectRef(CreatedObjectKind.RECEIVE_QUEUE, "rq:shared"),
+        ObjectOwner.DEVICE_RUNTIME,
+        0,
+    )
+    cq = CreatedObjectRecord(
+        CreatedObjectRef(CreatedObjectKind.COMPLETION_QUEUE, "cq:shared"),
+        ObjectOwner.DEVICE_RUNTIME,
+        0,
+    )
+    facts: list[BookkeepingFact] = [sq, rq, cq]
+    cycle = 0
+    while len(facts) < count:
+        timestamp = 100 + cycle * 16
+        execution_id = f"execution:{cycle}"
+        operation_id = f"operation:{cycle}"
+        scope = BookkeepingScope(
+            correlation=OperationCorrelation(request_ids=(f"request:{cycle}",)),
+            step_index=cycle,
+            execution_id=execution_id,
+            operation_id=operation_id,
+        )
+        operation = CreatedObjectRecord(
+            CreatedObjectRef(
+                CreatedObjectKind.EXECUTION_OPERATION,
+                f"operation-object:{cycle}",
+            ),
+            ObjectOwner.CORE,
+            timestamp,
+            scope,
+        )
+        nccl = CreatedObjectRecord(
+            CreatedObjectRef(CreatedObjectKind.NCCL_COMMAND, f"nccl:{cycle}"),
+            ObjectOwner.NCCL,
+            timestamp + 1,
+            scope,
+            parent_refs=(operation.ref,),
+        )
+        wqe = CreatedObjectRecord(
+            CreatedObjectRef(CreatedObjectKind.NETWORK_WQE, f"wqe:{cycle}"),
+            ObjectOwner.DEVICE_RUNTIME,
+            timestamp + 2,
+            scope,
+            parent_refs=(nccl.ref, sq.ref, rq.ref, cq.ref),
+            metadata=(("bytes", 4096), ("transport_kind", "none")),
+        )
+        send_resource = ResourceRef(ResourceKind.NIC_SEND_QUEUE, sq.ref.object_id)
+        facts.extend(
+            (
+                operation,
+                nccl,
+                wqe,
+                StageRecord(
+                    ProcessingStage.NETWORK,
+                    StagePhase.ENTERED,
+                    timestamp + 3,
+                    scope,
+                    (wqe.ref,),
+                ),
+                CompletionEvent(
+                    execution_id,
+                    operation_id,
+                    EventPhase.SUBMITTED,
+                    timestamp + 4,
+                    send_resource,
+                    subject_object_id=wqe.ref.object_id,
+                ),
+                CompletionEvent(
+                    execution_id,
+                    operation_id,
+                    EventPhase.QUEUED,
+                    timestamp + 5,
+                    send_resource,
+                    subject_object_id=wqe.ref.object_id,
+                ),
+                CompletionEvent(
+                    execution_id,
+                    operation_id,
+                    EventPhase.STARTED,
+                    timestamp + 6,
+                    send_resource,
+                    subject_object_id=wqe.ref.object_id,
+                ),
+                CompletionEvent(
+                    execution_id,
+                    operation_id,
+                    EventPhase.COMPLETED,
+                    timestamp + 7,
+                    ResourceRef(ResourceKind.COMPLETION_QUEUE, cq.ref.object_id),
+                    completed_bytes=4096,
+                    subject_object_id=wqe.ref.object_id,
+                ),
+            )
+        )
+        cycle += 1
+    return tuple(facts[:count])
+
+
+def _append_incrementally(facts: tuple[BookkeepingFact, ...]) -> int:
+    bookkeeper = RequestBookkeeper()
+    for fact in facts:
+        bookkeeper.append(fact)
+    return len(bookkeeper.snapshot().entries)
+
+
+def _append_with_full_candidates(facts: tuple[BookkeepingFact, ...]) -> int:
+    entries: list[BookkeepingEntry] = []
+    for fact in facts:
+        entry = BookkeepingEntry(len(entries), fact)
+        candidate = BookkeepingLedger((*entries, entry))
+        validate_bookkeeping_ledger(candidate)
+        entries.append(entry)
+    return len(entries)
+
+
+def _measure(
+    function: Callable[[tuple[BookkeepingFact, ...]], int],
+    facts: tuple[BookkeepingFact, ...],
+) -> tuple[int, int]:
+    gc.collect()
+    gc_was_enabled = gc.isenabled()
+    gc.disable()
+    try:
+        started_ns = time.perf_counter_ns()
+        ledger_length = function(facts)
+        elapsed_ns = time.perf_counter_ns() - started_ns
+    finally:
+        if gc_was_enabled:
+            gc.enable()
+    return elapsed_ns, ledger_length
+
+
+def _run_sweep(
+    *,
+    mode: str,
+    function: Callable[[tuple[BookkeepingFact, ...]], int],
+    fact_streams: dict[str, tuple[BookkeepingFact, ...]],
+    sizes: tuple[int, ...],
+    repetitions: int,
+) -> list[dict[str, int | str]]:
+    for fact_mix, stream in fact_streams.items():
+        for size in sizes:
+            _, ledger_length = _measure(function, stream[:size])
+            if ledger_length != size:
+                raise AssertionError(
+                    f"{mode}/{fact_mix}/{size}: ledger length {ledger_length}"
+                )
+
+    measurements: list[dict[str, int | str]] = []
+    for repetition in range(repetitions):
+        for fact_mix, stream in fact_streams.items():
+            for size in sizes:
+                elapsed_ns, ledger_length = _measure(function, stream[:size])
+                if ledger_length != size:
+                    raise AssertionError(
+                        f"{mode}/{fact_mix}/{size}: ledger length {ledger_length}"
+                    )
+                measurements.append(
+                    {
+                        "mode": mode,
+                        "fact_mix": fact_mix,
+                        "size": size,
+                        "repetition": repetition,
+                        "elapsed_ns": elapsed_ns,
+                        "ledger_length": ledger_length,
+                    }
+                )
+    return measurements
+
+
+def _median_rows(
+    measurements: list[dict[str, int | str]],
+) -> list[dict[str, int | str]]:
+    keys = sorted(
+        {
+            (str(row["mode"]), str(row["fact_mix"]), int(row["size"]))
+            for row in measurements
+        }
+    )
+    rows: list[dict[str, int | str]] = []
+    for mode, fact_mix, size in keys:
+        values = [
+            int(row["elapsed_ns"])
+            for row in measurements
+            if row["mode"] == mode
+            and row["fact_mix"] == fact_mix
+            and row["size"] == size
+        ]
+        rows.append(
+            {
+                "mode": mode,
+                "fact_mix": fact_mix,
+                "size": size,
+                "median_elapsed_ns": int(statistics.median(values)),
+            }
+        )
+    return rows
+
+
+def _median_lookup(
+    medians: list[dict[str, int | str]],
+    mode: str,
+    fact_mix: str,
+    size: int,
+) -> int:
+    return next(
+        int(row["median_elapsed_ns"])
+        for row in medians
+        if row["mode"] == mode
+        and row["fact_mix"] == fact_mix
+        and row["size"] == size
+    )
+
+
+def _relations(medians: list[dict[str, int | str]]) -> list[dict[str, Any]]:
+    relations: list[dict[str, Any]] = []
+    for fact_mix in ("stage", "wqe"):
+        for smaller, larger in pairwise(INCREMENTAL_SIZES):
+            ratio = _median_lookup(
+                medians, "incremental", fact_mix, larger
+            ) / _median_lookup(medians, "incremental", fact_mix, smaller)
+            relations.append(
+                {
+                    "relation": "incremental_quadrupling",
+                    "fact_mix": fact_mix,
+                    "smaller_size": smaller,
+                    "larger_size": larger,
+                    "ratio": ratio,
+                    "bound": 6.0,
+                    "passed": ratio <= 6.0,
+                }
+            )
+        reference_ratio = _median_lookup(
+            medians, "reference", fact_mix, 4_000
+        ) / _median_lookup(medians, "reference", fact_mix, 1_000)
+        relations.append(
+            {
+                "relation": "reference_endpoint_growth",
+                "fact_mix": fact_mix,
+                "smaller_size": 1_000,
+                "larger_size": 4_000,
+                "ratio": reference_ratio,
+                "bound": 8.0,
+                "passed": reference_ratio >= 8.0,
+            }
+        )
+    return relations
+
+
+def run(out_dir: Path) -> dict[str, Any]:
+    maximum_size = max(*INCREMENTAL_SIZES, *REFERENCE_SIZES)
+    fact_streams = {
+        "stage": _stage_facts(maximum_size),
+        "wqe": _wqe_facts(maximum_size),
+    }
+    for fact_mix, stream in fact_streams.items():
+        validate_bookkeeping_ledger(_ledger_from_facts(stream))
+        if len(stream) != maximum_size:
+            raise AssertionError(f"{fact_mix}: generated {len(stream)} facts")
+
+    measurements = _run_sweep(
+        mode="incremental",
+        function=_append_incrementally,
+        fact_streams=fact_streams,
+        sizes=INCREMENTAL_SIZES,
+        repetitions=INCREMENTAL_REPETITIONS,
+    )
+    measurements.extend(
+        _run_sweep(
+            mode="reference",
+            function=_append_with_full_candidates,
+            fact_streams=fact_streams,
+            sizes=REFERENCE_SIZES,
+            repetitions=REFERENCE_REPETITIONS,
+        )
+    )
+    medians = _median_rows(measurements)
+    relations = _relations(medians)
+    report = {
+        "expectations_commit": EXPECTATIONS_COMMIT,
+        "clock": "time.perf_counter_ns",
+        "host": {
+            "python": sys.version,
+            "platform": platform.platform(),
+            "processor": platform.processor(),
+        },
+        "configuration": {
+            "incremental_sizes": INCREMENTAL_SIZES,
+            "reference_sizes": REFERENCE_SIZES,
+            "incremental_repetitions": INCREMENTAL_REPETITIONS,
+            "reference_repetitions": REFERENCE_REPETITIONS,
+            "warmup_sweeps": 1,
+            "garbage_collection_during_measurement": False,
+        },
+        "measurements": measurements,
+        "medians": medians,
+        "relations": relations,
+        "structural_checks": {
+            "generated_streams_reference_valid": True,
+            "same_fact_tuples_used_by_both_modes": True,
+            "all_ledger_lengths_equal_requested_size": True,
+        },
+        "passed": all(bool(relation["passed"]) for relation in relations),
+    }
+    out_dir.mkdir(parents=True, exist_ok=True)
+    output_path = out_dir / "measurements.json"
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    return report
+
+
+def _ledger_from_facts(facts: tuple[BookkeepingFact, ...]) -> BookkeepingLedger:
+    return BookkeepingLedger(
+        tuple(BookkeepingEntry(index, fact) for index, fact in enumerate(facts))
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args()
+    report = run(args.out)
+    summary = {
+        "expectations_commit": report["expectations_commit"],
+        "medians": report["medians"],
+        "relations": report["relations"],
+        "passed": report["passed"],
+    }
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    if not report["passed"]:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/simllm/core/bookkeeping.py
+++ b/simllm/core/bookkeeping.py
@@ -330,229 +330,61 @@ def _validate_completion_event(fact: CompletionEvent, path: str) -> None:
 def validate_bookkeeping_ledger(ledger: BookkeepingLedger) -> None:
     """Validate sequence, lineage, WQE context and completion consistency."""
 
-    if not isinstance(ledger, BookkeepingLedger):
-        raise TypeError("ledger: expected BookkeepingLedger")
-    if not isinstance(ledger.entries, tuple):
-        raise TypeError("ledger.entries: in-memory contract requires a tuple")
-
-    objects: dict[str, CreatedObjectRecord] = {}
-    subject_timestamp: dict[str, int] = {}
-    completed_wqes: set[str] = set()
-    for index, entry in enumerate(ledger.entries):
-        path = f"ledger.entries[{index}]"
-        if not isinstance(entry, BookkeepingEntry):
-            raise TypeError(f"{path}: expected BookkeepingEntry")
-        _require_integer(entry.sequence, f"{path}.sequence", nonnegative=True)
-        if entry.sequence != index:
-            raise ValueError(f"{path}.sequence: expected contiguous value {index}")
-        fact = entry.fact
-        timestamp = _fact_timestamp(fact)
-        _require_integer(timestamp, f"{path}.timestamp_ps", nonnegative=True)
-
-        if isinstance(fact, CreatedObjectRecord):
-            _validate_ref(fact.ref, f"{path}.fact.ref")
-            if fact.ref.object_id in objects:
-                raise ValueError(f"{path}.fact.ref.object_id: duplicate object ID")
-            if not isinstance(fact.owner, ObjectOwner):
-                raise TypeError(f"{path}.fact.owner: expected ObjectOwner")
-            _validate_scope(fact.scope, f"{path}.fact.scope")
-            if fact.native_id is not None:
-                _require_text(fact.native_id, f"{path}.fact.native_id")
-            _validate_ref_tuple(fact.parent_refs, f"{path}.fact.parent_refs")
-            if fact.ref in fact.parent_refs:
-                raise ValueError(f"{path}.fact.parent_refs: object cannot parent itself")
-            parent_records: list[CreatedObjectRecord] = []
-            for parent_index, parent in enumerate(fact.parent_refs):
-                prior = objects.get(parent.object_id)
-                if prior is None or prior.ref != parent:
-                    raise ValueError(
-                        f"{path}.fact.parent_refs[{parent_index}]: unknown object reference"
-                    )
-                if fact.created_at_ps < prior.created_at_ps:
-                    raise ValueError(
-                        f"{path}.fact.parent_refs[{parent_index}]: child predates parent"
-                    )
-                parent_records.append(prior)
-            _validate_scope_lineage(
-                tuple(parent_records),
-                fact.scope,
-                f"{path}.fact.parent_refs",
-            )
-            _validate_metadata(fact.metadata, f"{path}.fact.metadata")
-            if fact.ref.kind is CreatedObjectKind.NETWORK_WQE:
-                parent_kinds = [parent.kind for parent in fact.parent_refs]
-                for queue_kind, queue_name in (
-                    (CreatedObjectKind.SEND_QUEUE, "send queue"),
-                    (CreatedObjectKind.RECEIVE_QUEUE, "receive queue"),
-                    (CreatedObjectKind.COMPLETION_QUEUE, "completion queue"),
-                ):
-                    if parent_kinds.count(queue_kind) != 1:
-                        raise ValueError(
-                            f"{path}.fact.parent_refs: WQE requires exactly one {queue_name}"
-                        )
-                transports = parent_kinds.count(
-                    CreatedObjectKind.DCQCN_QP
-                ) + parent_kinds.count(CreatedObjectKind.RNIC_CN_LINK_PAIR)
-                if transports > 1:
-                    raise ValueError(
-                        f"{path}.fact.parent_refs: WQE permits at most one QP or link pair"
-                    )
-                transport_metadata = _metadata_dict(fact.metadata).get("transport_kind")
-                if transports == 0 and transport_metadata != "none":
-                    raise ValueError(
-                        f"{path}.fact.metadata: transport-free WQE requires transport_kind=none"
-                    )
-                if transports == 1 and transport_metadata == "none":
-                    raise ValueError(
-                        f"{path}.fact.metadata: physical WQE cannot use transport_kind=none"
-                    )
-            objects[fact.ref.object_id] = fact
-            continue
-
-        if isinstance(fact, StageRecord):
-            if not isinstance(fact.stage, ProcessingStage):
-                raise TypeError(f"{path}.fact.stage: expected ProcessingStage")
-            if not isinstance(fact.phase, StagePhase):
-                raise TypeError(f"{path}.fact.phase: expected StagePhase")
-            _validate_scope(fact.scope, f"{path}.fact.scope")
-            _validate_ref_tuple(fact.object_refs, f"{path}.fact.object_refs")
-            referenced_records: list[CreatedObjectRecord] = []
-            for ref_index, ref in enumerate(fact.object_refs):
-                prior = objects.get(ref.object_id)
-                if prior is None or prior.ref != ref:
-                    raise ValueError(
-                        f"{path}.fact.object_refs[{ref_index}]: unknown object reference"
-                    )
-                if fact.timestamp_ps < prior.created_at_ps:
-                    raise ValueError(
-                        f"{path}.fact.object_refs[{ref_index}]: stage predates object"
-                    )
-                referenced_records.append(prior)
-            _validate_scope_lineage(
-                tuple(referenced_records),
-                fact.scope,
-                f"{path}.fact.object_refs",
-            )
-            continue
-
-        if not isinstance(fact, CompletionEvent):
-            raise TypeError(f"{path}.fact: unsupported fact {type(fact).__name__}")
-        _validate_completion_event(fact, f"{path}.fact")
-        subject_id = fact.subject_object_id
-        if subject_id is None:
-            continue
-        subject = objects.get(subject_id)
-        if subject is None:
-            raise ValueError(f"{path}.fact.subject_object_id: unknown object ID")
-        scope = subject.scope
-        if scope.execution_id is not None and scope.execution_id != fact.execution_id:
-            raise ValueError(f"{path}.fact.execution_id: does not match subject scope")
-        if scope.operation_id is not None and scope.operation_id != fact.operation_id:
-            raise ValueError(f"{path}.fact.operation_id: does not match subject scope")
-        if fact.timestamp_ps < subject.created_at_ps:
-            raise ValueError(f"{path}.fact.timestamp_ps: completion predates subject")
-        prior_timestamp = subject_timestamp.get(subject_id, -1)
-        if fact.timestamp_ps < prior_timestamp:
-            raise ValueError(f"{path}.fact.timestamp_ps: subject timestamps must be nondecreasing")
-        subject_timestamp[subject_id] = fact.timestamp_ps
-        if subject.ref.kind is CreatedObjectKind.NETWORK_WQE:
-            if subject_id in completed_wqes:
-                if fact.phase is EventPhase.COMPLETED:
-                    raise ValueError(f"{path}.fact: WQE has more than one completion")
-                raise ValueError(
-                    f"{path}.fact: WQE accepts no events after its completion"
-                )
-            if fact.phase is EventPhase.COMPLETED:
-                completion_queues = tuple(
-                    parent
-                    for parent in subject.parent_refs
-                    if parent.kind is CreatedObjectKind.COMPLETION_QUEUE
-                )
-                expected_resource = ResourceRef(
-                    ResourceKind.COMPLETION_QUEUE,
-                    completion_queues[0].object_id,
-                )
-                if fact.resource != expected_resource:
-                    raise ValueError(
-                        f"{path}.fact.resource: WQE completion must name its completion queue"
-                    )
-                completed_wqes.add(subject_id)
+    _validate_bookkeeping_ledger_state(ledger)
 
 
 @dataclass
-class _BookkeepingValidationIndex:
-    """Cross-entry state retained after one complete reference validation."""
+class _BookkeepingValidationState:
+    """Root or copy-on-write state consumed by the shared rule engine."""
 
+    base: _BookkeepingValidationState | None = None
     objects: dict[str, CreatedObjectRecord] = field(default_factory=dict)
     subject_timestamps: dict[str, int] = field(default_factory=dict)
     completed_wqes: set[str] = field(default_factory=set)
 
-    @classmethod
-    def from_validated_ledger(
-        cls,
-        ledger: BookkeepingLedger,
-    ) -> _BookkeepingValidationIndex:
-        """Build an index from a ledger already accepted by the reference."""
-
-        index = cls()
-        for entry in ledger.entries:
-            fact = entry.fact
-            if isinstance(fact, CreatedObjectRecord):
-                index.objects[fact.ref.object_id] = fact
-                continue
-            if not isinstance(fact, CompletionEvent) or fact.subject_object_id is None:
-                continue
-            subject_id = fact.subject_object_id
-            index.subject_timestamps[subject_id] = fact.timestamp_ps
-            subject = index.objects[subject_id]
-            if (
-                subject.ref.kind is CreatedObjectKind.NETWORK_WQE
-                and fact.phase is EventPhase.COMPLETED
-            ):
-                index.completed_wqes.add(subject_id)
-        return index
-
-    def transaction(self) -> _BookkeepingValidationTransaction:
+    def transaction(self) -> _BookkeepingValidationState:
         """Return an isolated batch overlay that can be committed atomically."""
 
-        return _BookkeepingValidationTransaction(self)
-
-
-@dataclass
-class _BookkeepingValidationTransaction:
-    """Copy-on-write validation state for one append or extend call."""
-
-    base: _BookkeepingValidationIndex
-    objects: dict[str, CreatedObjectRecord] = field(default_factory=dict)
-    subject_timestamps: dict[str, int] = field(default_factory=dict)
-    completed_wqes: set[str] = field(default_factory=set)
+        return _BookkeepingValidationState(base=self)
 
     def object_for(self, object_id: str) -> CreatedObjectRecord | None:
-        return self.objects.get(object_id) or self.base.objects.get(object_id)
+        record = self.objects.get(object_id)
+        if record is not None:
+            return record
+        if self.base is not None:
+            return self.base.object_for(object_id)
+        return None
 
     def has_object(self, object_id: str) -> bool:
-        return object_id in self.objects or object_id in self.base.objects
+        return self.object_for(object_id) is not None
 
     def subject_timestamp(self, object_id: str) -> int:
-        if object_id in self.subject_timestamps:
-            return self.subject_timestamps[object_id]
-        return self.base.subject_timestamps.get(object_id, -1)
+        timestamp = self.subject_timestamps.get(object_id)
+        if timestamp is not None:
+            return timestamp
+        if self.base is not None:
+            return self.base.subject_timestamp(object_id)
+        return -1
 
     def wqe_is_completed(self, object_id: str) -> bool:
-        return object_id in self.completed_wqes or object_id in self.base.completed_wqes
+        if object_id in self.completed_wqes:
+            return True
+        return self.base is not None and self.base.wqe_is_completed(object_id)
 
     def commit(self) -> None:
+        if self.base is None:
+            raise RuntimeError("root validation state cannot be committed")
         self.base.objects.update(self.objects)
         self.base.subject_timestamps.update(self.subject_timestamps)
         self.base.completed_wqes.update(self.completed_wqes)
 
 
-def _validate_incremental_entry(
+def _validate_bookkeeping_entry(
     entry: BookkeepingEntry,
     expected_sequence: int,
-    state: _BookkeepingValidationTransaction,
+    state: _BookkeepingValidationState,
 ) -> None:
-    """Validate one generated entry against prior indexed ledger state."""
+    """Apply every per-fact rule against the supplied prior ledger state."""
 
     path = f"ledger.entries[{expected_sequence}]"
     if not isinstance(entry, BookkeepingEntry):
@@ -692,6 +524,22 @@ def _validate_incremental_entry(
             state.completed_wqes.add(subject_id)
 
 
+def _validate_bookkeeping_ledger_state(
+    ledger: BookkeepingLedger,
+) -> _BookkeepingValidationState:
+    """Fully validate a ledger and return the resulting incremental state."""
+
+    if not isinstance(ledger, BookkeepingLedger):
+        raise TypeError("ledger: expected BookkeepingLedger")
+    if not isinstance(ledger.entries, tuple):
+        raise TypeError("ledger.entries: in-memory contract requires a tuple")
+
+    state = _BookkeepingValidationState()
+    for index, entry in enumerate(ledger.entries):
+        _validate_bookkeeping_entry(entry, index, state)
+    return state
+
+
 def _escape_object_id_component(value: str) -> str:
     """Escape the composite-ID separator so distinct pairs never collide."""
 
@@ -703,9 +551,8 @@ class RequestBookkeeper:
 
     def __init__(self, ledger: BookkeepingLedger | None = None) -> None:
         initial = ledger or BookkeepingLedger()
-        validate_bookkeeping_ledger(initial)
+        self._validation_state = _validate_bookkeeping_ledger_state(initial)
         self._entries = list(initial.entries)
-        self._validation_index = _BookkeepingValidationIndex.from_validated_ledger(initial)
 
     def append(self, fact: BookkeepingFact) -> BookkeepingEntry:
         """Append one fact and return its ledger-assigned entry."""
@@ -719,9 +566,9 @@ class RequestBookkeeper:
         additions = tuple(
             BookkeepingEntry(start + offset, fact) for offset, fact in enumerate(facts)
         )
-        transaction = self._validation_index.transaction()
+        transaction = self._validation_state.transaction()
         for offset, entry in enumerate(additions):
-            _validate_incremental_entry(entry, start + offset, transaction)
+            _validate_bookkeeping_entry(entry, start + offset, transaction)
         transaction.commit()
         self._entries.extend(additions)
         return additions

--- a/simllm/core/bookkeeping.py
+++ b/simllm/core/bookkeeping.py
@@ -479,6 +479,219 @@ def validate_bookkeeping_ledger(ledger: BookkeepingLedger) -> None:
                 completed_wqes.add(subject_id)
 
 
+@dataclass
+class _BookkeepingValidationIndex:
+    """Cross-entry state retained after one complete reference validation."""
+
+    objects: dict[str, CreatedObjectRecord] = field(default_factory=dict)
+    subject_timestamps: dict[str, int] = field(default_factory=dict)
+    completed_wqes: set[str] = field(default_factory=set)
+
+    @classmethod
+    def from_validated_ledger(
+        cls,
+        ledger: BookkeepingLedger,
+    ) -> _BookkeepingValidationIndex:
+        """Build an index from a ledger already accepted by the reference."""
+
+        index = cls()
+        for entry in ledger.entries:
+            fact = entry.fact
+            if isinstance(fact, CreatedObjectRecord):
+                index.objects[fact.ref.object_id] = fact
+                continue
+            if not isinstance(fact, CompletionEvent) or fact.subject_object_id is None:
+                continue
+            subject_id = fact.subject_object_id
+            index.subject_timestamps[subject_id] = fact.timestamp_ps
+            subject = index.objects[subject_id]
+            if (
+                subject.ref.kind is CreatedObjectKind.NETWORK_WQE
+                and fact.phase is EventPhase.COMPLETED
+            ):
+                index.completed_wqes.add(subject_id)
+        return index
+
+    def transaction(self) -> _BookkeepingValidationTransaction:
+        """Return an isolated batch overlay that can be committed atomically."""
+
+        return _BookkeepingValidationTransaction(self)
+
+
+@dataclass
+class _BookkeepingValidationTransaction:
+    """Copy-on-write validation state for one append or extend call."""
+
+    base: _BookkeepingValidationIndex
+    objects: dict[str, CreatedObjectRecord] = field(default_factory=dict)
+    subject_timestamps: dict[str, int] = field(default_factory=dict)
+    completed_wqes: set[str] = field(default_factory=set)
+
+    def object_for(self, object_id: str) -> CreatedObjectRecord | None:
+        return self.objects.get(object_id) or self.base.objects.get(object_id)
+
+    def has_object(self, object_id: str) -> bool:
+        return object_id in self.objects or object_id in self.base.objects
+
+    def subject_timestamp(self, object_id: str) -> int:
+        if object_id in self.subject_timestamps:
+            return self.subject_timestamps[object_id]
+        return self.base.subject_timestamps.get(object_id, -1)
+
+    def wqe_is_completed(self, object_id: str) -> bool:
+        return object_id in self.completed_wqes or object_id in self.base.completed_wqes
+
+    def commit(self) -> None:
+        self.base.objects.update(self.objects)
+        self.base.subject_timestamps.update(self.subject_timestamps)
+        self.base.completed_wqes.update(self.completed_wqes)
+
+
+def _validate_incremental_entry(
+    entry: BookkeepingEntry,
+    expected_sequence: int,
+    state: _BookkeepingValidationTransaction,
+) -> None:
+    """Validate one generated entry against prior indexed ledger state."""
+
+    path = f"ledger.entries[{expected_sequence}]"
+    if not isinstance(entry, BookkeepingEntry):
+        raise TypeError(f"{path}: expected BookkeepingEntry")
+    _require_integer(entry.sequence, f"{path}.sequence", nonnegative=True)
+    if entry.sequence != expected_sequence:
+        raise ValueError(f"{path}.sequence: expected contiguous value {expected_sequence}")
+    fact = entry.fact
+    timestamp = _fact_timestamp(fact)
+    _require_integer(timestamp, f"{path}.timestamp_ps", nonnegative=True)
+
+    if isinstance(fact, CreatedObjectRecord):
+        _validate_ref(fact.ref, f"{path}.fact.ref")
+        if state.has_object(fact.ref.object_id):
+            raise ValueError(f"{path}.fact.ref.object_id: duplicate object ID")
+        if not isinstance(fact.owner, ObjectOwner):
+            raise TypeError(f"{path}.fact.owner: expected ObjectOwner")
+        _validate_scope(fact.scope, f"{path}.fact.scope")
+        if fact.native_id is not None:
+            _require_text(fact.native_id, f"{path}.fact.native_id")
+        _validate_ref_tuple(fact.parent_refs, f"{path}.fact.parent_refs")
+        if fact.ref in fact.parent_refs:
+            raise ValueError(f"{path}.fact.parent_refs: object cannot parent itself")
+        parent_records: list[CreatedObjectRecord] = []
+        for parent_index, parent in enumerate(fact.parent_refs):
+            prior = state.object_for(parent.object_id)
+            if prior is None or prior.ref != parent:
+                raise ValueError(
+                    f"{path}.fact.parent_refs[{parent_index}]: unknown object reference"
+                )
+            if fact.created_at_ps < prior.created_at_ps:
+                raise ValueError(
+                    f"{path}.fact.parent_refs[{parent_index}]: child predates parent"
+                )
+            parent_records.append(prior)
+        _validate_scope_lineage(
+            tuple(parent_records),
+            fact.scope,
+            f"{path}.fact.parent_refs",
+        )
+        _validate_metadata(fact.metadata, f"{path}.fact.metadata")
+        if fact.ref.kind is CreatedObjectKind.NETWORK_WQE:
+            parent_kinds = [parent.kind for parent in fact.parent_refs]
+            for queue_kind, queue_name in (
+                (CreatedObjectKind.SEND_QUEUE, "send queue"),
+                (CreatedObjectKind.RECEIVE_QUEUE, "receive queue"),
+                (CreatedObjectKind.COMPLETION_QUEUE, "completion queue"),
+            ):
+                if parent_kinds.count(queue_kind) != 1:
+                    raise ValueError(
+                        f"{path}.fact.parent_refs: WQE requires exactly one {queue_name}"
+                    )
+            transports = parent_kinds.count(
+                CreatedObjectKind.DCQCN_QP
+            ) + parent_kinds.count(CreatedObjectKind.RNIC_CN_LINK_PAIR)
+            if transports > 1:
+                raise ValueError(
+                    f"{path}.fact.parent_refs: WQE permits at most one QP or link pair"
+                )
+            transport_metadata = _metadata_dict(fact.metadata).get("transport_kind")
+            if transports == 0 and transport_metadata != "none":
+                raise ValueError(
+                    f"{path}.fact.metadata: transport-free WQE requires transport_kind=none"
+                )
+            if transports == 1 and transport_metadata == "none":
+                raise ValueError(
+                    f"{path}.fact.metadata: physical WQE cannot use transport_kind=none"
+                )
+        state.objects[fact.ref.object_id] = fact
+        return
+
+    if isinstance(fact, StageRecord):
+        if not isinstance(fact.stage, ProcessingStage):
+            raise TypeError(f"{path}.fact.stage: expected ProcessingStage")
+        if not isinstance(fact.phase, StagePhase):
+            raise TypeError(f"{path}.fact.phase: expected StagePhase")
+        _validate_scope(fact.scope, f"{path}.fact.scope")
+        _validate_ref_tuple(fact.object_refs, f"{path}.fact.object_refs")
+        referenced_records: list[CreatedObjectRecord] = []
+        for ref_index, ref in enumerate(fact.object_refs):
+            prior = state.object_for(ref.object_id)
+            if prior is None or prior.ref != ref:
+                raise ValueError(
+                    f"{path}.fact.object_refs[{ref_index}]: unknown object reference"
+                )
+            if fact.timestamp_ps < prior.created_at_ps:
+                raise ValueError(
+                    f"{path}.fact.object_refs[{ref_index}]: stage predates object"
+                )
+            referenced_records.append(prior)
+        _validate_scope_lineage(
+            tuple(referenced_records),
+            fact.scope,
+            f"{path}.fact.object_refs",
+        )
+        return
+
+    if not isinstance(fact, CompletionEvent):
+        raise TypeError(f"{path}.fact: unsupported fact {type(fact).__name__}")
+    _validate_completion_event(fact, f"{path}.fact")
+    subject_id = fact.subject_object_id
+    if subject_id is None:
+        return
+    subject = state.object_for(subject_id)
+    if subject is None:
+        raise ValueError(f"{path}.fact.subject_object_id: unknown object ID")
+    scope = subject.scope
+    if scope.execution_id is not None and scope.execution_id != fact.execution_id:
+        raise ValueError(f"{path}.fact.execution_id: does not match subject scope")
+    if scope.operation_id is not None and scope.operation_id != fact.operation_id:
+        raise ValueError(f"{path}.fact.operation_id: does not match subject scope")
+    if fact.timestamp_ps < subject.created_at_ps:
+        raise ValueError(f"{path}.fact.timestamp_ps: completion predates subject")
+    prior_timestamp = state.subject_timestamp(subject_id)
+    if fact.timestamp_ps < prior_timestamp:
+        raise ValueError(f"{path}.fact.timestamp_ps: subject timestamps must be nondecreasing")
+    state.subject_timestamps[subject_id] = fact.timestamp_ps
+    if subject.ref.kind is CreatedObjectKind.NETWORK_WQE:
+        if state.wqe_is_completed(subject_id):
+            if fact.phase is EventPhase.COMPLETED:
+                raise ValueError(f"{path}.fact: WQE has more than one completion")
+            raise ValueError(f"{path}.fact: WQE accepts no events after its completion")
+        if fact.phase is EventPhase.COMPLETED:
+            completion_queues = tuple(
+                parent
+                for parent in subject.parent_refs
+                if parent.kind is CreatedObjectKind.COMPLETION_QUEUE
+            )
+            expected_resource = ResourceRef(
+                ResourceKind.COMPLETION_QUEUE,
+                completion_queues[0].object_id,
+            )
+            if fact.resource != expected_resource:
+                raise ValueError(
+                    f"{path}.fact.resource: WQE completion must name its completion queue"
+                )
+            state.completed_wqes.add(subject_id)
+
+
 def _escape_object_id_component(value: str) -> str:
     """Escape the composite-ID separator so distinct pairs never collide."""
 
@@ -492,6 +705,7 @@ class RequestBookkeeper:
         initial = ledger or BookkeepingLedger()
         validate_bookkeeping_ledger(initial)
         self._entries = list(initial.entries)
+        self._validation_index = _BookkeepingValidationIndex.from_validated_ledger(initial)
 
     def append(self, fact: BookkeepingFact) -> BookkeepingEntry:
         """Append one fact and return its ledger-assigned entry."""
@@ -499,14 +713,16 @@ class RequestBookkeeper:
         return self.extend((fact,))[0]
 
     def extend(self, facts: Iterable[BookkeepingFact]) -> tuple[BookkeepingEntry, ...]:
-        """Atomically append facts after validating the full candidate ledger."""
+        """Atomically append facts after incremental validation."""
 
         start = len(self._entries)
         additions = tuple(
             BookkeepingEntry(start + offset, fact) for offset, fact in enumerate(facts)
         )
-        candidate = BookkeepingLedger((*self._entries, *additions))
-        validate_bookkeeping_ledger(candidate)
+        transaction = self._validation_index.transaction()
+        for offset, entry in enumerate(additions):
+            _validate_incremental_entry(entry, start + offset, transaction)
+        transaction.commit()
         self._entries.extend(additions)
         return additions
 

--- a/tests/test_bookkeeping_incremental.py
+++ b/tests/test_bookkeeping_incremental.py
@@ -1,0 +1,702 @@
+import random
+from dataclasses import replace
+
+import pytest
+
+from simllm.core.bookkeeping import (
+    BookkeepingEntry,
+    BookkeepingLedger,
+    BookkeepingScope,
+    CreatedObjectKind,
+    CreatedObjectRecord,
+    CreatedObjectRef,
+    ObjectOwner,
+    ProcessingStage,
+    RequestBookkeeper,
+    StagePhase,
+    StageRecord,
+    validate_bookkeeping_ledger,
+)
+from simllm.core.execution import (
+    CompletionEvent,
+    EventPhase,
+    OperationCorrelation,
+    ResourceKind,
+    ResourceRef,
+)
+
+_SEEDS = (7001, 7002, 7003, 7004, 7005, 7006)
+_LENGTHS = (8, 32, 128)
+_BATCH_WIDTHS = (1, 2, 7, 32)
+
+
+def _record(
+    kind: CreatedObjectKind,
+    object_id: str,
+    timestamp_ps: int,
+    *,
+    owner: ObjectOwner = ObjectOwner.DEVICE_RUNTIME,
+    scope: BookkeepingScope | None = None,
+    parents: tuple[CreatedObjectRef, ...] = (),
+    metadata: tuple[tuple[str, str | int | float | bool], ...] = (),
+) -> CreatedObjectRecord:
+    return CreatedObjectRecord(
+        CreatedObjectRef(kind, object_id),
+        owner,
+        timestamp_ps,
+        scope or BookkeepingScope(),
+        parent_refs=parents,
+        metadata=metadata,
+    )
+
+
+def _valid_fact_stream(seed: int, length: int) -> tuple[object, ...]:
+    rng = random.Random(seed)
+    empty_scope = BookkeepingScope()
+    sq = _record(CreatedObjectKind.SEND_QUEUE, "sq:shared", 0)
+    rq = _record(CreatedObjectKind.RECEIVE_QUEUE, "rq:shared", 0)
+    cq = _record(CreatedObjectKind.COMPLETION_QUEUE, "cq:shared", 0)
+    qp = _record(
+        CreatedObjectKind.DCQCN_QP,
+        "qp:shared",
+        1,
+        owner=ObjectOwner.NETWORK_BACKEND,
+        parents=(sq.ref, rq.ref, cq.ref),
+    )
+    link = _record(
+        CreatedObjectKind.RNIC_CN_LINK_PAIR,
+        "link:shared",
+        1,
+        owner=ObjectOwner.NETWORK_BACKEND,
+        parents=(sq.ref, rq.ref, cq.ref),
+    )
+    facts: list[object] = [sq, rq, cq, qp, link]
+
+    cycle = 0
+    while len(facts) < length:
+        timestamp = 100 + cycle * 32
+        request_ids = (f"request:{cycle}:a", f"request:{cycle}:b")
+        request_scope_a = BookkeepingScope(
+            correlation=OperationCorrelation(request_ids=(request_ids[0],))
+        )
+        request_scope_b = BookkeepingScope(
+            correlation=OperationCorrelation(request_ids=(request_ids[1],))
+        )
+        operation_scope = BookkeepingScope(
+            correlation=OperationCorrelation(
+                request_ids=request_ids,
+                batch_id=f"batch:{cycle}",
+                layer=cycle % 8,
+                microbatch=cycle % 3,
+                iteration=cycle // 3,
+            ),
+            step_index=cycle,
+            execution_id=f"execution:{cycle}",
+            operation_id=f"operation:{cycle}",
+        )
+        narrowed_ids = request_ids if rng.randrange(2) else (rng.choice(request_ids),)
+        child_scope = replace(
+            operation_scope,
+            correlation=replace(operation_scope.correlation, request_ids=narrowed_ids),
+        )
+        request_a = _record(
+            CreatedObjectKind.FRAMEWORK_REQUEST,
+            f"request-object:{cycle}:a",
+            timestamp,
+            owner=ObjectOwner.FRAMEWORK,
+            scope=request_scope_a,
+        )
+        request_b = _record(
+            CreatedObjectKind.FRAMEWORK_REQUEST,
+            f"request-object:{cycle}:b",
+            timestamp,
+            owner=ObjectOwner.FRAMEWORK,
+            scope=request_scope_b,
+        )
+        operation = _record(
+            CreatedObjectKind.EXECUTION_OPERATION,
+            f"operation-object:{cycle}",
+            timestamp + 2,
+            owner=ObjectOwner.CORE,
+            scope=operation_scope,
+        )
+        nccl = _record(
+            CreatedObjectKind.NCCL_COMMAND,
+            f"nccl:{cycle}",
+            timestamp + 3,
+            owner=ObjectOwner.NCCL,
+            scope=child_scope,
+            parents=(operation.ref,),
+        )
+        transport_mode = cycle % 3
+        transport_refs: tuple[CreatedObjectRef, ...]
+        metadata: tuple[tuple[str, str | int | float | bool], ...]
+        if transport_mode == 0:
+            transport_refs = ()
+            metadata = (("bytes", 4096 + cycle), ("transport_kind", "none"))
+        elif transport_mode == 1:
+            transport_refs = (qp.ref,)
+            metadata = (("bytes", 4096 + cycle),)
+        else:
+            transport_refs = (link.ref,)
+            metadata = (("bytes", 4096 + cycle),)
+        wqe = _record(
+            CreatedObjectKind.NETWORK_WQE,
+            f"wqe:{cycle}",
+            timestamp + 4,
+            scope=child_scope,
+            parents=(nccl.ref, sq.ref, rq.ref, cq.ref, *transport_refs),
+            metadata=metadata,
+        )
+        resource = ResourceRef(ResourceKind.NIC_SEND_QUEUE, sq.ref.object_id)
+        event_args = (child_scope.execution_id, child_scope.operation_id)
+        assert event_args[0] is not None
+        assert event_args[1] is not None
+        facts.extend(
+            (
+                request_a,
+                request_b,
+                operation,
+                nccl,
+                wqe,
+                StageRecord(
+                    ProcessingStage.NETWORK,
+                    StagePhase.ENTERED,
+                    timestamp + 5,
+                    child_scope,
+                    (wqe.ref,),
+                ),
+                CompletionEvent(
+                    event_args[0],
+                    event_args[1],
+                    EventPhase.SUBMITTED,
+                    timestamp + 6,
+                    resource,
+                    subject_object_id=wqe.ref.object_id,
+                ),
+                CompletionEvent(
+                    event_args[0],
+                    event_args[1],
+                    EventPhase.QUEUED,
+                    timestamp + 8,
+                    resource,
+                    subject_object_id=wqe.ref.object_id,
+                ),
+                CompletionEvent(
+                    event_args[0],
+                    event_args[1],
+                    EventPhase.STARTED,
+                    timestamp + 10,
+                    resource,
+                    subject_object_id=wqe.ref.object_id,
+                ),
+                CompletionEvent(
+                    event_args[0],
+                    event_args[1],
+                    EventPhase.PROGRESS,
+                    timestamp + 12,
+                    resource,
+                    completed_bytes=2048,
+                    subject_object_id=wqe.ref.object_id,
+                ),
+                CompletionEvent(
+                    event_args[0],
+                    event_args[1],
+                    EventPhase.COMPLETED,
+                    timestamp + 14,
+                    ResourceRef(ResourceKind.COMPLETION_QUEUE, cq.ref.object_id),
+                    completed_bytes=4096 + cycle,
+                    subject_object_id=wqe.ref.object_id,
+                ),
+                StageRecord(
+                    ProcessingStage.NETWORK,
+                    StagePhase.COMPLETED,
+                    timestamp + 15,
+                    child_scope,
+                    (wqe.ref,),
+                ),
+                CompletionEvent(
+                    event_args[0],
+                    event_args[1],
+                    EventPhase.COMPLETED,
+                    timestamp + 16,
+                ),
+            )
+        )
+        cycle += 1
+
+    stream = tuple(facts[:length])
+    validate_bookkeeping_ledger(_ledger(stream))
+    assert empty_scope == sq.scope
+    return stream
+
+
+def _ledger(facts: tuple[object, ...]) -> BookkeepingLedger:
+    return BookkeepingLedger(
+        tuple(BookkeepingEntry(index, fact) for index, fact in enumerate(facts))
+    )
+
+
+def _reference_candidate(
+    ledger: BookkeepingLedger,
+    facts: tuple[object, ...],
+) -> tuple[BookkeepingLedger, tuple[BookkeepingEntry, ...]]:
+    start = len(ledger.entries)
+    additions = tuple(
+        BookkeepingEntry(start + offset, fact) for offset, fact in enumerate(facts)
+    )
+    candidate = BookkeepingLedger((*ledger.entries, *additions))
+    validate_bookkeeping_ledger(candidate)
+    return candidate, additions
+
+
+def _assert_append_equivalent(facts: tuple[object, ...]) -> None:
+    reference = BookkeepingLedger()
+    bookkeeper = RequestBookkeeper()
+    for fact in facts:
+        before = bookkeeper.snapshot()
+        try:
+            candidate, additions = _reference_candidate(reference, (fact,))
+        except (TypeError, ValueError) as reference_error:
+            with pytest.raises(type(reference_error)):
+                bookkeeper.append(fact)
+            assert bookkeeper.snapshot() == before == reference
+        else:
+            assert bookkeeper.append(fact) == additions[0]
+            reference = candidate
+            assert bookkeeper.snapshot() == reference
+
+
+def _assert_extend_equivalent(facts: tuple[object, ...], seed: int) -> None:
+    reference = BookkeepingLedger()
+    bookkeeper = RequestBookkeeper()
+    candidate, additions = _reference_candidate(reference, ())
+    assert bookkeeper.extend(()) == additions == ()
+    assert candidate == bookkeeper.snapshot()
+
+    rng = random.Random(seed)
+    position = 0
+    while position < len(facts):
+        width = rng.choice(_BATCH_WIDTHS)
+        batch = facts[position : position + width]
+        before = bookkeeper.snapshot()
+        try:
+            candidate, additions = _reference_candidate(reference, batch)
+        except (TypeError, ValueError) as reference_error:
+            with pytest.raises(type(reference_error)):
+                bookkeeper.extend(batch)
+            assert bookkeeper.snapshot() == before == reference
+        else:
+            assert bookkeeper.extend(batch) == additions
+            reference = candidate
+            assert bookkeeper.snapshot() == reference
+        position += len(batch)
+
+
+def _pick_index(rng: random.Random, facts: list[object], predicate) -> int:
+    matches = [index for index, fact in enumerate(facts) if predicate(fact)]
+    assert matches
+    return rng.choice(matches)
+
+
+def _replace_timestamp(fact: object, timestamp: object) -> object:
+    if isinstance(fact, CreatedObjectRecord):
+        return replace(fact, created_at_ps=timestamp)
+    return replace(fact, timestamp_ps=timestamp)
+
+
+def _mutated_stream(seed: int, mutation: str) -> tuple[object, ...]:
+    rng = random.Random(seed * 1009 + sum(ord(character) for character in mutation))
+    facts = list(_valid_fact_stream(seed, 128))
+    object_records = {
+        fact.ref.object_id: fact for fact in facts if isinstance(fact, CreatedObjectRecord)
+    }
+
+    if mutation == "unsupported-fact":
+        facts.insert(rng.randrange(len(facts) + 1), object())
+    elif mutation in {"boolean-timestamp", "negative-timestamp"}:
+        index = rng.randrange(len(facts))
+        timestamp = True if mutation == "boolean-timestamp" else -1
+        facts[index] = _replace_timestamp(facts[index], timestamp)
+    elif mutation == "invalid-ref-kind":
+        index = _pick_index(rng, facts, lambda fact: isinstance(fact, CreatedObjectRecord))
+        fact = facts[index]
+        facts[index] = replace(fact, ref=replace(fact.ref, kind="not-a-kind"))
+    elif mutation == "invalid-owner":
+        index = _pick_index(rng, facts, lambda fact: isinstance(fact, CreatedObjectRecord))
+        facts[index] = replace(facts[index], owner="not-an-owner")
+    elif mutation == "invalid-scope":
+        index = _pick_index(
+            rng,
+            facts,
+            lambda fact: isinstance(fact, (CreatedObjectRecord, StageRecord)),
+        )
+        facts[index] = replace(facts[index], scope="not-a-scope")
+    elif mutation == "correlation-list":
+        index = _pick_index(
+            rng,
+            facts,
+            lambda fact: isinstance(fact, (CreatedObjectRecord, StageRecord)),
+        )
+        fact = facts[index]
+        correlation = replace(fact.scope.correlation, request_ids=["request:list"])
+        facts[index] = replace(fact, scope=replace(fact.scope, correlation=correlation))
+    elif mutation == "correlation-duplicate":
+        index = _pick_index(
+            rng,
+            facts,
+            lambda fact: isinstance(fact, (CreatedObjectRecord, StageRecord)),
+        )
+        fact = facts[index]
+        correlation = replace(fact.scope.correlation, request_ids=("duplicate", "duplicate"))
+        facts[index] = replace(fact, scope=replace(fact.scope, correlation=correlation))
+    elif mutation == "boolean-scope-integer":
+        index = _pick_index(
+            rng,
+            facts,
+            lambda fact: isinstance(fact, (CreatedObjectRecord, StageRecord)),
+        )
+        fact = facts[index]
+        facts[index] = replace(fact, scope=replace(fact.scope, step_index=True))
+    elif mutation == "operation-without-execution":
+        index = _pick_index(rng, facts, lambda fact: isinstance(fact, StageRecord))
+        fact = facts[index]
+        facts[index] = replace(
+            fact,
+            scope=replace(fact.scope, execution_id=None, operation_id="orphan"),
+        )
+    elif mutation == "metadata-list":
+        index = _pick_index(rng, facts, lambda fact: isinstance(fact, CreatedObjectRecord))
+        facts[index] = replace(facts[index], metadata=[])
+    elif mutation == "metadata-invalid-scalar":
+        index = _pick_index(rng, facts, lambda fact: isinstance(fact, CreatedObjectRecord))
+        facts[index] = replace(facts[index], metadata=(("bad", None),))
+    elif mutation == "metadata-duplicate":
+        index = _pick_index(rng, facts, lambda fact: isinstance(fact, CreatedObjectRecord))
+        facts[index] = replace(facts[index], metadata=(("same", 1), ("same", 2)))
+    elif mutation == "parent-list":
+        index = _pick_index(
+            rng,
+            facts,
+            lambda fact: isinstance(fact, CreatedObjectRecord) and fact.parent_refs,
+        )
+        facts[index] = replace(facts[index], parent_refs=list(facts[index].parent_refs))
+    elif mutation == "duplicate-object":
+        indexes = [
+            index for index, fact in enumerate(facts) if isinstance(fact, CreatedObjectRecord)
+        ]
+        first, second = sorted(rng.sample(indexes, 2))
+        first_fact = facts[first]
+        second_fact = facts[second]
+        facts[second] = replace(
+            second_fact,
+            ref=replace(second_fact.ref, object_id=first_fact.ref.object_id),
+        )
+    elif mutation == "self-parent":
+        index = _pick_index(rng, facts, lambda fact: isinstance(fact, CreatedObjectRecord))
+        fact = facts[index]
+        facts[index] = replace(fact, parent_refs=(fact.ref,))
+    elif mutation in {"unknown-parent", "wrong-typed-parent"}:
+        index = _pick_index(
+            rng,
+            facts,
+            lambda fact: isinstance(fact, CreatedObjectRecord) and fact.parent_refs,
+        )
+        fact = facts[index]
+        parent = fact.parent_refs[0]
+        replacement = replace(parent, object_id="missing:parent")
+        if mutation == "wrong-typed-parent":
+            replacement = replace(parent, kind=CreatedObjectKind.FRAMEWORK_REQUEST)
+        facts[index] = replace(fact, parent_refs=(replacement, *fact.parent_refs[1:]))
+    elif mutation == "child-predates-parent":
+        index = _pick_index(
+            rng,
+            facts,
+            lambda fact: isinstance(fact, CreatedObjectRecord)
+            and fact.parent_refs
+            and object_records[fact.parent_refs[0].object_id].created_at_ps > 0,
+        )
+        fact = facts[index]
+        parent = object_records[fact.parent_refs[0].object_id]
+        facts[index] = replace(fact, created_at_ps=parent.created_at_ps - 1)
+    elif mutation == "request-introduction":
+        index = _pick_index(
+            rng,
+            facts,
+            lambda fact: isinstance(fact, CreatedObjectRecord)
+            and fact.ref.kind is CreatedObjectKind.NCCL_COMMAND,
+        )
+        fact = facts[index]
+        correlation = replace(
+            fact.scope.correlation,
+            request_ids=(*fact.scope.correlation.request_ids, "request:introduced"),
+        )
+        facts[index] = replace(fact, scope=replace(fact.scope, correlation=correlation))
+    elif mutation == "causal-parent-disagreement":
+        index = _pick_index(
+            rng,
+            facts,
+            lambda fact: isinstance(fact, CreatedObjectRecord)
+            and fact.ref.kind is CreatedObjectKind.NETWORK_WQE
+            and any(
+                isinstance(prior, CreatedObjectRecord)
+                and prior.ref.kind is CreatedObjectKind.NCCL_COMMAND
+                and prior.ref not in fact.parent_refs
+                for prior in facts[: facts.index(fact)]
+            ),
+        )
+        fact = facts[index]
+        other = next(
+            prior
+            for prior in facts[:index]
+            if isinstance(prior, CreatedObjectRecord)
+            and prior.ref.kind is CreatedObjectKind.NCCL_COMMAND
+            and prior.ref not in fact.parent_refs
+        )
+        facts[index] = replace(fact, parent_refs=(*fact.parent_refs, other.ref))
+    elif mutation == "wqe-missing-queue":
+        index = _pick_index(
+            rng,
+            facts,
+            lambda fact: isinstance(fact, CreatedObjectRecord)
+            and fact.ref.kind is CreatedObjectKind.NETWORK_WQE,
+        )
+        fact = facts[index]
+        missing_kind = rng.choice(
+            (
+                CreatedObjectKind.SEND_QUEUE,
+                CreatedObjectKind.RECEIVE_QUEUE,
+                CreatedObjectKind.COMPLETION_QUEUE,
+            )
+        )
+        facts[index] = replace(
+            fact,
+            parent_refs=tuple(parent for parent in fact.parent_refs if parent.kind is not missing_kind),
+        )
+    elif mutation == "wqe-multiple-transports":
+        index = _pick_index(
+            rng,
+            facts,
+            lambda fact: isinstance(fact, CreatedObjectRecord)
+            and fact.ref.kind is CreatedObjectKind.NETWORK_WQE
+            and any(
+                parent.kind
+                in {CreatedObjectKind.DCQCN_QP, CreatedObjectKind.RNIC_CN_LINK_PAIR}
+                for parent in fact.parent_refs
+            ),
+        )
+        fact = facts[index]
+        alternate = next(
+            ref
+            for ref in (
+                CreatedObjectRef(CreatedObjectKind.DCQCN_QP, "qp:shared"),
+                CreatedObjectRef(CreatedObjectKind.RNIC_CN_LINK_PAIR, "link:shared"),
+            )
+            if ref not in fact.parent_refs
+        )
+        facts[index] = replace(fact, parent_refs=(*fact.parent_refs, alternate))
+    elif mutation == "transport-free-implicit":
+        index = _pick_index(
+            rng,
+            facts,
+            lambda fact: isinstance(fact, CreatedObjectRecord)
+            and fact.ref.kind is CreatedObjectKind.NETWORK_WQE
+            and not any(
+                parent.kind
+                in {CreatedObjectKind.DCQCN_QP, CreatedObjectKind.RNIC_CN_LINK_PAIR}
+                for parent in fact.parent_refs
+            ),
+        )
+        fact = facts[index]
+        facts[index] = replace(
+            fact,
+            metadata=tuple(item for item in fact.metadata if item[0] != "transport_kind"),
+        )
+    elif mutation == "physical-transport-none":
+        index = _pick_index(
+            rng,
+            facts,
+            lambda fact: isinstance(fact, CreatedObjectRecord)
+            and fact.ref.kind is CreatedObjectKind.NETWORK_WQE
+            and any(
+                parent.kind
+                in {CreatedObjectKind.DCQCN_QP, CreatedObjectKind.RNIC_CN_LINK_PAIR}
+                for parent in fact.parent_refs
+            ),
+        )
+        fact = facts[index]
+        facts[index] = replace(fact, metadata=((*fact.metadata, ("transport_kind", "none"))))
+    elif mutation in {"invalid-stage", "invalid-stage-phase"}:
+        index = _pick_index(rng, facts, lambda fact: isinstance(fact, StageRecord))
+        field = "stage" if mutation == "invalid-stage" else "phase"
+        facts[index] = replace(facts[index], **{field: "invalid"})
+    elif mutation == "stage-ref-list":
+        index = _pick_index(rng, facts, lambda fact: isinstance(fact, StageRecord))
+        facts[index] = replace(facts[index], object_refs=list(facts[index].object_refs))
+    elif mutation == "stage-unknown-object":
+        index = _pick_index(rng, facts, lambda fact: isinstance(fact, StageRecord))
+        fact = facts[index]
+        facts[index] = replace(
+            fact,
+            object_refs=(CreatedObjectRef(CreatedObjectKind.NETWORK_WQE, "wqe:missing"),),
+        )
+    elif mutation == "stage-predates-object":
+        index = _pick_index(rng, facts, lambda fact: isinstance(fact, StageRecord))
+        fact = facts[index]
+        subject = object_records[fact.object_refs[0].object_id]
+        facts[index] = replace(fact, timestamp_ps=subject.created_at_ps - 1)
+    elif mutation in {
+        "invalid-completion-phase",
+        "boolean-completed-bytes",
+        "invalid-resource",
+        "invalid-resource-kind",
+    }:
+        index = _pick_index(rng, facts, lambda fact: isinstance(fact, CompletionEvent))
+        fact = facts[index]
+        if mutation == "invalid-completion-phase":
+            facts[index] = replace(fact, phase="invalid")
+        elif mutation == "boolean-completed-bytes":
+            facts[index] = replace(fact, completed_bytes=True)
+        elif mutation == "invalid-resource":
+            facts[index] = replace(fact, resource="invalid")
+        else:
+            facts[index] = replace(fact, resource=ResourceRef("invalid", "resource"))
+    elif mutation == "unknown-subject":
+        index = _pick_index(rng, facts, lambda fact: isinstance(fact, CompletionEvent))
+        facts[index] = replace(facts[index], subject_object_id="wqe:missing")
+    elif mutation in {"subject-execution-mismatch", "subject-operation-mismatch"}:
+        index = _pick_index(
+            rng,
+            facts,
+            lambda fact: isinstance(fact, CompletionEvent) and fact.subject_object_id is not None,
+        )
+        field = "execution_id" if mutation == "subject-execution-mismatch" else "operation_id"
+        facts[index] = replace(facts[index], **{field: "mismatch"})
+    elif mutation == "completion-predates-subject":
+        index = _pick_index(
+            rng,
+            facts,
+            lambda fact: isinstance(fact, CompletionEvent) and fact.subject_object_id is not None,
+        )
+        fact = facts[index]
+        subject = object_records[fact.subject_object_id]
+        facts[index] = replace(fact, timestamp_ps=subject.created_at_ps - 1)
+    elif mutation == "decreasing-subject-time":
+        index = _pick_index(
+            rng,
+            facts,
+            lambda fact: isinstance(fact, CompletionEvent)
+            and fact.phase is EventPhase.QUEUED
+            and fact.subject_object_id is not None,
+        )
+        facts[index] = replace(facts[index], timestamp_ps=facts[index].timestamp_ps - 3)
+    elif mutation == "wrong-completion-queue":
+        index = _pick_index(
+            rng,
+            facts,
+            lambda fact: isinstance(fact, CompletionEvent)
+            and fact.phase is EventPhase.COMPLETED
+            and fact.subject_object_id is not None,
+        )
+        facts[index] = replace(
+            facts[index],
+            resource=ResourceRef(ResourceKind.COMPLETION_QUEUE, "cq:wrong"),
+        )
+    elif mutation in {"duplicate-wqe-completion", "event-after-wqe-completion"}:
+        index = _pick_index(
+            rng,
+            facts,
+            lambda fact: isinstance(fact, CompletionEvent)
+            and fact.phase is EventPhase.COMPLETED
+            and fact.subject_object_id is not None,
+        )
+        completed = facts[index]
+        phase = (
+            EventPhase.COMPLETED
+            if mutation == "duplicate-wqe-completion"
+            else EventPhase.PROGRESS
+        )
+        facts.insert(index + 1, replace(completed, phase=phase, timestamp_ps=completed.timestamp_ps + 1))
+    else:
+        raise AssertionError(f"unknown mutation {mutation}")
+
+    stream = tuple(facts)
+    with pytest.raises((TypeError, ValueError)):
+        validate_bookkeeping_ledger(_ledger(stream))
+    return stream
+
+
+_MUTATIONS = (
+    "unsupported-fact",
+    "boolean-timestamp",
+    "negative-timestamp",
+    "invalid-ref-kind",
+    "invalid-owner",
+    "invalid-scope",
+    "correlation-list",
+    "correlation-duplicate",
+    "boolean-scope-integer",
+    "operation-without-execution",
+    "metadata-list",
+    "metadata-invalid-scalar",
+    "metadata-duplicate",
+    "parent-list",
+    "duplicate-object",
+    "self-parent",
+    "unknown-parent",
+    "wrong-typed-parent",
+    "child-predates-parent",
+    "request-introduction",
+    "causal-parent-disagreement",
+    "wqe-missing-queue",
+    "wqe-multiple-transports",
+    "transport-free-implicit",
+    "physical-transport-none",
+    "invalid-stage",
+    "invalid-stage-phase",
+    "stage-ref-list",
+    "stage-unknown-object",
+    "stage-predates-object",
+    "invalid-completion-phase",
+    "boolean-completed-bytes",
+    "invalid-resource",
+    "invalid-resource-kind",
+    "unknown-subject",
+    "subject-execution-mismatch",
+    "subject-operation-mismatch",
+    "completion-predates-subject",
+    "decreasing-subject-time",
+    "wrong-completion-queue",
+    "duplicate-wqe-completion",
+    "event-after-wqe-completion",
+)
+
+
+@pytest.mark.parametrize("seed", _SEEDS)
+@pytest.mark.parametrize("length", _LENGTHS)
+def test_seeded_valid_append_and_extend_match_full_validator(seed: int, length: int):
+    facts = _valid_fact_stream(seed, length)
+    _assert_append_equivalent(facts)
+    _assert_extend_equivalent(facts, seed + length)
+
+
+@pytest.mark.parametrize("seed", _SEEDS)
+def test_seeded_invalid_injections_match_full_validator(seed: int):
+    for mutation in _MUTATIONS:
+        facts = _mutated_stream(seed, mutation)
+        _assert_append_equivalent(facts)
+        _assert_extend_equivalent(facts, seed + len(mutation))
+
+
+def test_initial_boolean_sequence_rejection_stays_on_reference_validator():
+    stage = StageRecord(
+        ProcessingStage.REQUEST,
+        StagePhase.ENTERED,
+        0,
+        BookkeepingScope(),
+    )
+    ledger = BookkeepingLedger(
+        (BookkeepingEntry(0, stage), BookkeepingEntry(True, stage))
+    )
+    with pytest.raises(ValueError, match="sequence: must be an integer"):
+        RequestBookkeeper(ledger)

--- a/tests/test_bookkeeping_incremental.py
+++ b/tests/test_bookkeeping_incremental.py
@@ -688,6 +688,226 @@ def test_seeded_invalid_injections_match_full_validator(seed: int):
         _assert_extend_equivalent(facts, seed + len(mutation))
 
 
+def _assert_reference_and_incremental_reject(
+    prefix: tuple[object, ...],
+    fact: object,
+    error_type: type[Exception],
+    match: str,
+) -> None:
+    with pytest.raises(error_type, match=match):
+        validate_bookkeeping_ledger(_ledger((*prefix, fact)))
+
+    bookkeeper = RequestBookkeeper(_ledger(prefix))
+    before = bookkeeper.snapshot()
+    with pytest.raises(error_type, match=match):
+        bookkeeper.append(fact)
+    assert bookkeeper.snapshot() == before
+
+
+def test_child_scope_must_inherit_parent_step_index_directly():
+    facts = _valid_fact_stream(7001, 32)
+    index = next(
+        index
+        for index, fact in enumerate(facts)
+        if isinstance(fact, CreatedObjectRecord)
+        and fact.ref.kind is CreatedObjectKind.NCCL_COMMAND
+    )
+    child = facts[index]
+    assert isinstance(child, CreatedObjectRecord)
+    assert child.scope.step_index is not None
+    invalid = replace(
+        child,
+        scope=replace(child.scope, step_index=child.scope.step_index + 1),
+    )
+
+    _assert_reference_and_incremental_reject(
+        facts[:index],
+        invalid,
+        ValueError,
+        "child scope does not inherit parent step_index",
+    )
+
+
+@pytest.mark.parametrize("field", ("parent_refs", "object_refs"))
+def test_reference_tuples_reject_duplicate_refs_directly(field: str):
+    facts = _valid_fact_stream(7002, 32)
+    if field == "parent_refs":
+        index = next(
+            index
+            for index, fact in enumerate(facts)
+            if isinstance(fact, CreatedObjectRecord) and fact.parent_refs
+        )
+        fact = facts[index]
+        assert isinstance(fact, CreatedObjectRecord)
+        invalid = replace(fact, parent_refs=(fact.parent_refs[0], fact.parent_refs[0]))
+    else:
+        index = next(
+            index for index, fact in enumerate(facts) if isinstance(fact, StageRecord)
+        )
+        fact = facts[index]
+        assert isinstance(fact, StageRecord)
+        invalid = replace(fact, object_refs=(fact.object_refs[0], fact.object_refs[0]))
+
+    _assert_reference_and_incremental_reject(
+        facts[:index],
+        invalid,
+        ValueError,
+        "contains duplicate values",
+    )
+
+
+@pytest.mark.parametrize(
+    "queue_kind",
+    (
+        CreatedObjectKind.SEND_QUEUE,
+        CreatedObjectKind.RECEIVE_QUEUE,
+        CreatedObjectKind.COMPLETION_QUEUE,
+    ),
+)
+def test_wqe_rejects_more_than_one_queue_of_each_required_kind(queue_kind):
+    facts = _valid_fact_stream(7003, 32)
+    index = next(
+        index
+        for index, fact in enumerate(facts)
+        if isinstance(fact, CreatedObjectRecord)
+        and fact.ref.kind is CreatedObjectKind.NETWORK_WQE
+    )
+    wqe = facts[index]
+    assert isinstance(wqe, CreatedObjectRecord)
+    extra_queue = _record(queue_kind, f"extra:{queue_kind.value}", 0)
+    prefix = (*facts[:index], extra_queue)
+    invalid = replace(wqe, parent_refs=(*wqe.parent_refs, extra_queue.ref))
+
+    _assert_reference_and_incremental_reject(
+        prefix,
+        invalid,
+        ValueError,
+        "WQE requires exactly one",
+    )
+
+
+@pytest.mark.parametrize(
+    "fact,match",
+    (
+        (
+            _record(CreatedObjectKind.FRAMEWORK_REQUEST, " ", 0),
+            "ref.object_id",
+        ),
+        (
+            CreatedObjectRecord(
+                CreatedObjectRef(CreatedObjectKind.FRAMEWORK_REQUEST, "object:native"),
+                ObjectOwner.FRAMEWORK,
+                0,
+                native_id=" ",
+            ),
+            "native_id",
+        ),
+        (
+            StageRecord(
+                ProcessingStage.REQUEST,
+                StagePhase.ENTERED,
+                0,
+                BookkeepingScope(
+                    correlation=OperationCorrelation(request_ids=(" ",))
+                ),
+            ),
+            "request_ids",
+        ),
+        (
+            StageRecord(
+                ProcessingStage.REQUEST,
+                StagePhase.ENTERED,
+                0,
+                BookkeepingScope(
+                    correlation=OperationCorrelation(batch_id=" ")
+                ),
+            ),
+            "batch_id",
+        ),
+        (
+            StageRecord(
+                ProcessingStage.EXECUTION,
+                StagePhase.ENTERED,
+                0,
+                BookkeepingScope(execution_id=" "),
+            ),
+            "execution_id",
+        ),
+        (
+            StageRecord(
+                ProcessingStage.EXECUTION,
+                StagePhase.ENTERED,
+                0,
+                BookkeepingScope(execution_id="execution", operation_id=" "),
+            ),
+            "operation_id",
+        ),
+        (
+            CompletionEvent(
+                " ",
+                "operation",
+                EventPhase.STARTED,
+                0,
+            ),
+            "execution_id",
+        ),
+        (
+            CompletionEvent(
+                "execution",
+                " ",
+                EventPhase.STARTED,
+                0,
+            ),
+            "operation_id",
+        ),
+        (
+            CompletionEvent(
+                "execution",
+                "operation",
+                EventPhase.STARTED,
+                0,
+                ResourceRef(ResourceKind.NIC_SEND_QUEUE, " "),
+            ),
+            "resource_id",
+        ),
+        (
+            CompletionEvent(
+                "execution",
+                "operation",
+                EventPhase.STARTED,
+                0,
+                subject_object_id=" ",
+            ),
+            "subject_object_id",
+        ),
+        (
+            CreatedObjectRecord(
+                CreatedObjectRef(CreatedObjectKind.FRAMEWORK_REQUEST, "object:metadata"),
+                ObjectOwner.FRAMEWORK,
+                0,
+                metadata=((" ", 1),),
+            ),
+            "metadata",
+        ),
+    ),
+)
+def test_blank_identity_fields_are_rejected_directly(fact: object, match: str):
+    _assert_reference_and_incremental_reject((), fact, ValueError, match)
+
+
+@pytest.mark.parametrize("field", ("layer", "microbatch", "iteration"))
+def test_noninteger_correlation_fields_are_rejected_directly(field: str):
+    correlation = replace(OperationCorrelation(), **{field: "not-an-integer"})
+    fact = StageRecord(
+        ProcessingStage.REQUEST,
+        StagePhase.ENTERED,
+        0,
+        BookkeepingScope(correlation=correlation),
+    )
+
+    _assert_reference_and_incremental_reject((), fact, ValueError, field)
+
+
 def test_initial_boolean_sequence_rejection_stays_on_reference_validator():
     stage = StageRecord(
         ProcessingStage.REQUEST,


### PR DESCRIPTION
Closes CORE-7. RequestBookkeeper.append and extend now validate incrementally with amortized constant-time appends; the full-ledger validator remains the reference for snapshot and wire loads, and after the review-driven consolidation both paths consume one shared per-fact rule engine over a copy-on-write state view, so a future rule edit cannot drift.

Evidence (frozen at d487a69 before implementation): seeded valid and invalid stream families match the reference validator on accept/reject decisions, exception classes, atomic rollback and final ledger state; incremental quadrupling ratios 4.19/4.27/4.06/4.02 within the frozen bound of 6; the reproduced reference path grows 16.5x/16.1x, above the frozen quadratic bound of 8. The batch-width protocol deviation from the frozen sweep is recorded in RESULTS.md. The module doc states the sequential-use contract plainly.

Produced by a Codex worker under orchestrated integration: freeze chronology verified, scaling bounds independently reproduced, hostile correctness review could not construct a divergence, consolidation fix round applied and re-verified. ruff clean; 367 passed, 3 skipped on the merged state.