### PR TITLE
Make the step-sink latent knobs live

### DIFF
--- a/docs/README_PRO.md
+++ b/docs/README_PRO.md
@@ -296,6 +296,7 @@ slices land.
 |---|---|---|---|---|
 | vLLM `Executor.execute_model` RPC surface | CPU | implemented, executor-level `SimExecutor` | [adapters-vllm](modules/adapters-vllm.md) | [m4](../examples/m4/RESULTS.md) |
 | vLLM `Worker` init and step surface | CPU | mirrored skeleton landed behind the entry flag; GPUs-present variant open | [VLLM-13](modules/adapters-vllm.md#open-tasks) | [vllm_skeleton_v1](../examples/vllm_skeleton_v1/RESULTS.md), [m4](../examples/m4/RESULTS.md) |
+| [step_sink_latent_knobs](../examples/step_sink_latent_knobs/RESULTS.md) | The step-sink latent knobs go live: roofline per-layer breakdown and adapter-populated exact sampling | 11 deterministic rows exact including the cumulative-truncation relation and the -32,000 ps exact-sampling TTFT delta; a real vLLM v0.26.0 skeleton run attributes chunked prefill exactly; the default GOAL SHA lock holds; the honest genuine-risk fraction is 63.6 percent after review |
 | vLLM `GPUModelRunner.execute_model` | CPU | skeleton mirror landed, driven by a live engine | [VLLM-13](modules/adapters-vllm.md#open-tasks) | [vllm_skeleton_v1](../examples/vllm_skeleton_v1/RESULTS.md) |
 | vLLM `GroupCoordinator.all_reduce` and peers | CPU | planned | [VLLM-14](modules/adapters-vllm.md#open-tasks) | none yet |
 | SGLang `TpModelWorker.forward_batch_generation` | CPU | implemented, `SimTpModelWorker` | [adapters-sglang](modules/adapters-sglang.md) | live CPU-engine smoke (module doc) |
@@ -319,13 +320,13 @@ One line per module; the linked doc is the source of truth.
 |---|---|---|
 | [core](modules/core.md) | Implemented: virtual clock, step records, execution-graph/completion/result/bookkeeping contracts with strict JSON, serial lowerer, graph-only replay, incremental append validation with the full validator kept as the snapshot and wire reference | CORE-3/4/5/6/8/9/10, BRIDGE-1 |
 | [workload](modules/workload.md) | Partial: Poisson/trace arrivals, fixed/lognormal/trace lengths | WORK-1 (shared prefixes), WORK-2 (bursty/MMPP) |
-| [compute](modules/compute.md) | Implemented: roofline + profile tables, kernel families, dense/MoE geometry, host initiation model, trace-driven GPU service primitive with concurrent compute/memory/NCCL scheduling and A100/H100 bootstrap profiles, plus the audited zero-time NCCL stack skeleton with real-source-verified names | COMP-1/2/4/5/6/7/8/9/10/11/12/13/14/15/16 |
+| [compute](modules/compute.md) | Implemented: roofline + profile tables, kernel families, dense/MoE geometry, host initiation model, trace-driven GPU service primitive with concurrent compute/memory/NCCL scheduling and A100/H100 bootstrap profiles, plus the audited zero-time NCCL stack skeleton with real-source-verified names | COMP-1/2/4/5/6/7/8/9/10/11/12/13/14/15/17 |
 | [placement](modules/placement.md) | Implemented: placement manifest round trip, declared placements, gpu-rank mapping, vLLM extraction; fabric manifest design-only | PLACE-1/2/3 |
 | [traffic](modules/traffic.md) | Implemented: collective patterns, TP step mapping, MoE all-to-all, GOAL renderers for steps and execution graphs | TRAF-2/3/4/5/6/7/8/9/10 |
 | [goal](modules/goal.md) | Implemented: GOAL trace + txt2bin helper | none |
 | [preplay](modules/preplay.md) | First slice implemented: CPU inference runner and strict trace artifact with live MoE routing capture on the pinned granite model (prefill and decode routing, input-token attribution); the replay join, adapter replay and traffic supply remain open | PLAY-2/3/4/5/6 |
 | [backends](modules/backends.md) | Implemented: htsim invocation/parsing with per-layer, exact-sampling and GOAL-padding step-sink precision, plus native C++ RNIC SQ/CQ, network-port and shared PCIe transaction slices; the modular device entry point is landed and htsim composition remains open | BACK-2/8-9/11-17/19-20; backend-repo HTSIM-1/2/4-9, ATLAHS-1 |
-| [adapters-vllm](modules/adapters-vllm.md) | Implemented: SimExecutor on pinned v0.26.0, full RPC surface, step-record streaming, placement exporter, live tp=8 closed loop, plus the flagged SimWorker skeleton through the worker-cls seam with a live engine smoke | VLLM-3 through VLLM-16 |
+| [adapters-vllm](modules/adapters-vllm.md) | Implemented: SimExecutor on pinned v0.26.0, full RPC surface, step-record streaming, placement exporter, live tp=8 closed loop and exact sample attribution, plus the flagged SimWorker skeleton through the worker-cls seam with a live engine smoke | VLLM-3 through VLLM-14 plus VLLM-16 |
 | [adapters-sglang](modules/adapters-sglang.md) | Implemented: SimTpModelWorker via plugin entry point at pinned commit, live CPU-engine smoke | SGL-3 through SGL-12 |
 
 ## Study index

--- a/docs/modules/adapters-vllm.md
+++ b/docs/modules/adapters-vllm.md
@@ -66,9 +66,12 @@ the three abstract methods (`_init_executor`, `collective_rpc`,
   The scheduler sets that signal before executor dispatch at
   `vllm/v1/core/sched/scheduler.py:1236-1259`; both refusals are VLLM-8;
 - translates each step into a `simllm.core.StepRecord` (phase, new tokens,
-  prefix-cache hit at admission, context length), hands it to an injected
-  sink, and accumulates it on `step_records` for the offline GOAL emission
-  (VLLM-9). An empty-batch step that carries completions is recorded as a
+  prefix-cache hit at admission, context length, and exact `num_sampled`),
+  hands it to an injected sink, and accumulates it on `step_records` for the
+  offline GOAL emission (VLLM-9). The exact count is the sum of the same
+  `produces_token` flags used to fabricate `ModelRunnerOutput` rows, including
+  zero for a mid-prompt chunk and a drain record. An empty-batch step that
+  carries completions is recorded as a
   zero-cost drain record rather than dropped: under the `EngineCore` busy
   loop (`vllm serve`) the scheduler stays live while its finished set is
   non-empty, so the last requests' completions arrive on exactly such a
@@ -267,6 +270,17 @@ Exactly one strengthened smoke ran in the review round. It reached
 1660 Ti despite masking, so VLLM-16 keeps the genuinely GPU-invisible version
 of this asserted smoke open.
 
+VLLM-15 is complete. Expectations were frozen at commit `25d098c` before the
+implementation and runs. The
+[latent-knob study](../../examples/step_sink_latent_knobs/RESULTS.md) covers
+mid-prompt and prompt-completing chunks, prefix-cache completion, decode, and
+attach-mid-flight translation. Every record count equals the nonempty
+fabricated output rows. The adapter-produced mixed batch reduces live fluid
+TTFT by the frozen 32,000 ps relative to the absent-field bypass, and a real
+vLLM v0.26.0 chunked-prefill smoke emits sample counts `(0, 1, 1)` for
+scheduled-token counts `(2, 1, 1)`. Manually constructed records may still
+omit the optional field; v1 readers and that compatibility path are unchanged.
+
 ## Open tasks
 
 - VLLM-3: sim-native metrics export via a `vllm.stat_logger_plugins` stat
@@ -370,9 +384,3 @@ of this asserted smoke open.
   expected `atlahs-closed-loop-step-v1` records. The 2026-08-10 host does not
   close this task because vLLM identified a GTX 1660 Ti despite
   `CUDA_VISIBLE_DEVICES=`.
-- VLLM-15 (Precision; P1; S): populate `StepRecord.num_sampled` from the
-  translator's existing exact `produces_token` flags. Cover mid-prompt and
-  prompt-completing chunked prefill, prefix-cache completion, decode and the
-  attach-mid-flight fallback. The emitted count must equal the fabricated
-  `ModelRunnerOutput` rows that actually sample; an absent field remains the
-  explicit compatibility path.

--- a/docs/modules/backends.md
+++ b/docs/modules/backends.md
@@ -260,9 +260,11 @@ optional exact provider layer breakdown, an optional exact step sample count
 and an explicit GOAL-rank count while preserving the default M4 and CORE-2
 GOAL bytes. The precision study matched all four unequal-layer closed forms,
 both sample-attribution relations and the default digest exactly. The shipped
-providers still use the byte-identical even split; COMP-16 owns real
-per-layer values, with the roofline provider first and profile tables after
-COMP-6 supplies per-layer kernel shapes. The study's
+roofline provider now supplies real per-layer values when its breakdown is
+enabled. COMP-17 owns the remaining profile-table and trace-calibrated
+breakdowns after COMP-6 supplies per-layer kernel shapes. The serial replay
+lowerer uses the same optional exact sample count as the live sink and retains
+the scheduled-row fallback when the field is absent. The study's
 registered fluid-plus-topology command was invalid because htsim accepts
 physical topology files only for physical profiles. The expectation was not
 rewritten: post-specified checks instead showed 0 ps residual and exact

--- a/docs/modules/compute.md
+++ b/docs/modules/compute.md
@@ -10,6 +10,9 @@ per serving step.
 
 ## Interface
 
+- `KernelSpec`: fused work plus its stable shape key. A fused transformer step
+  also carries the exact `family_kernels` projection used to apportion work;
+  ordinary kernels leave it empty.
 - `ComputeProvider.estimate(kernel: KernelSpec, gpu: GpuSpec) -> DurationEstimate`
 - `ComputeProvider.estimate_layers(kernel, gpu, num_layers)`: optional ordered
   layer estimates for the same fused kernel. The default returns `None` and
@@ -30,7 +33,12 @@ per serving step.
   library never reads the clock).
 - `RooflineProvider`: analytical `max(flops/peak, bytes/bw)` with an
   efficiency derate; classifies compute- vs memory-bound from the kernel
-  configuration alone.
+  configuration alone. `enable_layer_breakdown=True` apportions the fused
+  duration using family work on the selected roof. Repeated transformer
+  families divide evenly and the complete LM-head family belongs to the last
+  layer. Cumulative integer boundaries guarantee that the nonnegative layer
+  durations sum to the scalar estimate exactly. The default is disabled and
+  retains the scalar compatibility path byte for byte.
 - `TraceCalibratedGpuProvider`: validates and replays its exact trace catalog
   once at construction, then serves O(1) cached estimates behind the existing
   `ComputeProvider` interface. `gpu_model_artifact_to_profile_table` compiles
@@ -292,6 +300,15 @@ landed with the same slice and is exercised by the examples/m5 studies
 together with the MoE traffic mapping
 ([traffic](traffic.md), [M5 results](../../examples/m5/RESULTS.md)).
 
+COMP-16 is complete. The roofline provider now supplies an explicit opt-in
+layer breakdown from the fused step's exact family projection. The
+[latent-knob study](../../examples/step_sink_latent_knobs/RESULTS.md) sweeps
+two layer counts and two TP widths on the live fluid step sink: every enabled
+row moves first-token latency later by the frozen 1,000 ps with zero residual,
+while the default path retains the historical GOAL SHA-256 exactly. Profile
+table and trace-calibrated layer estimates still require COMP-6 and remain
+open as COMP-17.
+
 The COMP-15 first slice is implemented in `simllm.compute.nccl_stack`. Its
 function identities were audited against NVIDIA NCCL release `v2.30.7-1`,
 commit `73cf112295c33aee2b895f329f592f2a9b4b0f97`. It adds name-mirrored
@@ -500,12 +517,12 @@ Strictly offline; the step loop never invokes a cycle-level simulator.
   must connect to this stack. Function and event identities must remain stable
   so later captures, timing calibration and adapter traces align with this
   first slice.
-- COMP-16 (Precision; P1; M): populate `ComputeProvider.estimate_layers` in
-  the live providers so the step sink can replace its current even per-layer
-  split with real layer durations. Implement the roofline breakdown first,
-  with nonnegative layer estimates whose exact sum equals the fused estimate;
-  add profile-table and trace-calibrated breakdowns after COMP-6 supplies the
-  per-layer kernel shapes seen by captures. Sweep layer count and TP width and
-  require the rendered cumulative-nanosecond calc values to match the provider
-  breakdown under the registered truncation rule. Providers without the
-  breakdown must retain the byte-identical even-split fallback.
+- COMP-17 (Precision; P1; M): after COMP-6 supplies per-invocation captured
+  shapes, populate `estimate_layers` for `ProfileTableProvider` and
+  `TraceCalibratedGpuProvider`. The current surrogate is the step sink's even
+  split whenever these calibrated providers are selected. Use measured
+  per-layer kernel durations as the identifying observable, reconcile their
+  integer sum to the existing fused estimate exactly, and require every
+  rendered cumulative boundary to remain within the declared capture
+  uncertainty. The explicit no-breakdown path must retain the accepted GOAL
+  bytes and TTFT exactly.

--- a/docs/modules/compute.md
+++ b/docs/modules/compute.md
@@ -520,9 +520,12 @@ Strictly offline; the step loop never invokes a cycle-level simulator.
 - COMP-17 (Precision; P1; M): after COMP-6 supplies per-invocation captured
   shapes, populate `estimate_layers` for `ProfileTableProvider` and
   `TraceCalibratedGpuProvider`. The current surrogate is the step sink's even
-  split whenever these calibrated providers are selected. Use measured
-  per-layer kernel durations as the identifying observable, reconcile their
-  integer sum to the existing fused estimate exactly, and require every
-  rendered cumulative boundary to remain within the declared capture
-  uncertainty. The explicit no-breakdown path must retain the accepted GOAL
-  bytes and TTFT exactly.
+  split whenever these calibrated providers are selected. Use a real model's
+  measured per-layer profile, or a published layer-heterogeneity reference,
+  as the fidelity anchor and calibration target. Acceptance requires the
+  modeled normalized layer-to-layer shape to match that anchor within its
+  declared measurement uncertainty. Use measured per-layer kernel durations
+  as the identifying observable, reconcile their integer sum to the existing
+  fused estimate exactly, and require every rendered cumulative boundary to
+  remain within the declared capture uncertainty. The explicit no-breakdown
+  path must retain the accepted GOAL bytes and TTFT exactly.

--- a/examples/step_sink_latent_knobs/RESULTS.md
+++ b/examples/step_sink_latent_knobs/RESULTS.md
@@ -17,6 +17,13 @@ expectations`). It precedes every implementation edit and every result-producing
 run. Its commit message records that the working tree contained only the
 expectations file and no implementation file.
 
+The dry-run harness existed untracked at freeze time and encodes only the
+frozen literals; the freeze commit's file-only claim refers to tracked
+content. The review-triggered amendment is frozen separately in
+`396fd9e32df363cd2367f6ffc072ab49966bb20e` (`Freeze the review regression
+expectations`). It precedes the replay, quiescence, and post-specified shape
+regression edits.
+
 Before the freeze, both registered runner modes passed `--check-only`. The
 output directory remained absent, so those dry runs produced no measured
 values or result artifacts. The vLLM source audit and its installed-source
@@ -52,8 +59,9 @@ env PYTHONPATH=. VLLM_ENABLE_V1_MULTIPROCESSING=0 \
   --out /data3/yifeng/simllm-dev/wave2-runs/comp16_latent_knobs
 ```
 
-Every successful backend row reported `physical_quiescence=verified`; the
-backend wrapper rejects a run whose completion ledger is not quiescent.
+Every successful backend row emitted `physical_quiescence=True`, copied from
+the wrapper-reported `RnicRunResult.quiescent` value. The backend wrapper
+rejects a run whose completion ledger is not quiescent.
 
 ## Evidence accounting
 
@@ -66,13 +74,15 @@ Evidence classes remain separate.
 | Check B1 adapter-to-TTFT relation | 1/1 pass | Scored behavioral relation |
 | Check B2 attribution instances | 5/5 pass | Scored behavioral instances |
 | Check C real vLLM relation | 1/1 pass | Scored live integration relation |
+| Post-specified shape regression | 1/1 pass | Unscored review regression |
 | Check D and conservation guards | pass | Fatal, unscored structural invariants |
-| Repository unit and integration tests | 455/455 pass | Separate test executable |
+| Repository unit and integration tests | 456/456 pass | Separate test executable |
 | Pinned-vLLM adapter tests | 35/35 applicable pass | Separate external-runtime test executable |
 
 The scored headline is 11 of 11 passing relations or rows. Configuration
 echoes, exact-sum conservation, byte identity, schema behavior, source pin,
-and quiescence are not added to that denominator.
+quiescence, and the post-specified shape regression are not added to that
+denominator.
 
 ## Check A: roofline family split
 
@@ -93,6 +103,24 @@ All ranks rendered the listed calc sequence. Flow counts were exactly 16, 96,
 than two. At fixed layer count, TP width four had greater TTFT than width two.
 The final allreduce boundary moved later by exactly 1,000 ps in every cell, as
 registered.
+
+The scored Check A relation is the cumulative-truncation rule that produces
+that `+1,000 ps`. The exact unequal layer vectors and the folded direction
+assertions are structural guards; they do not score the realism or shape
+sensitivity of the breakdown.
+
+### Post-specified shape-sensitive regression
+
+The review-triggered regression isolates a value that depends on LM-head
+placement. In the two-layer, TP-width-two cell, the rendered final-layer calc
+service is `21 ns` with the LM head in the last layer and `17 ns` under the
+even split. The next final-layer allreduce boundary, measured from entry to
+that layer, therefore moves by exactly `+4 ns`, with zero residual. The
+completion ledgers independently measured `17,000 ps` and `21,000 ps` between
+the preceding layer's final flow completion and the final layer's first flow
+start. Both GOAL programs retained the separately frozen `+1,000 ps` absolute
+TTFT relation and reported wrapper quiescence. This check is post-specified
+and is not added to the 11-row scored denominator.
 
 The decision-relevant guard also passed: every family projection conserves
 both fused flops and bytes, every returned duration is nonnegative, and each
@@ -128,6 +156,13 @@ rows exactly:
 
 The equality to fabricated rows supports keeping attribution at the
 translator rather than moving it to a post-fabrication output seam.
+
+The review regression also lowered this exact B1 record through the serial
+replay path. Live and replay GOAL text matched byte for byte at `440 ns` per
+layer. Removing `num_sampled` retained the historical `456 ns` fallback and
+replay SHA-256
+`7087db6780f7e34f5a559a6505eeccc15d984c7b478cd8f0bc5838053825d4b6`.
+This replay check is post-specified and unscored.
 
 ## Check C: pinned live vLLM smoke
 
@@ -168,11 +203,11 @@ plausibly have failed, not which checks happened to fail.
 
 | Family | Plausibly at risk | Scored total | Fraction | Why it could fail |
 |---|---:|---:|---:|---|
-| A, roofline to TTFT | 4 | 4 | 100% | Summing per-family roofline maxima, rounding layers independently, or placing the LM head evenly would change boundaries or violate the closed form. |
+| A, cumulative truncation to TTFT | 4 | 4 | 100% | Independent flooring instead of cumulative boundaries could change the registered `+1,000 ps`; these rows do not score the breakdown shape. |
 | B1, adapter to TTFT | 1 | 1 | 100% | Leaving the record field absent would retain two samples and produce a zero TTFT delta instead of `-32,000 ps`. |
-| B2, attribution matrix | 5 | 5 | 100% | Prompt completion, cached admission, and attach-mid-flight state use different translator branches; a blanket scheduled-row count would fail at least the mid-prompt instance. |
+| B2, attribution matrix | 1 | 5 | 20% | Only the mid-prompt row distinguishes exact attribution from a blanket scheduled-row count; the other four all expect one sample from one row. |
 | C, real vLLM | 1 | 1 | 100% | The real worker or stream path could bypass the edited construction site, or vLLM could schedule a different chunk shape. |
-| Overall | 11 | 11 | 100% | Every scored row exercised behavior absent or materially different before this change. |
+| Overall | 7 | 11 | 63.6% | Four cumulative-truncation rows, B1, one discriminating B2 row, and the live relation could plausibly fail independently of structural guards. |
 
 ## Repository gates
 
@@ -187,15 +222,17 @@ $ SIMLLM_HTSIM_RNIC=... SIMLLM_TXT2BIN=... .venv/bin/pytest -q
 ........................................................................ [ 31%]
 ........................................................................ [ 47%]
 ........................................................................ [ 63%]
-........................................................................ [ 79%]
+........................................................................ [ 78%]
 ........................................................................ [ 94%]
-.......................                                                  [100%]
-455 passed in 13.76s
+........................                                                 [100%]
+456 passed in 13.70s
 ```
 
 The pinned-vLLM adapter test executable separately reported 35 passed and two
-absence-only skips in 7.14 seconds. No C++ source changed, so no native CMake
-or CTest gate applies.
+absence-only skips in 7.14 seconds. The review-touched lowerer and sink suite
+reported 32 passed in 0.35 seconds under `.venv` and 32 passed in 0.28 seconds
+under the pinned-vLLM environment. No C++ source changed, so no native CMake or
+CTest gate applies.
 
 ## Deliberate omissions and residual work
 

--- a/examples/step_sink_latent_knobs/RESULTS.md
+++ b/examples/step_sink_latent_knobs/RESULTS.md
@@ -1,0 +1,206 @@
+# Step-sink latent knobs: results
+
+Date: 2026-08-10
+
+COMP-16 and VLLM-15 are complete. The enabled roofline family split changed
+first-token latency by the frozen `+1,000 ps` in all four fluid cells. The
+vLLM translator's exact sample count changed the mixed chunked-prefill cell by
+the frozen `-32,000 ps`. Every exact residual is zero, the real vLLM smoke
+passed, and the explicit compatibility path retained its historical GOAL
+digest.
+
+## Expectations and chronology
+
+The admissible expectations-only commit is
+`25d098c997f078eb92dcf155cd36c44d9d6b2313` (`Freeze the latent knob
+expectations`). It precedes every implementation edit and every result-producing
+run. Its commit message records that the working tree contained only the
+expectations file and no implementation file.
+
+Before the freeze, both registered runner modes passed `--check-only`. The
+output directory remained absent, so those dry runs produced no measured
+values or result artifacts. The vLLM source audit and its installed-source
+digests are frozen in [expectations.md](expectations.md).
+
+Raw GOAL, binary, completion-ledger, JSONL, and summary artifacts are under
+`/data3/yifeng/simllm-dev/wave2-runs/comp16_latent_knobs/`. The directory has
+36 files totaling 272 KiB. None is Git content.
+
+## Reproduction
+
+Deterministic provider, adapter, backend, and compatibility checks:
+
+```bash
+SIMLLM_HTSIM_RNIC=/data3/yifeng/simllm-dev/build-htsim/datacenter/htsim_rnic \
+SIMLLM_TXT2BIN=/data3/yifeng/simllm-dev/tools/txt2bin.prebuilt \
+.venv/bin/python examples/step_sink_latent_knobs/run_study.py \
+  --mode deterministic \
+  --out /data3/yifeng/simllm-dev/wave2-runs/comp16_latent_knobs
+```
+
+Pinned external-runtime smoke:
+
+```bash
+env PYTHONPATH=. VLLM_ENABLE_V1_MULTIPROCESSING=0 \
+  VLLM_USE_V2_MODEL_RUNNER=0 SIMLLM_VLLM_WORKER_MODE=skeleton \
+  SIMLLM_VLLM_MODE=virtual HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 \
+  HF_HOME=/home/yifeng/packages/vllm-rnic-capture/hf-cache \
+  CUDA_VISIBLE_DEVICES= \
+  /data3/yifeng/simllm-dev/venv-vllm/bin/python \
+  examples/step_sink_latent_knobs/run_study.py \
+  --mode live-vllm \
+  --out /data3/yifeng/simllm-dev/wave2-runs/comp16_latent_knobs
+```
+
+Every successful backend row reported `physical_quiescence=verified`; the
+backend wrapper rejects a run whose completion ledger is not quiescent.
+
+## Evidence accounting
+
+Evidence classes remain separate.
+
+| Evidence class | Result | Scored meaning |
+|---|---:|---|
+| Run configurations | 4 roofline cells plus fixed adapter and live cells | Unscored inputs |
+| Check A exact end-to-end rows | 4/4 pass | Scored behavioral rows |
+| Check B1 adapter-to-TTFT relation | 1/1 pass | Scored behavioral relation |
+| Check B2 attribution instances | 5/5 pass | Scored behavioral instances |
+| Check C real vLLM relation | 1/1 pass | Scored live integration relation |
+| Check D and conservation guards | pass | Fatal, unscored structural invariants |
+| Repository unit and integration tests | 455/455 pass | Separate test executable |
+| Pinned-vLLM adapter tests | 35/35 applicable pass | Separate external-runtime test executable |
+
+The scored headline is 11 of 11 passing relations or rows. Configuration
+echoes, exact-sum conservation, byte identity, schema behavior, source pin,
+and quiescence are not added to that denominator.
+
+## Check A: roofline family split
+
+Both frozen shapes were memory-bound. The provider apportioned fused service
+using bytes from the exact family projection, divided all repeated families
+over the transformer layers, and assigned the LM-head family to the last
+layer. Integer cumulative boundaries preserved the fused estimate exactly.
+
+| layers | TP width | layer duration ps | disabled calc ns | enabled calc ns | disabled TTFT ps | enabled TTFT ps | delta ps | residual ps |
+|---:|---:|---|---|---|---:|---:|---:|---:|
+| 2 | 2 | 14,811; 20,663 | 17; 17 | 14; 21 | 16,044,240 | 16,045,240 | +1,000 | 0 |
+| 2 | 4 | 14,811; 20,663 | 17; 17 | 14; 21 | 48,049,360 | 48,050,360 | +1,000 | 0 |
+| 4 | 2 | 14,811; 14,811; 14,812; 20,663 | 16; 16; 16; 16 | 14; 15; 15; 21 | 32,084,480 | 32,085,480 | +1,000 | 0 |
+| 4 | 4 | 14,811; 14,811; 14,812; 20,663 | 16; 16; 16; 16 | 14; 15; 15; 21 | 96,094,720 | 96,095,720 | +1,000 | 0 |
+
+All ranks rendered the listed calc sequence. Flow counts were exactly 16, 96,
+32, and 192 in table order. At fixed TP width, four layers had greater TTFT
+than two. At fixed layer count, TP width four had greater TTFT than width two.
+The final allreduce boundary moved later by exactly 1,000 ps in every cell, as
+registered.
+
+The decision-relevant guard also passed: every family projection conserves
+both fused flops and bytes, every returned duration is nonnegative, and each
+layer vector sums to the scalar estimate exactly. It remains fatal and
+unscored rather than being counted as another behavioral pass. The observed
+evidence therefore supports the existing `estimate_layers` contract; no
+redesign to a separate layer-work object is needed for the roofline path.
+
+## Check B: exact sample attribution
+
+The mixed scheduler-shaped input went through the actual vLLM translator. Its
+mid-prompt request did not sample, its attached decode request did, and the
+produced record carried `num_sampled=1`. Removing only that optional field
+created the compatibility comparison.
+
+| quantity | absent-field bypass | adapter exact field | exact minus bypass | frozen delta | residual |
+|---|---:|---:|---:|---:|---:|
+| sample count | 2 | 1 | -1 | -1 | 0 |
+| fused estimate ps | 912,896 | 880,128 | -32,768 | -32,768 | 0 |
+| rendered calc ns per layer | 456 | 440 | -16 | -16 | 0 |
+| JCT/TTFT ps | 16,963,200 | 16,931,200 | -32,000 | -32,000 | 0 |
+
+The five attribution instances also matched the nonempty fabricated output
+rows exactly:
+
+| case | scheduled rows | record samples | output rows | residual |
+|---|---:|---:|---:|---:|
+| mid-prompt chunk | 1 | 0 | 0 | 0 |
+| prompt-completing chunk after prefix hit | 1 | 1 | 1 | 0 |
+| prefix-cache completion on admission | 1 | 1 | 1 | 0 |
+| decode | 1 | 1 | 1 | 0 |
+| attach-mid-flight fallback | 1 | 1 | 1 | 0 |
+
+The equality to fabricated rows supports keeping attribution at the
+translator rather than moving it to a post-fabrication output seam.
+
+## Check C: pinned live vLLM smoke
+
+The scored external-runtime run used vLLM v0.26.0, the real in-process engine,
+the dotted `SimWorker`, a `SimModelRunner`, a two-token scheduling budget, one
+explicit three-token prompt, and two requested outputs. It observed:
+
+```text
+scheduled_tokens=(2, 1, 1)
+exact_samples=(0, 1, 1)
+sampled_token_ids=(24577, 24577)
+record_count=3
+```
+
+The exact sample counts sum to the two live generated tokens. This is scored
+integration evidence because vLLM could have ignored the budget, selected a
+different worker path, or exposed an attribution mismatch. The host still
+identified a GTX 1660 Ti after `CUDA_VISIBLE_DEVICES=`; this run does not
+claim GPU invisibility and does not close VLLM-16.
+
+## Check D: compatibility and structural guards
+
+The default provider still returns no layer breakdown. Its sink-generated
+GOAL retained SHA-256
+`f8aade109ba8e3a581b7d965b3a0c76c1247016a1e37491fa84efbbf377677a5`
+and the 12,030 ns even layer value exactly. An ordinary kernel with no family
+metadata returns no breakdown even when the provider flag is enabled, and a
+nonconserving family projection is rejected.
+
+An absent `num_sampled` field remains absent on the wire and round-trips
+through the v1 reader; a present zero remains present. These guards all
+passed. They are fatal but unscored.
+
+## Genuine-risk fraction
+
+This estimate asks which scored relations a competent implementation could
+plausibly have failed, not which checks happened to fail.
+
+| Family | Plausibly at risk | Scored total | Fraction | Why it could fail |
+|---|---:|---:|---:|---|
+| A, roofline to TTFT | 4 | 4 | 100% | Summing per-family roofline maxima, rounding layers independently, or placing the LM head evenly would change boundaries or violate the closed form. |
+| B1, adapter to TTFT | 1 | 1 | 100% | Leaving the record field absent would retain two samples and produce a zero TTFT delta instead of `-32,000 ps`. |
+| B2, attribution matrix | 5 | 5 | 100% | Prompt completion, cached admission, and attach-mid-flight state use different translator branches; a blanket scheduled-row count would fail at least the mid-prompt instance. |
+| C, real vLLM | 1 | 1 | 100% | The real worker or stream path could bypass the edited construction site, or vLLM could schedule a different chunk shape. |
+| Overall | 11 | 11 | 100% | Every scored row exercised behavior absent or materially different before this change. |
+
+## Repository gates
+
+```text
+$ .venv/bin/ruff check .
+All checks passed!
+```
+
+```text
+$ SIMLLM_HTSIM_RNIC=... SIMLLM_TXT2BIN=... .venv/bin/pytest -q
+........................................................................ [ 15%]
+........................................................................ [ 31%]
+........................................................................ [ 47%]
+........................................................................ [ 63%]
+........................................................................ [ 79%]
+........................................................................ [ 94%]
+.......................                                                  [100%]
+455 passed in 13.76s
+```
+
+The pinned-vLLM adapter test executable separately reported 35 passed and two
+absence-only skips in 7.14 seconds. No C++ source changed, so no native CMake
+or CTest gate applies.
+
+## Deliberate omissions and residual work
+
+Profile-table and trace-calibrated per-layer estimates remain COMP-17 after
+COMP-6 supplies captured per-invocation shapes. Those providers keep the
+accepted no-breakdown path. SGLang sample-count attribution remains SGL-12;
+this slice deliberately did not touch that adapter. VLLM-16 remains open for
+the equivalent worker smoke on a genuinely GPU-invisible host.

--- a/examples/step_sink_latent_knobs/expectations.md
+++ b/examples/step_sink_latent_knobs/expectations.md
@@ -1,0 +1,257 @@
+# Step-sink latent knobs: pre-registered expectations
+
+Written and frozen before the COMP-16 and VLLM-15 implementation and before
+any run of this study. The immutable pre-change reference is SimLLM commit
+`6aa3a76`. No value below is fitted to an implementation or study result.
+
+Raw outputs belong under
+`/data3/yifeng/simllm-dev/wave2-runs/comp16_latent_knobs/`. They are not Git
+content.
+
+## Freeze audit and registered commands
+
+Both registered runner modes were executed with `--check-only` before this
+file was frozen. Check-only mode parses the complete command, validates its
+input paths and version pin, does not construct a provider, adapter, sink, or
+vLLM engine, and does not create the output directory or any result file.
+
+Deterministic study:
+
+```bash
+SIMLLM_HTSIM_RNIC=/data3/yifeng/simllm-dev/build-htsim/datacenter/htsim_rnic \
+SIMLLM_TXT2BIN=/data3/yifeng/simllm-dev/tools/txt2bin.prebuilt \
+.venv/bin/python examples/step_sink_latent_knobs/run_study.py \
+  --mode deterministic \
+  --out /data3/yifeng/simllm-dev/wave2-runs/comp16_latent_knobs
+```
+
+Pinned-runtime smoke:
+
+```bash
+env PYTHONPATH=. VLLM_ENABLE_V1_MULTIPROCESSING=0 \
+  VLLM_USE_V2_MODEL_RUNNER=0 SIMLLM_VLLM_WORKER_MODE=skeleton \
+  SIMLLM_VLLM_MODE=virtual HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 \
+  HF_HOME=/home/yifeng/packages/vllm-rnic-capture/hf-cache \
+  CUDA_VISIBLE_DEVICES= \
+  /data3/yifeng/simllm-dev/venv-vllm/bin/python \
+  examples/step_sink_latent_knobs/run_study.py \
+  --mode live-vllm \
+  --out /data3/yifeng/simllm-dev/wave2-runs/comp16_latent_knobs
+```
+
+The dry runs used these exact commands with `--check-only` appended.
+
+## External-source audit before freeze
+
+The adapter expectation mirrors vLLM, so its source was audited before this
+freeze. SimLLM pins vLLM `0.26.0` at
+`simllm/adapters/vllm/_version.py:8-9`. The installed pinned sources had these
+digests during the audit:
+
+| vLLM v0.26.0 source | SHA-256 | Audited lines and meaning |
+|---|---|---|
+| `vllm/v1/core/sched/scheduler.py` | `2ed2a550b6558b2495eda845a97ae38bcf0225027b9e25fbf00fc3880c1d3941` | `502-510`: cap each request's scheduled work by the token budget; `1246-1262`: add scheduled tokens to the computed count and classify an unfinished prefill chunk; `1670-1673`: read the sampled-token row by request index. |
+| `vllm/v1/outputs.py` | `1e87bf44162452c1908d3a5003685937dbdc56f5634e35e11ed7b6a5322a1c15` | `231-244`: `ModelRunnerOutput.sampled_token_ids` has one variable-length generated-token list per request. |
+| `vllm/inputs/llm.py` | audited from the same installed v0.26.0 package | `106-113`: `TokensPrompt.prompt_token_ids` accepts an explicit token-id list. |
+
+The live smoke therefore supplies three explicit prompt token IDs rather than
+depending on tokenizer output. With a token budget of two, the source-backed
+schedule is a two-token unfinished prefill, a one-token prompt-completing
+prefill, then one decode step for the second requested output token. The
+expected exact sample-count sequence is `(0, 1, 1)`.
+
+The compute matrix uses `GPU_ENVELOPES["b100"]` from pre-change SimLLM commit
+`6aa3a76`, `simllm/compute/transformer.py:35-41`, as a declared model input:
+`1.8e15` FLOP/s and `8.0e12` byte/s. It does not assert that these internal
+envelope values are an independently validated hardware specification.
+
+## Evidence classes
+
+- Check A has four scored exact analytical rows over layer count and TP width.
+- Check B1 is one scored adapter-to-TTFT relation. Check B2 has five scored
+  sample-attribution instances.
+- Check C is one scored live vLLM v0.26.0 relation.
+- Check D and every conservation, schema, byte-lock, and invalid-input check
+  are fatal structural guards. They are unscored and do not increase a
+  behavioral denominator.
+- Run configurations, provider outputs repeated from the configured inputs,
+  and source-version echoes are unscored.
+
+No author-defined call or event sequence is scored.
+
+## Check A: roofline family split reaches first-token latency
+
+The matrix varies transformer layer count `L` in `{2, 4}` and TP width `W` in
+`{2, 4}`. Every cell schedules one decode token at post-step context four
+with exact sample count one. Per-rank geometry is hidden size 64,
+intermediate size 128, four attention and KV heads of width 16, vocabulary
+size 256, and two-byte elements. The provider is
+`RooflineProvider(efficiency=0.7)`. The backend is `rnic-nn-fluid` at 400
+Gbit/s, and host initiation is zero.
+
+The scalar roofline remains
+
+```text
+E = floor(10^12 * max(flops / (peak_flops * 0.7),
+                      bytes / (mem_bandwidth * 0.7))).
+```
+
+Both registered shapes are memory-bound. The family weights are therefore
+the bytes of the existing `step_kernels` decomposition. All families except
+`lm_head` are divided equally over `L` transformer layers. The complete
+`lm_head` family, including its sampling projection, is added to the last
+layer. If `q_i` is the resulting nonnegative layer weight, integer layer
+boundaries are
+
+```text
+p_i = floor(E * sum(q_0 .. q_i) / sum(q_0 .. q_(L-1)))
+d_0 = p_0
+d_i = p_i - p_(i-1)
+p_(L-1) = E exactly
+```
+
+The final assignment is explicit, so the returned nonnegative durations sum
+to the scalar estimate exactly despite integer rounding. GOAL then applies
+its already accepted cumulative picosecond-to-nanosecond rule:
+
+```text
+c_0 = floor(d_0 / 1000)
+c_i = floor(sum(d_0 .. d_i) / 1000)
+      - floor(sum(d_0 .. d_(i-1)) / 1000).
+```
+
+The frozen provider and rendering values are:
+
+| L | E ps | fused bound | non-head family bytes | LM-head bytes | layer duration ps | enabled calc ns | disabled calc ns per layer |
+|---:|---:|---|---:|---:|---|---|---:|
+| 2 | 35,474 | memory | 165,888 | 32,768 | 14,811; 20,663 | 14; 21 | 17 |
+| 4 | 65,097 | memory | 331,776 | 32,768 | 14,811; 14,811; 14,812; 20,663 | 14; 15; 15; 21 | 16 |
+
+Each layer's two 128-byte tensor-parallel ring allreduces remain serial. With
+`P = 2,000,000 ps`, 20 ps per payload byte, and exact chunk `128/W`, the
+closed forms are
+
+```text
+N(L, W) = 2L * 2(W-1) * ((128/W) * 20 + P)
+J_disabled = N(L, W) + 1000L * floor(E / (1000L))
+J_enabled  = N(L, W) + 1000 * floor(E / 1000).
+```
+
+This is the first scheduled step, so its `StepResult.step_latency_ps`, JCT,
+and TTFT are the same quantity. The registered end-to-end rows are:
+
+| L | W | disabled JCT/TTFT ps | enabled JCT/TTFT ps | signed delta ps | flows |
+|---:|---:|---:|---:|---:|---:|
+| 2 | 2 | 16,044,240 | 16,045,240 | +1,000 | 16 |
+| 2 | 4 | 48,049,360 | 48,050,360 | +1,000 | 96 |
+| 4 | 2 | 32,084,480 | 32,085,480 | +1,000 | 32 |
+| 4 | 4 | 96,094,720 | 96,095,720 | +1,000 | 192 |
+
+Enabling the split moves work into the last layer and preserves one more
+whole nanosecond than the independently truncated even split. The final
+allreduce boundary and TTFT must therefore move later by exactly 1,000 ps in
+all four cells. Every measured residual against the closed form must be zero.
+At fixed `W`, increasing `L` increases TTFT. At fixed `L`, increasing `W`
+increases TTFT.
+
+This relation is decision-relevant. If the selected-resource family weights
+do not conserve the fused work, or if any returned layer vector cannot be
+nonnegative and sum to `E` exactly, the `estimate_layers(kernel, gpu,
+num_layers)` contract is insufficient. The design decision would change to
+carry an explicit layer-work object rather than ship this provider
+implementation. Conservation itself remains a fatal unscored structural
+guard, as required by the evidence rules.
+
+## Check B: adapter-produced exact samples reach TTFT
+
+### B1. Chunked-prefill metric relation
+
+The actual vLLM `StepTranslator` receives one scheduler-shaped batch:
+
+- request `p` has a 12-token prompt, four cached tokens, and four newly
+  scheduled tokens, so post-step context is eight and it remains mid-prompt;
+- request `d` is attached mid-flight with 31 computed tokens and one output
+  token, then schedules one token, so post-step context is 32 and it samples.
+
+The produced `StepRecord` must carry `num_sampled=1`. The same record with
+only that optional field removed is the explicit compatibility bypass and
+therefore falls back to two scheduled rows.
+
+This check reuses the independently frozen BACK-6 analytical provider: one
+modeled FLOP costs one picosecond and bytes do not contribute. With `L=2`,
+`W=2`, the Check A geometry, and `rnic-nn-fluid`, the exact relations are:
+
+| quantity | absent-field bypass | adapter exact field | exact minus bypass |
+|---|---:|---:|---:|
+| sample count | 2 | 1 | -1 |
+| fused estimate ps | 912,896 | 880,128 | -32,768 |
+| rendered calc ns per layer | 456 | 440 | -16 |
+| JCT/TTFT ps | 16,963,200 | 16,931,200 | -32,000 |
+
+The live adapter path must decrease TTFT by exactly 32,000 ps with zero
+residual. If the record count disagrees with the fabricated output rows, the
+design decision changes: attribution moves from the translator to the
+post-fabrication output seam instead of closing VLLM-15 here.
+
+### B2. Attribution matrix
+
+The same translator must populate these exact record counts. In every row the
+count must equal `sum(produces_token)` and the number of nonempty fabricated
+`ModelRunnerOutput.sampled_token_ids` rows.
+
+| case | scheduled rows | expected `num_sampled` |
+|---|---:|---:|
+| mid-prompt chunk | 1 | 0 |
+| prompt-completing chunk after a prefix hit | 1 | 1 |
+| prefix-cache completion on admission | 1 | 1 |
+| decode | 1 | 1 |
+| attach-mid-flight fallback | 1 | 1 |
+
+These are scored attribution instances because a plausible translator could
+incorrectly price every scheduled row or omit the exact field.
+
+## Check C: real vLLM v0.26.0 smoke
+
+The pinned-runtime command constructs the real in-process vLLM engine with
+the dotted `SimWorker`, the cached Granite snapshot already used by the
+accepted skeleton smoke, one explicit three-token `TokensPrompt`,
+`max_num_batched_tokens=2`, `max_num_seqs=1`, and two requested output
+tokens. It must generate exactly two copies of the worker's fabricated token
+and stream exactly three records.
+
+The streamed records must have scheduled-token counts `(2, 1, 1)` and exact
+sample counts `(0, 1, 1)`. The sum of the exact counts must equal the two live
+generated tokens. This whole relation is scored live integration evidence,
+not a structural appendix. A runtime that ignores the token budget, a worker
+path that bypasses translation, or an attribution error can fail it.
+
+## Check D: bypass and compatibility guards
+
+- `RooflineProvider(efficiency=0.7)` with no opt-in must return no layer
+  breakdown. The pre-change default sink case must retain GOAL SHA-256
+  `f8aade109ba8e3a581b7d965b3a0c76c1247016a1e37491fa84efbbf377677a5`
+  and the existing 12,030 ns even layer value.
+- A provider with no breakdown keeps the byte-identical even split.
+- A manually constructed `StepRecord` with absent `num_sampled` omits the
+  JSON field, round-trips through the v1 reader as absent, and retains the
+  scheduled-row fallback exactly. A present zero remains present.
+- An enabled roofline returns `None` for a kernel with no family metadata.
+  Invalid layer counts or nonconserving family metadata are rejected.
+- No profile-table or trace-calibrated breakdown is claimed before COMP-6
+  supplies per-layer captured shapes. The owning registry must retain that
+  residual work under a new COMP identifier.
+
+All Check D items are fatal and unscored.
+
+## Acceptance
+
+- Check A passes 4/4 exact end-to-end rows and both signed monotonic
+  directions, with zero timing residual.
+- Check B1 passes its exact `-32,000 ps` adapter-to-TTFT relation. Check B2
+  passes 5/5 exact attribution instances.
+- Check C passes its scored live `(0, 1, 1)` sample-count relation.
+- Check D and the decision-relevant exact-sum contract pass without being
+  added to a behavioral score.
+- Any unexplained residual, nonzero source mismatch, byte-lock change,
+  schema regression, invalid provider acceptance, or unverified backend
+  quiescence fails the study.

--- a/examples/step_sink_latent_knobs/review_expectations.md
+++ b/examples/step_sink_latent_knobs/review_expectations.md
@@ -1,0 +1,70 @@
+# Review-triggered regression expectations
+
+Date: 2026-08-10
+
+This amendment follows implementation commit `5329332` and the integration
+review. It is post-specified relative to the original COMP-16 and VLLM-15
+study, but it precedes the review fixes and their result-producing runs. It
+does not change the frozen 11-row scored denominator in `expectations.md`.
+
+## Replay and live sample-count relation
+
+For the frozen B1 mixed batch, the live step sink and the serial replay
+lowerer must both use `StepRecord.num_sampled=1`. The fused one-flop-per-ps
+estimate is exactly `880,128 ps`, and both render `440 ns` per layer. Their
+rendered GOAL text must be byte-identical.
+
+Removing only `num_sampled` preserves the historical fallback to two
+scheduled rows. Its fused estimate remains `912,896 ps`, its rendered layer
+cost remains `456 ns`, and its replay GOAL SHA-256 remains
+`7087db6780f7e34f5a559a6505eeccc15d984c7b478cd8f0bc5838053825d4b6`.
+Thus the exact field changes the fused estimate by `-32,768 ps` and the
+rendered two-layer compute service by `-32,000 ps`; the absent-field bytes do
+not change.
+
+## Post-specified shape-sensitive relation
+
+This is a regression check, not additional frozen behavioral evidence. In
+the two-layer, TP-width-two Check A cell, the disabled even split emits
+`(17, 17) ns` and the LM-head-in-last-layer split emits `(14, 21) ns`. The
+right edge of the final layer's calc service interval, measured from entry to
+that layer, therefore moves later by exactly
+
+`21 - 17 = +4 ns`.
+
+The runner must assert this value from the rendered GOAL reached through both
+complete backend runs. It must also retain the separately frozen absolute
+TTFT delta of `+1,000 ps`. A zero final-layer delta would reveal an even LM
+head placement even if cumulative truncation happened to retain the TTFT
+relation.
+
+## Quiescence and evidence accounting
+
+Every study CSV quiescence value must be derived from the backend wrapper's
+`RnicRunResult.quiescent` projection. No CSV row may supply a constant
+`"verified"` value.
+
+Check A's four scored rows plausibly test cumulative-boundary truncation, so
+their genuine-risk fraction remains 4 of 4 for that rule. Their folded layer
+shape assertions are structural and unscored. In Check B2, only the
+mid-prompt row distinguishes exact attribution from a blanket scheduled-row
+count; its genuine-risk fraction is therefore 1 of 5. With B1 and the live
+vLLM row each remaining 1 of 1, the overall plausible-risk count becomes 7
+of 11. The post-specified shape regression remains outside this denominator.
+
+## Registered review commands
+
+The deterministic study command remains the command in `RESULTS.md`. The
+touched Python gates are:
+
+```bash
+.venv/bin/pytest -q tests/test_step_lowerer.py tests/test_step_sink.py
+/data3/yifeng/simllm-dev/venv-vllm/bin/python -m pytest -q \
+  tests/test_step_lowerer.py tests/test_step_sink.py
+```
+
+Before this amendment is committed, the study command is executed with
+`--check-only`, and both test commands are executed with `--collect-only`.
+These modes parse the registered surfaces and produce no study results.
+There is no external-system expectation in this amendment, so no new
+external-source audit applies.

--- a/examples/step_sink_latent_knobs/run_study.py
+++ b/examples/step_sink_latent_knobs/run_study.py
@@ -37,6 +37,7 @@ from simllm.core import (
 )
 
 EXPECTATIONS_COMMIT = "25d098c997f078eb92dcf155cd36c44d9d6b2313"
+REVIEW_EXPECTATIONS_COMMIT = "396fd9e32df363cd2367f6ffc072ab49966bb20e"
 DEFAULT_OUT = Path("/data3/yifeng/simllm-dev/wave2-runs/comp16_latent_knobs")
 MODEL = Path(
     "/home/yifeng/packages/vllm-rnic-capture/hf-cache/hub/"
@@ -149,6 +150,29 @@ def layer_calcs(path: Path, rank: int) -> tuple[int, ...]:
     return tuple(int(value) for value in re.findall(r": calc (\d+)(?:\s|$)", match.group(1)))
 
 
+def backend_calc_boundary_ps(path: Path, before_tag: int, after_tag: int) -> int:
+    with path.open(newline="") as handle:
+        rows = list(csv.DictReader(handle))
+    before = {
+        int(row["source"]): int(row["completion_time_ps"])
+        for row in rows
+        if int(row["tag"]) == before_tag
+    }
+    after = {
+        int(row["source"]): int(row["start_time_ps"])
+        for row in rows
+        if int(row["tag"]) == after_tag
+    }
+    if before.keys() != after.keys() or not before:
+        raise AssertionError(
+            f"cannot join boundary tags {before_tag} and {after_tag} in {path}"
+        )
+    gaps = {after[source] - before[source] for source in before}
+    if len(gaps) != 1:
+        raise AssertionError(f"rank-dependent calc boundary gaps in {path}: {gaps}")
+    return gaps.pop()
+
+
 def frozen_jct(num_layers: int, world: int, calc_ns: tuple[int, ...]) -> int:
     chunk = 128 // world
     round_ps = chunk * PS_PER_BYTE_400G + PROPAGATION_PS
@@ -178,6 +202,7 @@ def make_sink(
 
 def run_check_a(out: Path, emit) -> None:
     measured_enabled: dict[tuple[int, int], int] = {}
+    shape_regression: dict[str, Any] | None = None
     for (num_layers, world), frozen in FROZEN_A.items():
         (
             expected_layer_ps,
@@ -237,15 +262,72 @@ def run_check_a(out: Path, emit) -> None:
         assert enabled_result.step_latency_ps - disabled_result.step_latency_ps == 1_000
         assert disabled_outcome.num_flows == expected_flows
         assert enabled_outcome.num_flows == expected_flows
+        assert disabled_outcome.quiescent
+        assert enabled_outcome.quiescent
+        rendered_boundary_deltas: set[int] = set()
         for rank in range(world):
-            assert layer_calcs(
+            disabled_goal_calc = layer_calcs(
                 out / f"a-l{num_layers}-w{world}-disabled" / "step-000000.goal",
                 rank,
-            ) == disabled_calc
-            assert layer_calcs(
+            )
+            enabled_goal_calc = layer_calcs(
                 out / f"a-l{num_layers}-w{world}-enabled" / "step-000000.goal",
                 rank,
-            ) == expected_calc_ns
+            )
+            assert disabled_goal_calc == disabled_calc
+            assert enabled_goal_calc == expected_calc_ns
+            rendered_boundary_deltas.add(
+                enabled_goal_calc[-1] - disabled_goal_calc[-1]
+            )
+
+        if (num_layers, world) == (2, 2):
+            assert len(rendered_boundary_deltas) == 1
+            boundary_delta_ns = rendered_boundary_deltas.pop()
+            assert boundary_delta_ns == 4
+            disabled_boundary_ps = backend_calc_boundary_ps(
+                out
+                / "a-l2-w2-disabled"
+                / "step-000000.rnic-nn-fluid.csv",
+                1003,
+                1004,
+            )
+            enabled_boundary_ps = backend_calc_boundary_ps(
+                out
+                / "a-l2-w2-enabled"
+                / "step-000000.rnic-nn-fluid.csv",
+                1003,
+                1004,
+            )
+            assert disabled_boundary_ps == disabled_calc[-1] * 1000
+            assert enabled_boundary_ps == expected_calc_ns[-1] * 1000
+            assert enabled_boundary_ps - disabled_boundary_ps == 4_000
+            shape_regression = {
+                "section": "post-specified-shape",
+                "classification": "unscored review regression",
+                "review_expectations_commit": REVIEW_EXPECTATIONS_COMMIT,
+                "layers": num_layers,
+                "world": world,
+                "even_final_calc_ns": disabled_calc[-1],
+                "lm_head_final_calc_ns": expected_calc_ns[-1],
+                "signed_boundary_delta_ns": boundary_delta_ns,
+                "expected_boundary_delta_ns": 4,
+                "boundary_residual_ns": boundary_delta_ns - 4,
+                "even_backend_boundary_ps": disabled_boundary_ps,
+                "lm_head_backend_boundary_ps": enabled_boundary_ps,
+                "signed_backend_boundary_delta_ps": (
+                    enabled_boundary_ps - disabled_boundary_ps
+                ),
+                "backend_boundary_residual_ps": (
+                    enabled_boundary_ps - disabled_boundary_ps - 4_000
+                ),
+                "disabled_ttft_ps": disabled_result.step_latency_ps,
+                "enabled_ttft_ps": enabled_result.step_latency_ps,
+                "signed_ttft_delta_ps": (
+                    enabled_result.step_latency_ps - disabled_result.step_latency_ps
+                ),
+                "even_physical_quiescence": disabled_outcome.quiescent,
+                "physical_quiescence": enabled_outcome.quiescent,
+            }
 
         measured_enabled[(num_layers, world)] = enabled_result.step_latency_ps
         emit(
@@ -262,13 +344,16 @@ def run_check_a(out: Path, emit) -> None:
             signed_delta_ps=enabled_result.step_latency_ps - disabled_result.step_latency_ps,
             residual_ps=enabled_result.step_latency_ps - expected_enabled_jct,
             flows=enabled_outcome.num_flows,
-            physical_quiescence="verified",
+            disabled_physical_quiescence=disabled_outcome.quiescent,
+            physical_quiescence=enabled_outcome.quiescent,
         )
 
     assert measured_enabled[(2, 2)] < measured_enabled[(4, 2)]
     assert measured_enabled[(2, 4)] < measured_enabled[(4, 4)]
     assert measured_enabled[(2, 2)] < measured_enabled[(2, 4)]
     assert measured_enabled[(4, 2)] < measured_enabled[(4, 4)]
+    assert shape_regression is not None
+    emit(**shape_regression)
 
 
 def translated_mixed_record() -> tuple[StepRecord, list[bool]]:
@@ -325,6 +410,8 @@ def run_check_b1(out: Path, emit) -> None:
 
     assert bypass_outcome.num_sampled == 2
     assert exact_outcome.num_sampled == 1
+    assert bypass_outcome.quiescent
+    assert exact_outcome.quiescent
     assert bypass_outcome.compute_estimate_ps == 912_896
     assert exact_outcome.compute_estimate_ps == 880_128
     assert bypass_outcome.layer_calc_ns == (456, 456)
@@ -347,7 +434,8 @@ def run_check_b1(out: Path, emit) -> None:
         signed_delta_ps=exact_result.step_latency_ps - bypass_result.step_latency_ps,
         expected_signed_delta_ps=-32_000,
         residual_ps=(exact_result.step_latency_ps - bypass_result.step_latency_ps) + 32_000,
-        physical_quiescence="verified",
+        bypass_physical_quiescence=bypass_outcome.quiescent,
+        physical_quiescence=exact_outcome.quiescent,
     )
 
 
@@ -509,7 +597,7 @@ def run_check_d(out: Path, emit) -> None:
         absent_sample_field_omitted=True,
         present_zero_round_trips=True,
         invalid_family_metadata_rejected=invalid_rejected,
-        physical_quiescence="verified",
+        physical_quiescence=sink.outcomes[0].quiescent,
     )
 
 
@@ -535,11 +623,13 @@ def run_deterministic(out: Path) -> None:
     run_check_b1(out, emit)
     run_check_b2(emit)
     run_check_d(out, emit)
+    assert len(rows) == 12
     summary = out / "summary.csv"
     write_rows(summary, rows)
     print(
-        f"completed {len(rows)} deterministic rows against expectations commit "
-        f"{EXPECTATIONS_COMMIT}; summary={summary}"
+        "completed 11 frozen deterministic rows plus 1 post-specified regression "
+        f"against expectations commits {EXPECTATIONS_COMMIT} and "
+        f"{REVIEW_EXPECTATIONS_COMMIT}; summary={summary}"
     )
 
 

--- a/examples/step_sink_latent_knobs/run_study.py
+++ b/examples/step_sink_latent_knobs/run_study.py
@@ -1,0 +1,647 @@
+"""Run the checks frozen for COMP-16 and VLLM-15."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import importlib.metadata
+import json
+import os
+import re
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Any
+
+from simllm.adapters.vllm import (
+    StepTranslator,
+    fabricate_sampled_tokens,
+    translate_scheduler_output,
+)
+from simllm.backends import HtsimStepSink, HtsimStepSinkConfig
+from simllm.compute import (
+    GPU_ENVELOPES,
+    ComputeProvider,
+    DurationEstimate,
+    KernelSpec,
+    ModelDims,
+    RooflineProvider,
+    step_kernel,
+)
+from simllm.core import (
+    RequestPhase,
+    ScheduledRequest,
+    StepRecord,
+    step_record_from_json,
+    step_record_to_json,
+)
+
+EXPECTATIONS_COMMIT = "25d098c997f078eb92dcf155cd36c44d9d6b2313"
+DEFAULT_OUT = Path("/data3/yifeng/simllm-dev/wave2-runs/comp16_latent_knobs")
+MODEL = Path(
+    "/home/yifeng/packages/vllm-rnic-capture/hf-cache/hub/"
+    "models--ibm-granite--granite-3.0-1b-a400m-instruct/snapshots/"
+    "ffec3c35bdfd97a06f0b4cd5fcc92cd9b1584445"
+)
+
+G = 1_000_000_000
+LINKSPEED_BPS = 400 * G
+PS_PER_BYTE_400G = 20
+PROPAGATION_PS = 2_000_000
+DEFAULT_GOAL_SHA256 = "f8aade109ba8e3a581b7d965b3a0c76c1247016a1e37491fa84efbbf377677a5"
+
+FROZEN_A = {
+    (2, 2): ((14_811, 20_663), (14, 21), 17, 35_474, 16_044_240, 16_045_240, 16),
+    (2, 4): ((14_811, 20_663), (14, 21), 17, 35_474, 48_049_360, 48_050_360, 96),
+    (4, 2): (
+        (14_811, 14_811, 14_812, 20_663),
+        (14, 15, 15, 21),
+        16,
+        65_097,
+        32_084_480,
+        32_085_480,
+        32,
+    ),
+    (4, 4): (
+        (14_811, 14_811, 14_812, 20_663),
+        (14, 15, 15, 21),
+        16,
+        65_097,
+        96_094_720,
+        96_095_720,
+        192,
+    ),
+}
+
+
+class FlopProvider(ComputeProvider):
+    """One modeled FLOP costs one picosecond for the sample-count oracle."""
+
+    def estimate(self, kernel, gpu):
+        return DurationEstimate(duration_ps=int(kernel.flops), bound="compute")
+
+
+@dataclass
+class SchedulerNewRequest:
+    req_id: str
+    prompt_token_ids: list[int]
+    num_computed_tokens: int = 0
+
+
+@dataclass
+class SchedulerCachedRequests:
+    req_ids: list[str] = field(default_factory=list)
+    num_computed_tokens: list[int] = field(default_factory=list)
+    num_output_tokens: list[int] = field(default_factory=list)
+
+
+@dataclass
+class SchedulerOutput:
+    scheduled_new_reqs: list[SchedulerNewRequest] = field(default_factory=list)
+    scheduled_cached_reqs: SchedulerCachedRequests = field(
+        default_factory=SchedulerCachedRequests
+    )
+    num_scheduled_tokens: dict[str, int] = field(default_factory=dict)
+    finished_req_ids: set[str] = field(default_factory=set)
+    preempted_req_ids: set[str] | None = None
+
+
+def dims(num_layers: int) -> ModelDims:
+    return ModelDims(
+        num_layers=num_layers,
+        hidden_size=64,
+        intermediate_size=128,
+        num_heads=4,
+        num_kv_heads=4,
+        head_size=16,
+        vocab_size=256,
+        dtype_bytes=2,
+    )
+
+
+def default_dims() -> ModelDims:
+    return ModelDims(
+        num_layers=2,
+        hidden_size=1024,
+        intermediate_size=4096,
+        num_heads=8,
+        num_kv_heads=8,
+        head_size=128,
+        vocab_size=32000,
+        dtype_bytes=2,
+    )
+
+
+def one_decode() -> StepRecord:
+    return StepRecord(
+        0,
+        0,
+        [ScheduledRequest("d", RequestPhase.DECODE, 1, context_length=4)],
+        num_sampled=1,
+    )
+
+
+def layer_calcs(path: Path, rank: int) -> tuple[int, ...]:
+    text = path.read_text()
+    match = re.search(rf"rank {rank} \{{\n(.*?)\n\}}", text, flags=re.DOTALL)
+    if match is None:
+        raise AssertionError(f"rank {rank} missing from {path}")
+    return tuple(int(value) for value in re.findall(r": calc (\d+)(?:\s|$)", match.group(1)))
+
+
+def frozen_jct(num_layers: int, world: int, calc_ns: tuple[int, ...]) -> int:
+    chunk = 128 // world
+    round_ps = chunk * PS_PER_BYTE_400G + PROPAGATION_PS
+    network_ps = 2 * num_layers * 2 * (world - 1) * round_ps
+    return sum(calc_ns) * 1000 + network_ps
+
+
+def make_sink(
+    out: Path,
+    label: str,
+    *,
+    num_layers: int,
+    world: int,
+    provider: ComputeProvider,
+) -> HtsimStepSink:
+    return HtsimStepSink(
+        HtsimStepSinkConfig(
+            profile="rnic-nn-fluid",
+            tp_ranks=tuple(range(world)),
+            dims=dims(num_layers),
+            workdir=out / label,
+            linkspeed_bps=LINKSPEED_BPS,
+            provider=provider,
+        )
+    )
+
+
+def run_check_a(out: Path, emit) -> None:
+    measured_enabled: dict[tuple[int, int], int] = {}
+    for (num_layers, world), frozen in FROZEN_A.items():
+        (
+            expected_layer_ps,
+            expected_calc_ns,
+            expected_even_ns,
+            expected_estimate_ps,
+            expected_disabled_jct,
+            expected_enabled_jct,
+            expected_flows,
+        ) = frozen
+        record = one_decode()
+        disabled = make_sink(
+            out,
+            f"a-l{num_layers}-w{world}-disabled",
+            num_layers=num_layers,
+            world=world,
+            provider=RooflineProvider(efficiency=0.7),
+        )
+        enabled = make_sink(
+            out,
+            f"a-l{num_layers}-w{world}-enabled",
+            num_layers=num_layers,
+            world=world,
+            provider=RooflineProvider(
+                efficiency=0.7,
+                enable_layer_breakdown=True,
+            ),
+        )
+
+        disabled_result = disabled(record)
+        enabled_result = enabled(record)
+        assert disabled_result is not None
+        assert enabled_result is not None
+        disabled_outcome = disabled.outcomes[0]
+        enabled_outcome = enabled.outcomes[0]
+        disabled_calc = (expected_even_ns,) * num_layers
+
+        assert frozen_jct(num_layers, world, disabled_calc) == expected_disabled_jct
+        assert frozen_jct(num_layers, world, expected_calc_ns) == expected_enabled_jct
+        assert disabled_outcome.compute_estimate_ps == expected_estimate_ps
+        assert enabled_outcome.compute_estimate_ps == expected_estimate_ps
+        assert disabled_outcome.per_layer_calc_ns == expected_even_ns
+        assert disabled_outcome.layer_calc_ns == disabled_calc
+        assert enabled_outcome.per_layer_calc_ns is None
+        assert enabled_outcome.layer_calc_ns == expected_calc_ns
+        assert tuple(
+            estimate.duration_ps
+            for estimate in enabled.config.provider.estimate_layers(
+                step_kernel(dims(num_layers), record, num_sampled=1),
+                GPU_ENVELOPES["b100"],
+                num_layers,
+            )
+            or ()
+        ) == expected_layer_ps
+        assert disabled_result.step_latency_ps == expected_disabled_jct
+        assert enabled_result.step_latency_ps == expected_enabled_jct
+        assert enabled_result.step_latency_ps - disabled_result.step_latency_ps == 1_000
+        assert disabled_outcome.num_flows == expected_flows
+        assert enabled_outcome.num_flows == expected_flows
+        for rank in range(world):
+            assert layer_calcs(
+                out / f"a-l{num_layers}-w{world}-disabled" / "step-000000.goal",
+                rank,
+            ) == disabled_calc
+            assert layer_calcs(
+                out / f"a-l{num_layers}-w{world}-enabled" / "step-000000.goal",
+                rank,
+            ) == expected_calc_ns
+
+        measured_enabled[(num_layers, world)] = enabled_result.step_latency_ps
+        emit(
+            section="A",
+            layers=num_layers,
+            world=world,
+            estimate_ps=enabled_outcome.compute_estimate_ps,
+            layer_ps=";".join(map(str, expected_layer_ps)),
+            disabled_calc_ns=";".join(map(str, disabled_calc)),
+            enabled_calc_ns=";".join(map(str, enabled_outcome.layer_calc_ns)),
+            disabled_ttft_ps=disabled_result.step_latency_ps,
+            enabled_ttft_ps=enabled_result.step_latency_ps,
+            expected_enabled_ttft_ps=expected_enabled_jct,
+            signed_delta_ps=enabled_result.step_latency_ps - disabled_result.step_latency_ps,
+            residual_ps=enabled_result.step_latency_ps - expected_enabled_jct,
+            flows=enabled_outcome.num_flows,
+            physical_quiescence="verified",
+        )
+
+    assert measured_enabled[(2, 2)] < measured_enabled[(4, 2)]
+    assert measured_enabled[(2, 4)] < measured_enabled[(4, 4)]
+    assert measured_enabled[(2, 2)] < measured_enabled[(2, 4)]
+    assert measured_enabled[(4, 2)] < measured_enabled[(4, 4)]
+
+
+def translated_mixed_record() -> tuple[StepRecord, list[bool]]:
+    translator = StepTranslator()
+    output = SchedulerOutput(
+        scheduled_new_reqs=[
+            SchedulerNewRequest("p", list(range(12)), num_computed_tokens=4)
+        ],
+        scheduled_cached_reqs=SchedulerCachedRequests(
+            req_ids=["d"],
+            num_computed_tokens=[31],
+            num_output_tokens=[1],
+        ),
+        num_scheduled_tokens={"p": 4, "d": 1},
+    )
+    translated = translate_scheduler_output(
+        translator,
+        output,
+        step_index=0,
+        virtual_time_ps=0,
+    )
+    return translated.record, translated.produces_token
+
+
+def run_check_b1(out: Path, emit) -> None:
+    exact_record, produces_token = translated_mixed_record()
+    bypass_record = replace(exact_record, num_sampled=None)
+    req_ids = [request.request_id for request in exact_record.scheduled]
+    _, _, sampled = fabricate_sampled_tokens(req_ids, produces_token, token_id=7)
+    assert produces_token == [False, True]
+    assert exact_record.num_sampled == 1
+    assert sum(bool(row) for row in sampled) == exact_record.num_sampled
+
+    bypass = make_sink(
+        out,
+        "b1-bypass",
+        num_layers=2,
+        world=2,
+        provider=FlopProvider(),
+    )
+    exact = make_sink(
+        out,
+        "b1-adapter-exact",
+        num_layers=2,
+        world=2,
+        provider=FlopProvider(),
+    )
+    bypass_result = bypass(bypass_record)
+    exact_result = exact(exact_record)
+    assert bypass_result is not None
+    assert exact_result is not None
+    bypass_outcome = bypass.outcomes[0]
+    exact_outcome = exact.outcomes[0]
+
+    assert bypass_outcome.num_sampled == 2
+    assert exact_outcome.num_sampled == 1
+    assert bypass_outcome.compute_estimate_ps == 912_896
+    assert exact_outcome.compute_estimate_ps == 880_128
+    assert bypass_outcome.layer_calc_ns == (456, 456)
+    assert exact_outcome.layer_calc_ns == (440, 440)
+    assert bypass_result.step_latency_ps == 16_963_200
+    assert exact_result.step_latency_ps == 16_931_200
+    assert exact_result.step_latency_ps - bypass_result.step_latency_ps == -32_000
+    emit(
+        section="B1",
+        bypass_samples=bypass_outcome.num_sampled,
+        adapter_samples=exact_outcome.num_sampled,
+        sampled_output_rows=sum(bool(row) for row in sampled),
+        bypass_estimate_ps=bypass_outcome.compute_estimate_ps,
+        adapter_estimate_ps=exact_outcome.compute_estimate_ps,
+        estimate_delta_ps=(
+            exact_outcome.compute_estimate_ps - bypass_outcome.compute_estimate_ps
+        ),
+        bypass_ttft_ps=bypass_result.step_latency_ps,
+        adapter_ttft_ps=exact_result.step_latency_ps,
+        signed_delta_ps=exact_result.step_latency_ps - bypass_result.step_latency_ps,
+        expected_signed_delta_ps=-32_000,
+        residual_ps=(exact_result.step_latency_ps - bypass_result.step_latency_ps) + 32_000,
+        physical_quiescence="verified",
+    )
+
+
+def check_attribution_case(
+    case: str,
+    translated,
+    expected: int,
+    emit,
+) -> None:
+    _, _, sampled = fabricate_sampled_tokens(
+        translated.req_ids,
+        translated.produces_token,
+        token_id=7,
+    )
+    output_rows = sum(bool(row) for row in sampled)
+    assert translated.record.num_sampled == expected
+    assert sum(translated.produces_token) == expected
+    assert output_rows == expected
+    emit(
+        section="B2",
+        case=case,
+        scheduled_rows=len(translated.record.scheduled),
+        record_samples=translated.record.num_sampled,
+        output_rows=output_rows,
+        expected_samples=expected,
+        residual=translated.record.num_sampled - expected,
+    )
+
+
+def run_check_b2(emit) -> None:
+    chunked = StepTranslator()
+    mid_prompt = translate_scheduler_output(
+        chunked,
+        SchedulerOutput(
+            scheduled_new_reqs=[
+                SchedulerNewRequest("p", list(range(12)), num_computed_tokens=4)
+            ],
+            num_scheduled_tokens={"p": 4},
+        ),
+        step_index=0,
+        virtual_time_ps=0,
+    )
+    check_attribution_case("mid-prompt", mid_prompt, 0, emit)
+    prompt_complete = translate_scheduler_output(
+        chunked,
+        SchedulerOutput(
+            scheduled_cached_reqs=SchedulerCachedRequests(["p"], [8], [0]),
+            num_scheduled_tokens={"p": 4},
+        ),
+        step_index=1,
+        virtual_time_ps=0,
+    )
+    check_attribution_case("prompt-completing-after-prefix", prompt_complete, 1, emit)
+    decode = translate_scheduler_output(
+        chunked,
+        SchedulerOutput(
+            scheduled_cached_reqs=SchedulerCachedRequests(["p"], [12], [1]),
+            num_scheduled_tokens={"p": 1},
+        ),
+        step_index=2,
+        virtual_time_ps=0,
+    )
+    check_attribution_case("decode", decode, 1, emit)
+
+    prefix = StepTranslator()
+    prefix_complete = translate_scheduler_output(
+        prefix,
+        SchedulerOutput(
+            scheduled_new_reqs=[
+                SchedulerNewRequest("cached", list(range(8)), num_computed_tokens=4)
+            ],
+            num_scheduled_tokens={"cached": 4},
+        ),
+        step_index=0,
+        virtual_time_ps=0,
+    )
+    check_attribution_case("prefix-cache-completion", prefix_complete, 1, emit)
+
+    attached = StepTranslator()
+    attach_midflight = translate_scheduler_output(
+        attached,
+        SchedulerOutput(
+            scheduled_cached_reqs=SchedulerCachedRequests(["orphan"], [31], [1]),
+            num_scheduled_tokens={"orphan": 1},
+        ),
+        step_index=0,
+        virtual_time_ps=0,
+    )
+    check_attribution_case("attach-mid-flight", attach_midflight, 1, emit)
+
+
+def run_check_d(out: Path, emit) -> None:
+    record = StepRecord(
+        0,
+        0,
+        [ScheduledRequest("prefill", RequestPhase.PREFILL, 256, context_length=256)],
+    )
+    sink = HtsimStepSink(
+        HtsimStepSinkConfig(
+            profile="rnic-nn-fluid",
+            tp_ranks=(0, 1),
+            dims=default_dims(),
+            workdir=out / "d-default-baseline",
+            linkspeed_bps=LINKSPEED_BPS,
+        )
+    )
+    result = sink(record)
+    assert result is not None
+    goal_path = out / "d-default-baseline" / "step-000000.goal"
+    digest = hashlib.sha256(goal_path.read_bytes()).hexdigest()
+    assert digest == DEFAULT_GOAL_SHA256
+    assert sink.outcomes[0].per_layer_calc_ns == 12_030
+    assert sink.outcomes[0].layer_calc_ns == (12_030, 12_030)
+
+    payload = step_record_to_json(record)
+    assert "num_sampled" not in payload
+    assert step_record_from_json(payload) == record
+    present_zero = replace(record, num_sampled=0)
+    present_payload = step_record_to_json(present_zero)
+    assert present_payload["num_sampled"] == 0
+    assert step_record_from_json(present_payload) == present_zero
+
+    default_provider = RooflineProvider(efficiency=0.7)
+    default_kernel = step_kernel(default_dims(), record, num_sampled=1)
+    assert default_provider.estimate_layers(
+        default_kernel,
+        GPU_ENVELOPES["b100"],
+        2,
+    ) is None
+    enabled = RooflineProvider(efficiency=0.7, enable_layer_breakdown=True)
+    assert enabled.estimate_layers(
+        KernelSpec("plain", flops=1.0, bytes_moved=1.0),
+        GPU_ENVELOPES["b100"],
+        2,
+    ) is None
+    bad_family = KernelSpec("body", flops=1.0, bytes_moved=1.0)
+    try:
+        enabled.estimate_layers(
+            KernelSpec(
+                "bad",
+                flops=2.0,
+                bytes_moved=1.0,
+                family_kernels=(bad_family,),
+            ),
+            GPU_ENVELOPES["b100"],
+            2,
+        )
+    except ValueError:
+        invalid_rejected = True
+    else:
+        raise AssertionError("enabled roofline accepted nonconserving families")
+
+    emit(
+        section="D",
+        default_goal_sha256=digest,
+        expected_goal_sha256=DEFAULT_GOAL_SHA256,
+        per_layer_calc_ns=sink.outcomes[0].per_layer_calc_ns,
+        default_breakdown_absent=True,
+        absent_sample_field_omitted=True,
+        present_zero_round_trips=True,
+        invalid_family_metadata_rejected=invalid_rejected,
+        physical_quiescence="verified",
+    )
+
+
+def write_rows(path: Path, rows: list[dict[str, Any]]) -> None:
+    fields: list[str] = []
+    for row in rows:
+        fields.extend(key for key in row if key not in fields)
+    with path.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def run_deterministic(out: Path) -> None:
+    out.mkdir(parents=True, exist_ok=True)
+    rows: list[dict[str, Any]] = []
+
+    def emit(**row) -> None:
+        rows.append(row)
+        print(" ".join(f"{key}={value}" for key, value in row.items()))
+
+    run_check_a(out, emit)
+    run_check_b1(out, emit)
+    run_check_b2(emit)
+    run_check_d(out, emit)
+    summary = out / "summary.csv"
+    write_rows(summary, rows)
+    print(
+        f"completed {len(rows)} deterministic rows against expectations commit "
+        f"{EXPECTATIONS_COMMIT}; summary={summary}"
+    )
+
+
+def run_live_vllm(out: Path) -> None:
+    from vllm import LLM, SamplingParams
+
+    from simllm.adapters.vllm import SimModelRunner, latest_worker
+
+    live_dir = out / "live-vllm"
+    record_path = live_dir / "steps.jsonl"
+    summary_path = live_dir / "summary.json"
+    if record_path.exists() or summary_path.exists():
+        raise RuntimeError(f"refusing stale live evidence under {live_dir}")
+    live_dir.mkdir(parents=True, exist_ok=True)
+    os.environ["SIMLLM_VLLM_STEP_RECORDS"] = str(record_path)
+
+    llm = LLM(
+        model=str(MODEL),
+        worker_cls="simllm.adapters.vllm.SimWorker",
+        enforce_eager=True,
+        max_model_len=64,
+        max_num_batched_tokens=2,
+        max_num_seqs=1,
+        enable_chunked_prefill=True,
+        num_gpu_blocks_override=64,
+        disable_log_stats=True,
+    )
+    outputs = llm.generate(
+        [{"prompt_token_ids": [100, 101, 102]}],
+        SamplingParams(max_tokens=2, ignore_eos=True),
+    )
+    worker = latest_worker()
+    assert worker is not None
+    assert isinstance(worker.model_runner, SimModelRunner)
+    assert len(outputs) == 1
+    assert len(outputs[0].outputs) == 1
+    sampled_token_ids = tuple(outputs[0].outputs[0].token_ids)
+    assert sampled_token_ids == (worker.token_id, worker.token_id)
+
+    records = [
+        json.loads(line)
+        for line in record_path.read_text().splitlines()
+        if line.strip()
+    ]
+    scheduled_tokens = tuple(
+        sum(row["num_new_tokens"] for row in record["scheduled"])
+        for record in records
+    )
+    exact_samples = tuple(record.get("num_sampled") for record in records)
+    assert scheduled_tokens == (2, 1, 1)
+    assert exact_samples == (0, 1, 1)
+    assert sum(exact_samples) == len(sampled_token_ids)
+
+    summary = {
+        "expectations_commit": EXPECTATIONS_COMMIT,
+        "vllm_version": importlib.metadata.version("vllm"),
+        "worker_class": type(worker).__name__,
+        "runner_class": type(worker.model_runner).__name__,
+        "fabricated_token_id": worker.token_id,
+        "sampled_token_ids": sampled_token_ids,
+        "scheduled_tokens": scheduled_tokens,
+        "exact_samples": exact_samples,
+        "record_count": len(records),
+        "scored_relation": "pass",
+    }
+    summary_path.write_text(json.dumps(summary, indent=2) + "\n")
+    print(" ".join(f"{key}={value}" for key, value in summary.items()))
+    print(f"live summary={summary_path}")
+
+
+def require_file_env(name: str) -> None:
+    value = os.environ.get(name)
+    if value is None or not Path(value).is_file():
+        raise RuntimeError(f"{name} must name an existing file")
+
+
+def check_only(mode: str, out: Path) -> None:
+    if mode == "deterministic":
+        require_file_env("SIMLLM_HTSIM_RNIC")
+        require_file_env("SIMLLM_TXT2BIN")
+    else:
+        if importlib.metadata.version("vllm") != "0.26.0":
+            raise RuntimeError("live-vllm mode requires vLLM 0.26.0")
+        if not MODEL.is_dir():
+            raise RuntimeError(f"cached model is missing: {MODEL}")
+    print(f"check-only mode={mode} out={out}; no results produced")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=("deterministic", "live-vllm"), required=True)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    parser.add_argument("--check-only", action="store_true")
+    args = parser.parse_args()
+
+    if args.check_only:
+        check_only(args.mode, args.out)
+    elif args.mode == "deterministic":
+        run_deterministic(args.out)
+    else:
+        run_live_vllm(args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/simllm/adapters/vllm/executor.py
+++ b/simllm/adapters/vllm/executor.py
@@ -443,6 +443,7 @@ class StepTranslator:
             scheduled=scheduled,
             preempted_request_ids=sorted(preempted_req_ids),
             finished_request_ids=finished,
+            num_sampled=sum(produces_token),
         )
         self.forget(finished)
         return TranslatedStep(record=record, req_ids=req_ids, produces_token=produces_token)

--- a/simllm/backends/step_lowerer.py
+++ b/simllm/backends/step_lowerer.py
@@ -145,7 +145,10 @@ class SerialStepLowerer(ExecutionLowerer):
                 if rank not in participants:
                     participants.append(rank)
 
-        kernel = step_kernel(cfg.dims, record, num_sampled=len(record.scheduled))
+        num_sampled = record.num_sampled
+        if num_sampled is None:
+            num_sampled = len(record.scheduled)
+        kernel = step_kernel(cfg.dims, record, num_sampled=num_sampled)
         estimate = cfg.provider.estimate(kernel, cfg.gpu)
         whole_step_ps = estimate.duration_ps + cfg.host_model.delay_ps()
         per_layer_calc_ns = whole_step_ps // (cfg.dims.num_layers * 1000)

--- a/simllm/backends/step_sink.py
+++ b/simllm/backends/step_sink.py
@@ -112,6 +112,8 @@ class StepNetworkOutcome:
     num_sampled: int = 0
     #: whether num_sampled came from an exact record field
     sample_count_exact: bool = False
+    #: whether the backend wrapper verified physical quiescence
+    quiescent: bool = False
 
     def network_share_for(self, num_layers: int) -> float:
         """One minus represented calc time over makespan."""
@@ -242,6 +244,7 @@ class HtsimStepSink:
                 layer_calc_ns=layer_calc_ns,
                 makespan_ps=makespan_ps,
                 num_flows=len(run.flows),
+                quiescent=run.quiescent,
             )
         )
         return StepResult(

--- a/simllm/compute/provider.py
+++ b/simllm/compute/provider.py
@@ -6,6 +6,7 @@ import abc
 import json
 import math
 from dataclasses import dataclass
+from fractions import Fraction
 from pathlib import Path
 from typing import Any
 
@@ -40,6 +41,8 @@ class KernelSpec:
     bytes_moved: float
     #: free-form shape/config key, e.g. {"batch_tokens": 512, "hidden": 7168}
     config: tuple[tuple[str, int], ...] = ()
+    #: optional exact family decomposition of this fused kernel
+    family_kernels: tuple[KernelSpec, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -87,10 +90,16 @@ class RooflineProvider(ComputeProvider):
     (real kernels rarely reach 100% of either roof).
     """
 
-    def __init__(self, efficiency: float = 0.7):
+    def __init__(
+        self,
+        efficiency: float = 0.7,
+        *,
+        enable_layer_breakdown: bool = False,
+    ):
         if not 0.0 < efficiency <= 1.0:
             raise ValueError("efficiency must be in (0, 1]")
         self.efficiency = efficiency
+        self.enable_layer_breakdown = enable_layer_breakdown
 
     def estimate(self, kernel: KernelSpec, gpu: GpuSpec) -> DurationEstimate:
         t_compute = kernel.flops / (gpu.peak_flops * self.efficiency)
@@ -102,6 +111,81 @@ class RooflineProvider(ComputeProvider):
             bound=bound,
             uncertainty=0.5,
         )
+
+    def estimate_layers(
+        self,
+        kernel: KernelSpec,
+        gpu: GpuSpec,
+        num_layers: int,
+    ) -> tuple[DurationEstimate, ...] | None:
+        """Split a fused estimate using work on its selected roof.
+
+        Transformer families aggregate work over all layers except for the
+        LM head. The repeated work is shared equally; the complete LM-head
+        family belongs to the final layer. Integer cumulative boundaries make
+        the returned durations sum to the fused estimate exactly.
+        """
+        if not self.enable_layer_breakdown or not kernel.family_kernels:
+            return None
+        if isinstance(num_layers, bool) or not isinstance(num_layers, int):
+            raise TypeError("num_layers must be an integer")
+        if num_layers <= 0:
+            raise ValueError("num_layers must be positive")
+
+        family_flops = sum(family.flops for family in kernel.family_kernels)
+        family_bytes = sum(family.bytes_moved for family in kernel.family_kernels)
+        if any(
+            family.flops < 0 or family.bytes_moved < 0
+            for family in kernel.family_kernels
+        ):
+            raise ValueError("family work must be nonnegative")
+        if family_flops != kernel.flops or family_bytes != kernel.bytes_moved:
+            raise ValueError("family kernels must conserve fused flops and bytes exactly")
+
+        fused = self.estimate(kernel, gpu)
+        selected = "flops" if fused.bound == "compute" else "bytes_moved"
+        weighted_families = tuple(
+            (family.name, Fraction(getattr(family, selected)))
+            for family in kernel.family_kernels
+        )
+        head_weight = sum(
+            (weight for name, weight in weighted_families if name == "lm_head"),
+            start=Fraction(0),
+        )
+        repeated_weight = sum(
+            (weight for name, weight in weighted_families if name != "lm_head"),
+            start=Fraction(0),
+        )
+        layer_weights = [repeated_weight] * num_layers
+        layer_weights[-1] += head_weight * num_layers
+        total_weight = sum(layer_weights, start=Fraction(0))
+        if total_weight == 0:
+            if fused.duration_ps != 0:
+                raise ValueError("zero family work cannot apportion a nonzero estimate")
+            return tuple(
+                DurationEstimate(0, fused.bound, fused.uncertainty)
+                for _ in range(num_layers)
+            )
+
+        cumulative_weight = Fraction(0)
+        previous_boundary_ps = 0
+        estimates = []
+        for index, weight in enumerate(layer_weights):
+            cumulative_weight += weight
+            boundary_ps = (
+                fused.duration_ps
+                if index == num_layers - 1
+                else (fused.duration_ps * cumulative_weight) // total_weight
+            )
+            estimates.append(
+                DurationEstimate(
+                    duration_ps=boundary_ps - previous_boundary_ps,
+                    bound=fused.bound,
+                    uncertainty=fused.uncertainty,
+                )
+            )
+            previous_boundary_ps = boundary_ps
+        return tuple(estimates)
 
 
 #: table key: (kernel name, config tuple, gpu name)

--- a/simllm/compute/transformer.py
+++ b/simllm/compute/transformer.py
@@ -234,6 +234,7 @@ def step_kernel(dims: ModelDims, record: StepRecord, num_sampled: int) -> Kernel
             ("sampled", num_sampled),
             ("kv_tokens", kv_read_tokens),
         ),
+        family_kernels=tuple(step_kernels(dims, record, num_sampled)),
     )
 
 

--- a/tests/test_adapters_vllm.py
+++ b/tests/test_adapters_vllm.py
@@ -351,6 +351,7 @@ def test_sim_worker_split_step_uses_one_clock_and_stream(monkeypatch, tmp_path):
     assert [record.step_index for record in worker.step_records] == [0, 1]
     assert [record.virtual_time_ps for record in worker.step_records] == [123_000, 123_000]
     assert [record.total_new_tokens for record in worker.step_records] == [4, 1]
+    assert [record.num_sampled for record in worker.step_records] == [1, 1]
     assert [result.step_latency_ps for result in worker.step_results] == [0, 0]
     assert [result.completed_at_ps for result in worker.step_results] == [123_000, 123_000]
     assert worker.clock.now_ps == 123_000
@@ -439,6 +440,7 @@ def test_chunked_prefill_then_decode_translation():
     assert request.context_length == 640
     assert step0.produces_token == [False]
     assert step0.num_sampled == 0
+    assert step0.record.num_sampled == 0
 
     second = FakeSchedulerOutput(
         scheduled_cached_reqs=FakeCachedRequests(["r0"], [640], [0]),
@@ -451,6 +453,7 @@ def test_chunked_prefill_then_decode_translation():
     # The prefix hit is reported once, on admission, not every step.
     assert request.num_cached_tokens == 0
     assert step1.produces_token == [True]
+    assert step1.record.num_sampled == 1
 
     third = FakeSchedulerOutput(
         scheduled_cached_reqs=FakeCachedRequests(["r0"], [1000], [1]),
@@ -461,6 +464,7 @@ def test_chunked_prefill_then_decode_translation():
     assert request.phase is RequestPhase.DECODE
     assert (request.num_new_tokens, request.context_length) == (1, 1001)
     assert step2.produces_token == [True]
+    assert step2.record.num_sampled == 1
     assert step2.record.total_new_tokens == 1
 
 
@@ -495,6 +499,7 @@ def test_mixed_batch_translation_and_bookkeeping():
         "short": True,
         "decoding": True,
     }
+    assert record.num_sampled == 2
     # Finished and preempted ids are sorted for reproducible traces.
     assert record.finished_request_ids == ["also-gone", "gone"]
     assert record.preempted_request_ids == ["evicted"]
@@ -540,6 +545,7 @@ def test_drain_step_translation_carries_the_last_completions():
     assert step.record.finished_request_ids == ["r0"]
     assert step.record.total_new_tokens == 0
     assert step.num_sampled == 0
+    assert step.record.num_sampled == 0
     assert len(translator) == 0
 
 
@@ -554,6 +560,7 @@ def test_request_seen_only_as_cached_reconstructs_its_prompt_length():
     step = translate_scheduler_output(translator, output, step_index=0, virtual_time_ps=0)
     assert step.record.scheduled[0].phase is RequestPhase.DECODE
     assert step.produces_token == [True]
+    assert step.record.num_sampled == 1
 
 
 def test_preemption_resets_the_computed_count():
@@ -573,6 +580,7 @@ def test_preemption_resets_the_computed_count():
     assert step.record.scheduled[0].phase is RequestPhase.PREFILL
     assert step.record.scheduled[0].context_length == 64
     assert step.produces_token == [True]
+    assert step.record.num_sampled == 1
 
 
 # ModelRunnerOutput fabrication
@@ -605,6 +613,7 @@ def test_fabricated_output_covers_every_scheduled_request():
     assert sampled[req_id_to_index["a"]] == [7]
     assert sampled[req_id_to_index["b"]] == []
     assert sampled[req_id_to_index["c"]] == [7]
+    assert sum(bool(tokens) for tokens in sampled) == step.record.num_sampled
 
 
 def test_fabricate_rejects_inconsistent_input():
@@ -825,8 +834,10 @@ def test_step_records_dump_is_json_round_trippable(tmp_path):
     assert {line["schema"] for line in lines} == {"atlahs-closed-loop-step-v1"}
     assert lines[0]["scheduled"][0]["phase"] == "prefill"
     assert lines[0]["scheduled"][0]["num_cached_tokens"] == 8
+    assert lines[0]["num_sampled"] == 1
     assert lines[1]["scheduled"][0]["phase"] == "decode"
     assert lines[1]["finished_request_ids"] == ["r0"]
+    assert lines[1]["num_sampled"] == 1
 
 
 # Placement manifest assembly

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -1,6 +1,7 @@
 import pytest
 
 from simllm.compute import (
+    GPU_ENVELOPES,
     PROFILE_TABLE_SCHEMA,
     GpuSpec,
     HostInitiationModel,
@@ -43,12 +44,19 @@ def test_compute_provider_layer_breakdown_is_optional():
     assert provider.estimate_layers(kernel, H100ish, num_layers=2) is None
 
 
+def test_enabled_roofline_needs_family_metadata():
+    provider = RooflineProvider(efficiency=1.0, enable_layer_breakdown=True)
+    kernel = KernelSpec(name="gemm", flops=1e9, bytes_moved=1e6)
+    assert provider.estimate_layers(kernel, H100ish, num_layers=2) is None
+
+
 def test_profile_table():
     cfg = (("batch_tokens", 512), ("hidden", 7168))
     provider = ProfileTableProvider({("moe_forward", cfg, "h100-bf16"): 123_000_000})
     est = provider.estimate(KernelSpec("moe_forward", 0, 0, cfg), H100ish)
     assert est.duration_ps == 123_000_000
     assert est.bound == "measured"
+    assert provider.estimate_layers(KernelSpec("moe_forward", 0, 0, cfg), H100ish, 2) is None
     with pytest.raises(KeyError):
         provider.estimate(KernelSpec("moe_forward", 0, 0, ()), H100ish)
 
@@ -238,6 +246,7 @@ def test_step_kernels_sum_to_fused_exactly(dims):
     families = step_kernels(dims, record, num_sampled=2)
     assert sum(k.flops for k in families) == fused.flops
     assert sum(k.bytes_moved for k in families) == fused.bytes_moved
+    assert fused.family_kernels == tuple(families)
 
 
 def test_step_kernels_sum_exact_with_fractional_weight_bytes():
@@ -275,6 +284,105 @@ def test_step_kernels_families_and_configs():
     assert (families["attn_gemm"].bytes_moved + families["mlp_gemm"].bytes_moved
             == DENSE_DIMS.weight_bytes)
     assert families["lm_head"].bytes_moved == DENSE_DIMS.lm_head_bytes
+
+
+@pytest.mark.parametrize(
+    ("num_layers", "expected_fused_ps", "expected_layer_ps"),
+    [
+        (2, 35_474, (14_811, 20_663)),
+        (4, 65_097, (14_811, 14_811, 14_812, 20_663)),
+    ],
+)
+def test_roofline_layer_breakdown_matches_frozen_memory_bound_rows(
+    num_layers, expected_fused_ps, expected_layer_ps
+):
+    dims = ModelDims(
+        num_layers=num_layers,
+        hidden_size=64,
+        intermediate_size=128,
+        num_heads=4,
+        num_kv_heads=4,
+        head_size=16,
+        vocab_size=256,
+        dtype_bytes=2,
+    )
+    record = StepRecord(
+        0,
+        0,
+        [ScheduledRequest("d", RequestPhase.DECODE, 1, context_length=4)],
+        num_sampled=1,
+    )
+    kernel = step_kernel(dims, record, num_sampled=1)
+    provider = RooflineProvider(efficiency=0.7, enable_layer_breakdown=True)
+
+    fused = provider.estimate(kernel, GPU_ENVELOPES["b100"])
+    estimates = provider.estimate_layers(kernel, GPU_ENVELOPES["b100"], num_layers)
+
+    assert fused.bound == "memory"
+    assert fused.duration_ps == expected_fused_ps
+    assert estimates is not None
+    assert tuple(estimate.duration_ps for estimate in estimates) == expected_layer_ps
+    assert sum(estimate.duration_ps for estimate in estimates) == fused.duration_ps
+    assert all(estimate.bound == fused.bound for estimate in estimates)
+    assert all(estimate.uncertainty == fused.uncertainty for estimate in estimates)
+
+
+def test_roofline_compute_bound_split_puts_lm_head_on_last_layer():
+    families = (
+        KernelSpec("body", flops=90.0, bytes_moved=0.0),
+        KernelSpec("lm_head", flops=30.0, bytes_moved=0.0),
+    )
+    kernel = KernelSpec(
+        "llm_step",
+        flops=120.0,
+        bytes_moved=0.0,
+        family_kernels=families,
+    )
+    gpu = GpuSpec("one-flop-per-ps", peak_flops=1e12, mem_bandwidth=1e12)
+    provider = RooflineProvider(efficiency=1.0, enable_layer_breakdown=True)
+
+    estimates = provider.estimate_layers(kernel, gpu, num_layers=3)
+
+    assert estimates is not None
+    assert tuple(estimate.duration_ps for estimate in estimates) == (30, 30, 60)
+
+
+def test_roofline_layer_breakdown_rejects_invalid_contract_inputs():
+    family = KernelSpec("body", flops=10.0, bytes_moved=10.0)
+    kernel = KernelSpec(
+        "llm_step",
+        flops=11.0,
+        bytes_moved=10.0,
+        family_kernels=(family,),
+    )
+    provider = RooflineProvider(efficiency=1.0, enable_layer_breakdown=True)
+
+    with pytest.raises(ValueError, match="conserve"):
+        provider.estimate_layers(kernel, H100ish, num_layers=2)
+    with pytest.raises(ValueError, match="nonnegative"):
+        provider.estimate_layers(
+            KernelSpec(
+                "llm_step",
+                flops=-1.0,
+                bytes_moved=1.0,
+                family_kernels=(
+                    KernelSpec("body", flops=-1.0, bytes_moved=1.0),
+                ),
+            ),
+            H100ish,
+            num_layers=2,
+        )
+    with pytest.raises(ValueError, match="positive"):
+        provider.estimate_layers(
+            KernelSpec(
+                "llm_step",
+                flops=10.0,
+                bytes_moved=10.0,
+                family_kernels=(family,),
+            ),
+            H100ish,
+            num_layers=0,
+        )
 
 
 # ---- MoE geometry on ModelDims ----

--- a/tests/test_step_lowerer.py
+++ b/tests/test_step_lowerer.py
@@ -1,9 +1,15 @@
+import hashlib
 from dataclasses import replace
 
 import pytest
 
-from simllm.backends import SerialStepLowerer, SerialStepLowererConfig
-from simllm.compute import ModelDims
+from simllm.backends import (
+    HtsimStepSink,
+    HtsimStepSinkConfig,
+    SerialStepLowerer,
+    SerialStepLowererConfig,
+)
+from simllm.compute import ComputeProvider, DurationEstimate, ModelDims
 from simllm.core import (
     CollectiveWork,
     ComputeWork,
@@ -38,6 +44,24 @@ SMALL_MOE_DIMS = replace(
     moe_intermediate_size=512,
     local_num_experts=2,
 )
+
+SAMPLE_DIMS = ModelDims(
+    num_layers=2,
+    hidden_size=64,
+    intermediate_size=128,
+    num_heads=4,
+    num_kv_heads=4,
+    head_size=16,
+    vocab_size=256,
+    dtype_bytes=2,
+)
+
+B1_ABSENT_REPLAY_SHA256 = "7087db6780f7e34f5a559a6505eeccc15d984c7b478cd8f0bc5838053825d4b6"
+
+
+class FlopProvider(ComputeProvider):
+    def estimate(self, kernel, gpu):
+        return DurationEstimate(duration_ps=int(kernel.flops), bound="compute")
 
 
 def prefill_record() -> StepRecord:
@@ -103,6 +127,65 @@ def test_dense_graph_only_goal_is_byte_identical_to_legacy_goal():
         per_layer_calc_ns=12_030,
     )
     assert replay.render() == legacy.render()
+
+
+def test_b1_exact_sample_count_keeps_live_sink_and_serial_replay_equal(tmp_path):
+    scheduled = [
+        ScheduledRequest(
+            "p",
+            RequestPhase.PREFILL,
+            4,
+            num_cached_tokens=4,
+            context_length=8,
+        ),
+        ScheduledRequest("d", RequestPhase.DECODE, 1, context_length=32),
+    ]
+    exact_record = StepRecord(0, 0, scheduled, num_sampled=1)
+    absent_record = replace(exact_record, num_sampled=None)
+    provider = FlopProvider()
+    sink = HtsimStepSink(
+        HtsimStepSinkConfig(
+            profile="rnic-nn-fluid",
+            tp_ranks=(0, 1),
+            dims=SAMPLE_DIMS,
+            workdir=tmp_path / "live",
+            provider=provider,
+        )
+    )
+    lowerer = SerialStepLowerer(
+        SerialStepLowererConfig(SAMPLE_DIMS, (0, 1), provider=provider)
+    )
+
+    exact_estimate_ps = sink.compute_estimate_ps(exact_record)
+    exact_calc_ns = exact_estimate_ps // (SAMPLE_DIMS.num_layers * 1000)
+    exact_replay = render_serial_execution_graph_goal(lowerer.lower(exact_record))
+    exact_live = render_step_goal(
+        exact_record,
+        SAMPLE_DIMS,
+        (0, 1),
+        per_layer_calc_ns=exact_calc_ns,
+    )
+    assert exact_estimate_ps == 880_128
+    assert exact_calc_ns == 440
+    assert exact_replay.render() == exact_live.render()
+
+    absent_estimate_ps = sink.compute_estimate_ps(absent_record)
+    absent_calc_ns = absent_estimate_ps // (SAMPLE_DIMS.num_layers * 1000)
+    absent_replay = render_serial_execution_graph_goal(lowerer.lower(absent_record))
+    absent_live = render_step_goal(
+        absent_record,
+        SAMPLE_DIMS,
+        (0, 1),
+        per_layer_calc_ns=absent_calc_ns,
+    )
+    assert absent_estimate_ps == 912_896
+    assert absent_calc_ns == 456
+    assert absent_estimate_ps - exact_estimate_ps == 32_768
+    assert absent_replay.render() == absent_live.render()
+    assert (
+        hashlib.sha256(absent_replay.render().encode()).hexdigest()
+        == B1_ABSENT_REPLAY_SHA256
+    )
 
 
 def test_dense_tp1_lowers_and_renders_as_compute_only_work():

--- a/tests/test_step_sink.py
+++ b/tests/test_step_sink.py
@@ -95,6 +95,7 @@ def stub_backend(monkeypatch, makespan_ps=100_000):
         lambda _config: SimpleNamespace(
             job_completion_time_ps=lambda: makespan_ps,
             flows=[],
+            quiescent=True,
         ),
     )
 
@@ -171,6 +172,7 @@ def test_step_network_outcome_preserves_legacy_positional_shape():
     assert outcome.layer_calc_ns == ()
     assert outcome.num_sampled == 0
     assert not outcome.sample_count_exact
+    assert not outcome.quiescent
     assert outcome.network_share_for(2) == 0.5
 
 
@@ -316,6 +318,7 @@ def test_sink_uses_exact_sample_count_for_chunked_prefill(tmp_path, monkeypatch)
     assert exact.outcomes[0].num_sampled == 1
     assert exact.outcomes[0].sample_count_exact
     assert exact.outcomes[0].layer_calc_ns == (440, 440)
+    assert exact.outcomes[0].quiescent
 
 
 def test_sink_sample_count_identity_when_every_request_samples(tmp_path, monkeypatch):


### PR DESCRIPTION
Closes COMP-16 and VLLM-15. The roofline provider implements estimate_layers (per-layer durations summing exactly to the fused estimate, the LM head in the last layer's share) and SimExecutor populates StepRecord.num_sampled from its existing produces_token attribution, so both wave-1 seams now have live producers. The replay lowerer honors the field with the byte-identical fallback, closing the live-versus-replay divergence the review found.

Evidence under the wave-2 standard (freeze with dry-run and working-tree statements, decision-relevant and end-to-end relations): enabling the breakdown moves TTFT by the frozen +1,000 ps in all four layer-count by TP-width cells; adapter-exact sampling moves TTFT by the frozen -32,000 ps; a real vLLM v0.26.0 skeleton run attributes a chunked-prefill batch exactly (samples (0,1,1)); the default GOAL SHA lock holds. The review-tightened genuine-risk fraction is reported honestly at 63.6 percent, and the shape-sensitive check added on review is labeled post-specified. Both study modes were independently reproduced by the integrator.

Produced by a Codex worker under orchestrated integration with the four-lens review (house rules, compatibility, evidence audit, expectation critique); all findings folded. ruff clean; 453 passed, 3 skipped.