### PR TITLE
Keep byte-locked study artifacts and GOAL files LF-stable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,5 @@
 examples/gpu_task_mix/*.csv text eol=lf
+examples/nccl_stack_v1/*.csv text eol=lf
+examples/preplay_trace_v1/*.jsonl text eol=lf
+examples/vllm_skeleton_v1/*.csv text eol=lf
+examples/rnic_device_v1/*.csv text eol=lf

--- a/simllm/goal/emitter.py
+++ b/simllm/goal/emitter.py
@@ -88,5 +88,5 @@ class GoalTrace:
 
     def write(self, path: str | Path) -> Path:
         path = Path(path)
-        path.write_text(self.render())
+        path.write_text(self.render(), newline="\n")
         return path


### PR DESCRIPTION
Fixes the Windows CI failures introduced across the wave-1 merges (runs 31385232611 through 31387114085). One root cause, three shapes:

- examples/nccl_stack_v1/results.csv and the preplay jsonl fixtures are byte-compared by tests but were CRLF-converted at Windows checkout; they now carry the same eol=lf attributes the gpu_task_mix artifacts already use (vllm_skeleton_v1 and rnic_device_v1 CSVs included defensively, same class).
- GoalTrace.write rendered GOAL files through platform text mode, so the frozen GOAL SHA-256 diverged on Windows; the writer now pins LF explicitly, which also keeps txt2bin input byte-stable across platforms.

Process note recorded by the integrator: the six wave-1 PRs were merged on local gates without checking the Actions matrix; merges are CI-gated from this PR on.