### PR TITLE
Advance the htsim pin with honest lifecycle provenance

### DIFF
--- a/docs/modules/backends.md
+++ b/docs/modules/backends.md
@@ -660,7 +660,8 @@ was registered. See the
 HTSIM-19 is retired without a backend change and its ID will not be reused.
 The earlier P0 entry incorrectly treated a 2 of 4 Tier B bypass result as a
 backend-main regression. Three unchanged-command reproductions showed 4 of 4
-with current `4885c64` link OFF, 2 of 4 with a pre-v2 link-ON build and 4 of 4
+with the then-current `4885c64` link OFF, 2 of 4 with a pre-v2 link-ON build and
+4 of 4
 with the frozen wave-4 link-OFF build. The signature follows the link setting.
 A link-ON binary selects the structural session for `rnic-nn` and `rnic-cn`
 by design and is not the legacy bypass candidate. The harness now keeps those

--- a/examples/bridge_lifecycle_v1/RESULTS.md
+++ b/examples/bridge_lifecycle_v1/RESULTS.md
@@ -14,6 +14,32 @@ The registered outputs are external to Git:
 - `$SIMLLM_WAVE5_RUN_ROOT/bridge1-identity/summary.json` contains the unchanged
   BRIDGE-1 diagnostic-versus-prepared identity run.
 
+## Post-specified pin-provenance note
+
+This note was added after the accepted run and is not preregistered or scored
+evidence. The accepted BRIDGE-3 outputs, including the real-binary
+corroboration, were produced with an `htsim_rnic` built from
+`4885c647eecdfdf81479d1df052223c016ad086b`. The superproject gitlink later
+moved to backend main commit
+`fc4400e4ca619223481536632074045cb6af2756`. The intervening pin regression
+occurred when bulk staging captured an initialized submodule checkout at the
+older commit after a merge had already resolved the newer gitlink.
+
+The newer gitlink does not retroactively change or invalidate the accepted
+lifecycle evidence. The scored 3/3 relation uses the executable stand-in and
+tests ownership and orphan reaping in the SimLLM invocation layer. The real
+`htsim_rnic` cell is separately classified as fatal unscored corroboration,
+and its exact binary hash and source revision remain part of the original
+record. No result-producing lifecycle run was repeated for this provenance
+correction.
+
+The registered runner now keeps the authoring source-audit commit distinct
+from the superproject gitlink observed when a command runs. Check-only output
+records both commit values and the validated executable paths. Any future
+result summary records both commit values together with the executable
+digests, without asserting that a moving current gitlink equals the historical
+audit commit.
+
 ## Live killed-owner relation
 
 Every owner received a real `SIGTERM` only after its exact marker count had

--- a/examples/bridge_lifecycle_v1/run_study.py
+++ b/examples/bridge_lifecycle_v1/run_study.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import os
 import platform
+import re
 import signal
 import subprocess
 import sys
@@ -18,7 +19,7 @@ from typing import Any
 HERE = Path(__file__).resolve().parent
 REPO_ROOT = HERE.parents[1]
 SIMLLM_BASE_COMMIT = "90ada43070adb3b1e624b6819aff34d8620e8571"
-HTSIM_COMMIT = "4885c647eecdfdf81479d1df052223c016ad086b"
+AUTHORING_HTSIM_COMMIT = "4885c647eecdfdf81479d1df052223c016ad086b"
 EXPECTATIONS_COMMIT = "78ef408c4d14f599359c673e146ffa9ecc012d2e"
 CELLS = (
     {"cell": "D1", "mode": "diagnostic", "max_workers": None, "targets": 1},
@@ -56,7 +57,7 @@ def _configured_executable(path: Path, option: str) -> Path:
     return resolved
 
 
-def _pinned_htsim_revision() -> str:
+def _observed_htsim_gitlink() -> str:
     return subprocess.run(
         ["git", "rev-parse", "HEAD:third_party/htsim"],
         cwd=REPO_ROOT,
@@ -85,9 +86,11 @@ def _validate_registry(arguments: argparse.Namespace) -> dict[str, object]:
         raise AssertionError("frozen lifecycle time bounds drifted")
     if STANDIN_SLEEP_S <= READY_TIMEOUT_S + POLL_TIMEOUT_S:
         raise AssertionError("stand-in must outlive readiness and post-kill polling")
-    pinned = _pinned_htsim_revision()
-    if pinned != HTSIM_COMMIT:
-        raise AssertionError(f"pinned HTSIM commit drifted: expected {HTSIM_COMMIT}, got {pinned}")
+    observed_gitlink = _observed_htsim_gitlink()
+    if re.fullmatch(r"[0-9a-f]{40}", observed_gitlink) is None:
+        raise AssertionError(
+            f"observed HTSIM gitlink is not a full commit hash: {observed_gitlink}"
+        )
     required = (
         REPO_ROOT / "examples" / "bridge_persistent_v1" / "run_study.py",
         VLLM_FIXTURE,
@@ -100,9 +103,10 @@ def _validate_registry(arguments: argparse.Namespace) -> dict[str, object]:
         raise FileNotFoundError(f"frozen study inputs are missing: {missing}")
     return {
         "artifacts_created": False,
+        "authoring_htsim_commit": AUTHORING_HTSIM_COMMIT,
         "cells": CELLS,
         "expectations_commit": EXPECTATIONS_COMMIT,
-        "pinned_htsim_commit": pinned,
+        "observed_htsim_gitlink": observed_gitlink,
         "real_htsim": str(real_htsim),
         "real_txt2bin": str(real_txt2bin),
         "standin_sleep_s": STANDIN_SLEEP_S,
@@ -543,7 +547,10 @@ def _run_study(arguments: argparse.Namespace, plan: dict[str, object]) -> None:
             "python": platform.python_version(),
             "system": platform.system(),
         },
-        "pinned_htsim_commit": plan["pinned_htsim_commit"],
+        "htsim_provenance": {
+            "authoring_source_audit_commit": plan["authoring_htsim_commit"],
+            "observed_superproject_gitlink": plan["observed_htsim_gitlink"],
+        },
         "raw_observations": rows,
         "real_binary_corroboration": real_row,
         "scored_relation_family": {

--- a/examples/rnic_live_v1/RESULTS.md
+++ b/examples/rnic_live_v1/RESULTS.md
@@ -339,7 +339,7 @@ diagnosis below shows this was a harness-role error.
 The packet mechanism itself reached the live chain in two nonqualifying forms:
 a direct Tier C invocation after the fourth outer attempt had already stopped,
 and a post-specified hybrid outer invocation that used the older accepted Tier
-B candidates. Both used the current `4885c64` composed build for ABI-v2
+B candidates. Both used the then-current `4885c64` composed build for ABI-v2
 production. The hybrid output is retained at
 `$SIMLLM_WAVE5_RUN_ROOT/codex/htsim9_packet_closure-postspecified-hybrid`.
 Its overall, Tier C raw and Tier C result SHA-256 values are respectively

--- a/tests/test_bridge_lifecycle_demo.py
+++ b/tests/test_bridge_lifecycle_demo.py
@@ -1,3 +1,4 @@
+import json
 import os
 import subprocess
 import sys
@@ -30,5 +31,18 @@ def test_bridge_lifecycle_check_only_creates_no_artifacts(tmp_path):
         text=True,
     )
 
-    assert '"artifacts_created": false' in completed.stdout
+    report = json.loads(completed.stdout)
+    observed_gitlink = subprocess.run(
+        ["git", "rev-parse", "HEAD:third_party/htsim"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    assert report["artifacts_created"] is False
+    assert report["authoring_htsim_commit"] == (
+        "4885c647eecdfdf81479d1df052223c016ad086b"
+    )
+    assert report["observed_htsim_gitlink"] == observed_gitlink
     assert not out.exists()


### PR DESCRIPTION
Main's `third_party/htsim` pin was `4885c64`, the wave-4 ABI-v2 commit, while `docs/modules/backends.md` states the pin carries the ABI-v2 physical control producers and the persistent flow session, and two landed studies were run against binaries built from the newer backend. Anyone rebuilding from main's pin would not reproduce them.

The pin regressed during integration, and the cause was mine: the last wave-5 branch to merge had an initialized submodule checkout at the older commit, so staging that merge with `git add -A` recorded the submodule's checked-out HEAD over the gitlink the merge had already resolved. The stale value then rode onto main behind a clean, green merge.

A pin-only fix was not sufficient and its CI proved it. `examples/bridge_lifecycle_v1/run_study.py` froze the pin as a literal and asserted it equalled `HEAD:third_party/htsim`, so main could not move off the stale commit without that study's provenance moving in the same change.

The provenance is now recorded honestly rather than conveniently. The lifecycle study's accepted evidence genuinely ran at `4885c64`, and its scored relation concerns process-group ownership and orphan reaping, which do not depend on simulator internals. Relabelling that historical source as `fc4400e` would have been false, and rebuilding purely to satisfy a pin bump would have manufactured a second result chronology for no evidentiary gain. The runner therefore records the authoring-time audit commit and the gitlink observed at execution separately, with no equality assumption, and RESULTS carries a labelled post-specified note explaining the move and its cause. The frozen expectations are untouched and no new scored evidence is claimed.

An audit of every other frozen-pin site found no second instance of this coupling: the remaining references describe historical source audits or validate an explicitly supplied source tree, so no shared-helper residual was needed.

Gates: ruff clean, 830 pytest, native suite 350/350 built at `fc4400e`, the registered lifecycle check-only reporting both commits and creating no artifacts, and the task-progress check current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)