### PR TITLE
Make the module doc format a checked contract

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,9 @@ ctest --test-dir build/rnic --output-on-failure
 
 - Keep the core framework-agnostic: nothing in `simllm/core`, `simllm/goal`
   or `simllm/backends` may import vLLM or SGLang.
+- Module docs under `docs/modules/` follow the skeleton in
+  [docs/modules/FORMAT.md](docs/modules/FORMAT.md). `pytest -q` checks it; run
+  `python scripts/check_docs_format.py` for the messages on their own.
 - Changes to the backend simulators belong in their own repos
   (`third_party/atlahs`, `third_party/htsim`); SimLLM only pins refs.
 - Add a test for every new module. CI must stay green.

--- a/docs/modules/FORMAT.md
+++ b/docs/modules/FORMAT.md
@@ -1,0 +1,128 @@
+# Module doc format
+
+Every module doc under `docs/modules/` follows one skeleton, so a reader can
+move between modules without relearning the layout and so the open-task
+registry stays machine-checkable. `scripts/check_docs_format.py` is the
+executable half of this document, and `tests/test_docs_format.py` runs it, so
+`pytest -q` and CI fail on a violation.
+
+This file and any `README.md` in the same directory are not module docs and
+are excluded from the check.
+
+## Skeleton
+
+```
+# <module identity>                     level-1 title, first non-blank line
+
+<summary paragraph>                     what the module is, in prose
+
+## <optional context sections>          e.g. "## Why" for a design-only module
+## Interface                            required: the surface other code uses
+## <optional design sections>           mechanism detail, contracts, tables
+## Status                               required: what is landed and validated
+## Open tasks                           required: the registry, see below
+## <optional trailing registry>         e.g. backend-repo follow-ups
+```
+
+Rules the linter enforces:
+
+- Exactly one level-1 heading, and it is the first non-blank line.
+- A non-empty summary paragraph sits between the title and the first section.
+- `## Interface`, `## Status` and `## Open tasks` each appear exactly once,
+  in that relative order.
+- `## Open tasks` directly follows `## Status`. Design detail belongs above
+  `## Status`, not between the two. A doc that wants a long plan for one task
+  (see [compute.md](compute.md)) puts that section in the design block.
+- Optional sections are free in title and count. Context sections may precede
+  `## Interface`; detail sections sit between `## Interface` and `## Status`.
+
+## Task registry sections
+
+A registry section carries task entries. `## Open tasks` is always one; a
+section whose title contains "follow-ups" is also one, which is how
+[backends.md](backends.md) tracks work executed in the backend repos. Task
+entries are not allowed anywhere else.
+
+A registry section is laid out as:
+
+```
+## Open tasks
+
+<optional preamble: the tag legend, closure and retraction notes>
+
+### Precision
+- <ID> (Precision; P<n>; S|M|L): <what the current approximation is and what
+  observable identifies the replacement>
+
+### Completeness
+- <ID> (Completeness; P<n>; S|M|L): <the unavailable path and the off path
+  that must be preserved>
+
+### Uncategorized
+- <ID>: <legacy entry that predates the category rule>
+```
+
+Rules the linter enforces:
+
+- The only third-level headings inside a registry section are
+  `### Precision`, `### Completeness` and `### Uncategorized`, each at most
+  once, in that order. Precision comes first because active-path precision
+  normally precedes P2 completeness (AGENTS.md).
+- A bucket is present only when it has entries. A registry with no open work
+  says so in prose (see [goal.md](goal.md)) and carries no buckets.
+- Every task entry sits inside a bucket, never directly under the section
+  heading and never in the preamble.
+- An entry tagged `(Precision; ...)` sits under `### Precision`, an entry
+  tagged `(Completeness; ...)` under `### Completeness`, and an entry with no
+  category tag under `### Uncategorized`.
+- Task ids are unique within a file.
+- Closure and retraction notes go in the preamble, above the buckets, so the
+  buckets hold open work only.
+
+### Task entry grammar
+
+```
+- <PREFIX>-<n> (<Category>; P<0-2>; <S|M|L>)[ (<qualifier>)]: <description>
+```
+
+`<PREFIX>` is the module's stable prefix (`CORE-`, `WORK-`, `COMP-`,
+`PLACE-`, `TRAF-`, `GOAL-`, `PLAY-`, `BACK-`, `VLLM-`, `SGL-`, `BRIDGE-`, and
+`HTSIM-`/`ATLAHS-` for backend-repo follow-ups). The category tag is the first
+parenthetical after the id; an optional second parenthetical carries a
+qualifier such as `(remaining half)`. Categories, priorities and difficulties
+are defined in AGENTS.md, which is the authority on what each level means.
+
+### The Uncategorized bucket
+
+AGENTS.md migrates existing entries to a category when the task is next
+changed, not through unrelated bulk churn. `### Uncategorized` is where those
+entries wait: it makes the remaining migration debt countable without forcing
+anyone to invent a priority and difficulty they cannot defend. The linter
+prints the per-file count as a note. Moving an entry out of this bucket means
+assigning a real `(Category; P<n>; S|M|L)` tag, so it is a content change and
+belongs with the change that touches the task.
+
+## Writing style
+
+The repo-wide rules in AGENTS.md apply here in full. The one the linter adds
+to the structural rules above is the em dash ban: the em dash character
+(U+2014) appears nowhere in these docs, in prose or in code blocks. Use
+"i.e.", "e.g.", commas, colons, semicolons or parentheses instead. Markdown
+table separators (`|---|`) are fine.
+
+The rules the linter does not check still hold, in particular the filesystem
+path portability rule: no absolute paths and no path components derived from a
+person, account, home directory or machine in any tracked Markdown file.
+
+## Running the check
+
+```bash
+python scripts/check_docs_format.py
+```
+
+It exits non-zero and prints `path:line: message` for every violation. Pass
+explicit paths to check a subset:
+
+```bash
+python scripts/check_docs_format.py docs/modules/backends.md
+```

--- a/docs/modules/adapters-sglang.md
+++ b/docs/modules/adapters-sglang.md
@@ -293,8 +293,14 @@ communication by exactly the whole of it.
 
 ## Open tasks
 
-- SGL-3: RadixCache-aware studies: prefix-hit rate and re-prefill traffic
-  vs shared-prefix workload structure.
+Closed this milestone: SGL-1 (the worker, this module). SGL-2 (upstream
+worker-class selection flag) closed as moot 2026-08-04: SGLang's plugin
+framework (`sglang.srt.plugins` entry points plus `HookRegistry` `REPLACE`
+hooks, run before scheduler construction) is a supported non-fork selection
+seam, so no upstream flag is needed.
+
+### Precision
+
 - SGL-4 (Precision; P1; L) (remaining half): a paced-mode run checked against
   SGLang's own wall-clock metrics, a workload that actually exercises radix
   hits
@@ -308,19 +314,6 @@ communication by exactly the whole of it.
   mixed/bursty cases. Report p50 through p99.9 TTFT/TPOT and attributed queue,
   KV, kernel, collective, DMA, WQE/NIC, flow and control residuals. Calibrate
   early stages and reserve later stages as holdouts.
-- SGL-5: logprobs, speculative decoding and the dLLM/hybrid modes are
-  refused or unreachable rather than fabricated.
-- SGL-6: overlap-schedule support (the scheduler-side dual-stream loop with
-  its result queue; needs delayed-sample semantics in the fabricated
-  result). Its observed host-side order and completion waits lower to graph
-  dependencies; device overlap itself remains owned by CORE-4/TRAF-7.
-- SGL-7: mamba/hybrid-attention models need the auxiliary-state pool the
-  stub does not build; the stub currently builds a plain `ReqToTokenPool`
-  only.
-- SGL-8: a live closed-loop run with `HtsimStepSink` installed via
-  `configure(step_sink=...)` on the CPU-engine smoke path, mirroring the
-  vLLM tp=8 run of examples/m4 (the M4 slice covered this adapter by
-  JSONL replay only).
 - SGL-9 (Precision; P1; L) (remaining after the CPU-oracle lifecycle slice):
   the v2 fallback now observes stock Radix prefix matching, token-slot
   allocation, radix eviction and decode retraction with request and slot IDs.
@@ -332,37 +325,12 @@ communication by exactly the whole of it.
   event cardinality, identity and cause agreement against those objects, a
   direct comparison with VLLM-11, and byte preservation of the current v2 and
   oracle-disabled paths.
-- SGL-10: capture and replay the supported model runner's CUDA stream/event,
-  kernel and NCCL schedule as an `ExecutionGraph` template keyed by the same
-  identity envelope as its compute table. Bind batch shapes, radix events and
-  overlap-scheduler dependencies at runtime; never infer device concurrency
-  from a single elapsed phase duration.
-- SGL-11 (Completeness; P1; L) (remaining after the zero-time first slice):
-  extend the SGLang-shaped mirror only as accepted adapter modes make further
-  pinned `GroupCoordinator` calls reachable. In particular, DCP attention and
-  MoE paths still invoke `all_gather_into_tensor`, `reduce_scatter_tensor`,
-  `all_gatherv`, and `reduce_scatterv`; the current dense TP worker neither
-  claims nor silently fabricates them. Freeze each supported call site's
-  signature, shape contract, enabled behavior, and exact disabled baseline
-  before adding it. The landed slice mirrors `all_reduce`, `all_gather`,
-  `broadcast`, `send`, and `recv`, including SGLang's added
-  `all_gather(..., output_tensor_list=None)` form, on the shared VLLM-14
-  zero-time event base. SGL-13 owns runtime projection, SGL-14 owns native
-  operation-specific lowerings, and SGL-15 preserves the real-call
-  bottleneck-study clause.
 - SGL-12 (Precision; P1; M): source and populate exact
   `StepRecord.num_sampled` at the worker seam. Distinguish a mid-prompt extend
   row from the extend step that reaches `origin_input_ids`, including radix
   hits, retracted prefills and MIXED batches; prove the count matches the rows
   for which SGLang consumes a generated token. Keep the absent field as the
   explicit compatibility path.
-- SGL-13 (Completeness; P1; L): now that CORE-4 and CORE-5 have landed,
-  project each
-  simulated SGLang communicator `CollectiveWork` through the single runtime
-  authority into `CompletionEvent`, `StepResult`, and TTFT/TPOT. Freeze a
-  fixed-workload signed metric relation and quantitative band first. The
-  disabled projection must preserve every accepted SGLang worker timestamp,
-  token, record byte, and completion order exactly.
 - SGL-14 (Precision; P1; M): replace the zero-time
   `ncclAllReduce`-shaped compatibility call for SGLang all-gather, broadcast,
   send, and receive with native COMP stack entries when those entries exist.
@@ -378,15 +346,6 @@ communication by exactly the whole of it.
   one model and group size, require modeled median and p95 call cost within a
   pre-registered band, then verify the signed TTFT/TPOT effect and exact
   zero-cost bypass.
-- SGL-17 (Completeness; P2; L): add the SGLang communicator's source-backed
-  observed schedule as `ExecutionObservations`, including exact per-layer
-  semantic sites, logical streams, submission and program order, event-wait
-  dependencies, request correlation, and completion frontier for every
-  supported call. Derive concurrency only from the active communicator and
-  scheduler source, with no overlap percentage or compatibility-schedule
-  inference. When the producer is disabled or absent, preserve the accepted
-  worker records, event sidecar, sink calls, timestamps, tokens, and completion
-  order exactly.
 - SGL-16 (Precision; P1; M): replace the framework-oracle fallback's Granite
   model-order layer inference with stable layer IDs supplied by SGLang. The
   current surrogate cycles missing capture labels through the model's 24 MoE
@@ -397,8 +356,58 @@ communication by exactly the whole of it.
   request outputs and KV events relative to the current qualified Granite
   fallback.
 
-Closed this milestone: SGL-1 (the worker, this module). SGL-2 (upstream
-worker-class selection flag) closed as moot 2026-08-04: SGLang's plugin
-framework (`sglang.srt.plugins` entry points plus `HookRegistry` `REPLACE`
-hooks, run before scheduler construction) is a supported non-fork selection
-seam, so no upstream flag is needed.
+### Completeness
+
+- SGL-11 (Completeness; P1; L) (remaining after the zero-time first slice):
+  extend the SGLang-shaped mirror only as accepted adapter modes make further
+  pinned `GroupCoordinator` calls reachable. In particular, DCP attention and
+  MoE paths still invoke `all_gather_into_tensor`, `reduce_scatter_tensor`,
+  `all_gatherv`, and `reduce_scatterv`; the current dense TP worker neither
+  claims nor silently fabricates them. Freeze each supported call site's
+  signature, shape contract, enabled behavior, and exact disabled baseline
+  before adding it. The landed slice mirrors `all_reduce`, `all_gather`,
+  `broadcast`, `send`, and `recv`, including SGLang's added
+  `all_gather(..., output_tensor_list=None)` form, on the shared VLLM-14
+  zero-time event base. SGL-13 owns runtime projection, SGL-14 owns native
+  operation-specific lowerings, and SGL-15 preserves the real-call
+  bottleneck-study clause.
+- SGL-13 (Completeness; P1; L): now that CORE-4 and CORE-5 have landed,
+  project each
+  simulated SGLang communicator `CollectiveWork` through the single runtime
+  authority into `CompletionEvent`, `StepResult`, and TTFT/TPOT. Freeze a
+  fixed-workload signed metric relation and quantitative band first. The
+  disabled projection must preserve every accepted SGLang worker timestamp,
+  token, record byte, and completion order exactly.
+- SGL-17 (Completeness; P2; L): add the SGLang communicator's source-backed
+  observed schedule as `ExecutionObservations`, including exact per-layer
+  semantic sites, logical streams, submission and program order, event-wait
+  dependencies, request correlation, and completion frontier for every
+  supported call. Derive concurrency only from the active communicator and
+  scheduler source, with no overlap percentage or compatibility-schedule
+  inference. When the producer is disabled or absent, preserve the accepted
+  worker records, event sidecar, sink calls, timestamps, tokens, and completion
+  order exactly.
+
+### Uncategorized
+
+- SGL-3: RadixCache-aware studies: prefix-hit rate and re-prefill traffic
+  vs shared-prefix workload structure.
+- SGL-5: logprobs, speculative decoding and the dLLM/hybrid modes are
+  refused or unreachable rather than fabricated.
+- SGL-6: overlap-schedule support (the scheduler-side dual-stream loop with
+  its result queue; needs delayed-sample semantics in the fabricated
+  result). Its observed host-side order and completion waits lower to graph
+  dependencies; device overlap itself remains owned by CORE-4/TRAF-7.
+- SGL-7: mamba/hybrid-attention models need the auxiliary-state pool the
+  stub does not build; the stub currently builds a plain `ReqToTokenPool`
+  only.
+- SGL-8: a live closed-loop run with `HtsimStepSink` installed via
+  `configure(step_sink=...)` on the CPU-engine smoke path, mirroring the
+  vLLM tp=8 run of examples/m4 (the M4 slice covered this adapter by
+  JSONL replay only).
+- SGL-10: capture and replay the supported model runner's CUDA stream/event,
+  kernel and NCCL schedule as an `ExecutionGraph` template keyed by the same
+  identity envelope as its compute table. Bind batch shapes, radix events and
+  overlap-scheduler dependencies at runtime; never infer device concurrency
+  from a single elapsed phase duration.
+

--- a/docs/modules/core.md
+++ b/docs/modules/core.md
@@ -439,6 +439,41 @@ call the compute service model rather than grow a second SM or SASS model in
 `simllm.core`. The compute slice therefore does not claim whole-task execution
 timing or compute/copy overlap.
 
+## Pre-registered runtime sanity experiments
+
+These expectations are recorded before CORE-4 implements scheduling. CORE-2
+does not claim to produce these resource-contention measurements.
+
+1. **Dependency versus legal overlap.** Release one compute operation of C
+   picoseconds and one DMA operation of D picoseconds on independent logical
+   queues with ideal independent resources. With no edge, makespan must be
+   `max(C, D)`; adding a dependency must make it `C + D`. Sweep both the
+   dependency setting and two demand pairs, `(C, D) = (10 us, 40 us)` and
+   `(80 us, 40 us)`. Every result must match exactly in the ideal profile.
+2. **Eight GPU-affine RNICs.** Each active GPU submits one aligned WQE of B
+   bytes from its own FIFO/QP to its own rail RNIC, with no propagation or
+   protocol overhead in the ideal profile. Sweep active GPUs N in `{1, 8}`
+   and per-port rate R in `{200, 400}` Gbit/s. The phase makespan must be
+   `8 * B / R` seconds independent of N, aggregate useful throughput must be
+   `N * R`, and doubling R halves makespan exactly. Per-GPU FIFO order must
+   remain stable under both rates.
+3. **Tail attribution conservation.** For every completed operation, the sum
+   of critical-path time attributed to launch queue, device queue, service and
+   completion delivery must equal its end-to-end latency exactly. Separately
+   report the sum over all queue visits, which may exceed latency when visits
+   overlap and therefore must not enter that identity. No interval may be
+   negative, and graph completion must equal the latest required completion
+   event. Sweep synchronous versus asynchronous control delivery and two
+   control-class labels under identity. Class labels must move nothing; only
+   dependency-reachable work may move. Priority-caused movement belongs to the
+   class-aware policies, never to identity.
+4. **Identity arbitration is the exact off path.** Run each shared resource
+   with omitted class arbitration and with the explicit identity policy, then
+   permute class labels without changing arrivals or service demand. Event
+   order, every timestamp, all wait and byte counters, random draws and final
+   JCT must remain byte-identical. A separately enabled priority policy may
+   change only the order of simultaneously legal ready requests.
+
 ## Status
 
 Step records and the virtual clock (`VirtualClock`: heap-ordered events,
@@ -798,41 +833,6 @@ and never earlier. PLAY-13 and CORE-34 were accepted under the barrier
 configuration, and that qualification is now discharged; see
 [the routing lifetime results](../../examples/routing_lifetime_v1/RESULTS.md).
 
-## Pre-registered runtime sanity experiments
-
-These expectations are recorded before CORE-4 implements scheduling. CORE-2
-does not claim to produce these resource-contention measurements.
-
-1. **Dependency versus legal overlap.** Release one compute operation of C
-   picoseconds and one DMA operation of D picoseconds on independent logical
-   queues with ideal independent resources. With no edge, makespan must be
-   `max(C, D)`; adding a dependency must make it `C + D`. Sweep both the
-   dependency setting and two demand pairs, `(C, D) = (10 us, 40 us)` and
-   `(80 us, 40 us)`. Every result must match exactly in the ideal profile.
-2. **Eight GPU-affine RNICs.** Each active GPU submits one aligned WQE of B
-   bytes from its own FIFO/QP to its own rail RNIC, with no propagation or
-   protocol overhead in the ideal profile. Sweep active GPUs N in `{1, 8}`
-   and per-port rate R in `{200, 400}` Gbit/s. The phase makespan must be
-   `8 * B / R` seconds independent of N, aggregate useful throughput must be
-   `N * R`, and doubling R halves makespan exactly. Per-GPU FIFO order must
-   remain stable under both rates.
-3. **Tail attribution conservation.** For every completed operation, the sum
-   of critical-path time attributed to launch queue, device queue, service and
-   completion delivery must equal its end-to-end latency exactly. Separately
-   report the sum over all queue visits, which may exceed latency when visits
-   overlap and therefore must not enter that identity. No interval may be
-   negative, and graph completion must equal the latest required completion
-   event. Sweep synchronous versus asynchronous control delivery and two
-   control-class labels under identity. Class labels must move nothing; only
-   dependency-reachable work may move. Priority-caused movement belongs to the
-   class-aware policies, never to identity.
-4. **Identity arbitration is the exact off path.** Run each shared resource
-   with omitted class arbitration and with the explicit identity policy, then
-   permute class labels without changing arrivals or service demand. Event
-   order, every timestamp, all wait and byte counters, random draws and final
-   JCT must remain byte-identical. A separately enabled priority policy may
-   change only the order of simultaneously legal ready requests.
-
 ## Open tasks
 
 ### Precision
@@ -985,24 +985,6 @@ does not claim to produce these resource-contention measurements.
   each destination on its exact local predecessor frontier, conserve the
   selected causal timestamp through reporting and completion reduction, and
   preserve every accepted control byte and timestamp when the path is absent.
-- CORE-26 (Precision; P1; L): replace the cross-node collective path's current
-  independent GPU-versus-RNIC surrogate with one runtime composition of the
-  GPU-resident NCCL task and the existing WQE/NIC authority. Consume the
-  resource demands calibrated by COMP-22 and compose with CORE-13 and COMP-11
-  rather than adding a second SM, HBM or NVLink scheduler. Sweep payload,
-  participant count, channel count and compute-neighbor pressure across the
-  crossover; require TTFT and TPOT to enter the measured overlap bands and
-  reconcile every GPU and network byte exactly. Zero GPU demand and disabled
-  composition must preserve every accepted TRAF-7 timestamp and artifact byte.
-- CORE-27 (Precision; P1; L): add only the data-mover resources that COMP-22
-  observes on the cross-node NCCL path, including copy-engine or GPUDirect DMA
-  visits when present, plus their shared-HBM interaction and downstream
-  visibility. The current surrogate charges no such visit. Identify eligibility,
-  grant, release and consumer-visible completion from a reproducible concurrent
-  capture; vary transfer size, direction and competing copy pressure and match
-  held-out queue wait and JCT within the declared measurement band. An observed
-  no-copy path must stay explicitly zero, and disabling this mechanism must
-  preserve the CORE-26 baseline exactly.
 - CORE-32 (Completeness; P2; L): model optional framework or server admission
   control after arrival eligibility, including rejection, rate limits,
   concurrency caps and policy-driven deferral, without duplicating the

--- a/docs/modules/placement.md
+++ b/docs/modules/placement.md
@@ -57,6 +57,8 @@ no manifest schema change. General `unique-nic` projection remains PLACE-2.
 
 ## Open tasks
 
+### Completeness
+
 - PLACE-1 (Completeness; P2; L): fabric topology schema contents and general
   NIC selection in the mapper, sourcing intra-node structure from NCCL
   topology dumps. This is no longer blocked: CORE-4 validated the first
@@ -70,6 +72,9 @@ no manifest schema change. General `unique-nic` projection remains PLACE-2.
   `gpu-rank` and `unique-nic`
   happen to have the same cardinality there, but the general mapper must not
   assume that affinity.
+
+### Uncategorized
+
 - PLACE-3: expert-parallel group memberships and declared expert ownership
   in `declared_manifest`. The builder emits tp/pp/dp groups only, so the
   M5 MoE studies pass an explicit `ep_ranks` list to `HtsimStepSink`

--- a/docs/modules/preplay.md
+++ b/docs/modules/preplay.md
@@ -23,6 +23,30 @@ request's route, length and output are predefined, which is what lets the
 skeleton coupling mode (VLLM-13) run its name-mirrored virtual functions
 and still produce a real simulation.
 
+## Interface
+
+The surface other code uses, all exported from `simllm.preplay`:
+
+- **Capture.** `TransformersCpuRunner` is the baseline runner; `VllmCpuRunner`
+  and `SglangCpuRunner` capture through the real frameworks. Each is
+  configured by `SamplingConfig` and `SamplingMode` and yields a
+  `PreplayTrace` or `FrameworkPreplayTrace` of `RequestTrace` and
+  `ForwardTokenTrace` records with per-layer `LayerRouting`.
+- **Artifacts.** `PREPLAY_TRACE_SCHEMA`, `FRAMEWORK_PREPLAY_TRACE_SCHEMA`,
+  `ROUTED_EXPERTS_SCHEMA`, `ROUTING_ARENA_SCHEMA` and
+  `PREPLAY_REPLAY_RUN_SCHEMA` tag the on-disk forms. `PreplayTraceWriter` and
+  `PreplayTraceReader` stream them per request, and the `write_*` and
+  `validate_*` families are the only supported way to emit or accept one.
+- **Join.** `RequestArrival` plus a trace joins into `PreplayReplayRun` of
+  `JoinedRequest` records, which is what pins each request's arrival, output
+  length, stop reason and routing for a replay.
+- **Routing supply.** `RoutingArena` with `RoutingArenaIndex` and
+  `RoutingArenaRequestView` is the packed per-token routing form the traffic
+  expansion consumes; `RoutingReference` names the artifact a run used.
+- **Observed dispatch.** `ObservedTokenDispatch` and `ObservedLayerDispatch`
+  under `OBSERVED_DISPATCH_SOURCE` carry framework-observed routing, and
+  `KvCacheEvent` with `KvEventKind` carries the framework's own KV decisions.
+
 ## Design
 
 - **Runner.** Given the model identity (name, revision, dtype, tokenizer

--- a/docs/modules/workload.md
+++ b/docs/modules/workload.md
@@ -31,13 +31,18 @@ Shared-prefix prompt structure is not started.
 
 ## Open tasks
 
-- WORK-1: shared-prefix prompt structure (system-prompt pools, multi-turn
-  sessions) emitting token-ID sequences; the length-distribution part of
-  this task landed with M1.
-- WORK-2: bursty/MMPP arrival process for congestion-sensitive studies.
+### Completeness
+
 - WORK-4 (Completeness; P2; L): add a server-mode ingress coordinator that
   maps external request injection to simulated time without using wall-clock
   sleeps as model time. It must retain the in-process gate and ungated server
   path as explicit identity modes, preserve framework scheduler authority,
   and measure the coordinator's queue contribution separately from framework
   queueing.
+
+### Uncategorized
+
+- WORK-1: shared-prefix prompt structure (system-prompt pools, multi-turn
+  sessions) emitting token-ID sequences; the length-distribution part of
+  this task landed with M1.
+- WORK-2: bursty/MMPP arrival process for congestion-sensitive studies.

--- a/scripts/check_docs_format.py
+++ b/scripts/check_docs_format.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""Structural linter for the module docs under `docs/modules/`.
+
+The contract this script enforces is written down in `docs/modules/FORMAT.md`;
+this file is the executable half of that document. `tests/test_docs_format.py`
+runs it, so `pytest -q` and CI fail on a violation.
+
+Usage:
+
+    python scripts/check_docs_format.py                 # lint docs/modules
+    python scripts/check_docs_format.py path/to/doc.md  # lint specific files
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_DOC_DIR = REPO_ROOT / "docs" / "modules"
+
+#: Files in the module doc directory that are not module docs.
+EXCLUDED_FILES = frozenset({"FORMAT.md", "README.md"})
+
+#: Required second-level sections, in the order they must appear.
+REQUIRED_SECTIONS = ("Interface", "Status", "Open tasks")
+
+#: Third-level task buckets inside a registry section, in the order they must
+#: appear. "Uncategorized" holds legacy entries that predate the category rule;
+#: AGENTS.md migrates them when a task is next edited, not in bulk.
+CATEGORY_SECTIONS = ("Precision", "Completeness", "Uncategorized")
+
+#: Stable task-ID prefixes owned by the module registries (AGENTS.md).
+TASK_PREFIXES = (
+    "ATLAHS",
+    "BACK",
+    "BRIDGE",
+    "COMP",
+    "CORE",
+    "GOAL",
+    "HTSIM",
+    "PLACE",
+    "PLAY",
+    "SGL",
+    "TRAF",
+    "VLLM",
+    "WORK",
+)
+
+_PREFIX_ALT = "|".join(TASK_PREFIXES)
+
+HEADING_RE = re.compile(r"^(#{1,6})\s+(.*?)\s*$")
+FENCE_RE = re.compile(r"^\s*(?:```|~~~)")
+TASK_RE = re.compile(rf"^-\s+(?P<id>(?:{_PREFIX_ALT})-\d+)\b")
+TAG_RE = re.compile(
+    rf"^-\s+(?:{_PREFIX_ALT})-\d+\s+"
+    r"\((?P<category>Precision|Completeness);\s*"
+    r"(?P<priority>P[0-2]);\s*(?P<difficulty>[SML])\)"
+)
+#: A second-level section that carries task entries.
+REGISTRY_TITLE_RE = re.compile(r"^(?:Open tasks\b|.*\bfollow-ups\b)", re.IGNORECASE)
+
+#: The banned punctuation dash, spelled by codepoint so this file stays clean.
+EM_DASH = "\u2014"
+
+
+@dataclass(frozen=True)
+class Heading:
+    level: int
+    title: str
+    line: int
+
+
+@dataclass(frozen=True)
+class Task:
+    task_id: str
+    line: int
+    category: str | None
+    section: str | None
+    subsection: str | None
+
+
+@dataclass
+class Document:
+    path: Path
+    headings: list[Heading]
+    tasks: list[Task]
+    first_content_line: int
+    em_dash_lines: list[int]
+    body_lines: list[int]
+
+    @property
+    def sections(self) -> list[Heading]:
+        return [h for h in self.headings if h.level == 2]
+
+    def children(self, section: Heading) -> list[Heading]:
+        """Third-level headings owned by `section`."""
+        out: list[Heading] = []
+        for heading in self.headings:
+            if heading.line <= section.line:
+                continue
+            if heading.level <= 2:
+                break
+            if heading.level == 3:
+                out.append(heading)
+        return out
+
+
+def is_registry(title: str) -> bool:
+    return bool(REGISTRY_TITLE_RE.match(title))
+
+
+def parse(path: Path) -> Document:
+    headings: list[Heading] = []
+    tasks: list[Task] = []
+    em_dash_lines: list[int] = []
+    body_lines: list[int] = []
+    first_content_line = 0
+    in_fence = False
+    current_section: str | None = None
+    current_subsection: str | None = None
+
+    for number, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if EM_DASH in raw:
+            em_dash_lines.append(number)
+        if raw.strip() and not first_content_line:
+            first_content_line = number
+
+        if FENCE_RE.match(raw):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+
+        heading = HEADING_RE.match(raw)
+        if heading:
+            level = len(heading.group(1))
+            title = heading.group(2)
+            headings.append(Heading(level, title, number))
+            if level <= 2:
+                current_section = title if level == 2 else None
+                current_subsection = None
+            elif level == 3:
+                current_subsection = title
+            continue
+
+        if raw.strip():
+            body_lines.append(number)
+
+        task = TASK_RE.match(raw)
+        if task:
+            tag = TAG_RE.match(raw)
+            tasks.append(
+                Task(
+                    task_id=task.group("id"),
+                    line=number,
+                    category=tag.group("category") if tag else None,
+                    section=current_section,
+                    subsection=current_subsection,
+                )
+            )
+
+    return Document(
+        path=path,
+        headings=headings,
+        tasks=tasks,
+        first_content_line=first_content_line,
+        em_dash_lines=em_dash_lines,
+        body_lines=body_lines,
+    )
+
+
+def _check_title(doc: Document, errors: list[tuple[int, str]]) -> None:
+    titles = [h for h in doc.headings if h.level == 1]
+    if not titles:
+        errors.append((1, "missing the level-1 title heading"))
+        return
+    if titles[0].line != doc.first_content_line:
+        errors.append((titles[0].line, "the level-1 title must be the first non-blank line"))
+    for extra in titles[1:]:
+        errors.append((extra.line, f"only one level-1 heading is allowed, found {extra.title!r}"))
+
+    sections = doc.sections
+    summary_end = sections[0].line if sections else 10**9
+    has_summary = any(titles[0].line < line < summary_end for line in doc.body_lines)
+    if not has_summary:
+        errors.append(
+            (
+                titles[0].line,
+                "the title must be followed by a summary paragraph before the first section",
+            )
+        )
+
+
+def _check_required_sections(doc: Document, errors: list[tuple[int, str]]) -> None:
+    sections = doc.sections
+    titles = [h.title for h in sections]
+    positions: dict[str, int] = {}
+    for required in REQUIRED_SECTIONS:
+        found = [i for i, title in enumerate(titles) if title == required]
+        if not found:
+            errors.append((1, f"missing the required section '## {required}'"))
+            continue
+        for duplicate in found[1:]:
+            errors.append(
+                (sections[duplicate].line, f"section '## {required}' appears more than once")
+            )
+        positions[required] = found[0]
+
+    ordered = [positions[name] for name in REQUIRED_SECTIONS if name in positions]
+    if ordered != sorted(ordered):
+        errors.append(
+            (
+                sections[ordered[0]].line if ordered else 1,
+                "required sections must appear in the order "
+                + " then ".join(f"'## {name}'" for name in REQUIRED_SECTIONS),
+            )
+        )
+
+    if "Status" in positions and "Open tasks" in positions:
+        status_index = positions["Status"]
+        if titles[status_index + 1 : status_index + 2] != ["Open tasks"]:
+            offending = sections[status_index + 1] if status_index + 1 < len(sections) else None
+            errors.append(
+                (
+                    offending.line if offending else sections[status_index].line,
+                    (
+                        "'## Open tasks' must directly follow '## Status'; "
+                        "move design detail above '## Status'"
+                    ),
+                )
+            )
+
+
+def _check_registry_sections(doc: Document, errors: list[tuple[int, str]]) -> None:
+    for section in doc.sections:
+        children = doc.children(section)
+        if not is_registry(section.title):
+            for child in children:
+                if child.title in CATEGORY_SECTIONS:
+                    errors.append(
+                        (
+                            child.line,
+                            (
+                                f"'### {child.title}' belongs in a task registry "
+                                f"section, not '## {section.title}'"
+                            ),
+                        )
+                    )
+            continue
+
+        seen: list[str] = []
+        for child in children:
+            if child.title not in CATEGORY_SECTIONS:
+                errors.append(
+                    (
+                        child.line,
+                        f"'### {child.title}' is not a task bucket; allowed buckets are "
+                        + ", ".join(f"'### {name}'" for name in CATEGORY_SECTIONS),
+                    )
+                )
+                continue
+            if child.title in seen:
+                errors.append(
+                    (child.line, f"'### {child.title}' appears more than once in this registry")
+                )
+                continue
+            seen.append(child.title)
+
+        canonical = [name for name in CATEGORY_SECTIONS if name in seen]
+        if seen != canonical:
+            errors.append(
+                (
+                    children[0].line if children else section.line,
+                    "task buckets must appear in the order "
+                    + " then ".join(f"'### {name}'" for name in CATEGORY_SECTIONS)
+                    + f", found {' then '.join(seen)}",
+                )
+            )
+
+
+def _check_tasks(doc: Document, errors: list[tuple[int, str]]) -> None:
+    seen_ids: dict[str, int] = {}
+    for task in doc.tasks:
+        if task.task_id in seen_ids:
+            first = seen_ids[task.task_id]
+            errors.append(
+                (task.line, f"duplicate task id {task.task_id} (first seen on line {first})")
+            )
+        else:
+            seen_ids[task.task_id] = task.line
+
+        if task.section is None or not is_registry(task.section):
+            where = f"'## {task.section}'" if task.section else "the preamble"
+            errors.append(
+                (task.line, f"task {task.task_id} sits in {where}; move it into a registry section")
+            )
+            continue
+
+        if task.subsection is None:
+            errors.append(
+                (
+                    task.line,
+                    (
+                        f"task {task.task_id} sits directly under '## {task.section}'; "
+                        "every entry belongs in a task bucket"
+                    ),
+                )
+            )
+            continue
+
+        expected = task.category or "Uncategorized"
+        if task.subsection not in CATEGORY_SECTIONS:
+            continue  # already reported by the registry check
+        if task.subsection != expected:
+            if task.category is None:
+                detail = (
+                    f"task {task.task_id} carries no '(Category; P<n>; S|M|L)' tag "
+                    f"but sits under '### {task.subsection}'"
+                )
+            else:
+                detail = (
+                    f"task {task.task_id} is tagged {task.category} "
+                    f"but sits under '### {task.subsection}'"
+                )
+            errors.append((task.line, detail))
+
+
+def _check_style(doc: Document, errors: list[tuple[int, str]]) -> None:
+    for line in doc.em_dash_lines:
+        errors.append(
+            (line, "em dash is not allowed in this repo; use a comma, colon or parentheses")
+        )
+
+
+def check_file(path: Path) -> list[str]:
+    """Return one message per violation found in `path`."""
+    doc = parse(path)
+    errors: list[tuple[int, str]] = []
+    _check_title(doc, errors)
+    _check_required_sections(doc, errors)
+    _check_registry_sections(doc, errors)
+    _check_tasks(doc, errors)
+    _check_style(doc, errors)
+
+    try:
+        display = path.relative_to(REPO_ROOT)
+    except ValueError:
+        display = path
+    return [f"{display.as_posix()}:{line}: {message}" for line, message in sorted(errors)]
+
+
+def collect_docs(targets: list[Path]) -> list[Path]:
+    paths: list[Path] = []
+    for target in targets:
+        if target.is_dir():
+            paths.extend(
+                p for p in sorted(target.glob("*.md")) if p.name not in EXCLUDED_FILES
+            )
+        else:
+            paths.append(target)
+    return paths
+
+
+def check_all(targets: list[Path] | None = None) -> list[str]:
+    """Return every violation across `targets` (default: `docs/modules/`)."""
+    paths = collect_docs(targets or [DEFAULT_DOC_DIR])
+    messages: list[str] = []
+    for path in paths:
+        messages.extend(check_file(path))
+    return messages
+
+
+def uncategorized_debt(targets: list[Path] | None = None) -> dict[str, int]:
+    """Count the untagged legacy entries left per file, for reporting only."""
+    debt: dict[str, int] = {}
+    for path in collect_docs(targets or [DEFAULT_DOC_DIR]):
+        count = sum(1 for task in parse(path).tasks if task.category is None)
+        if count:
+            debt[path.name] = count
+    return debt
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        help="files or directories to check (default: docs/modules)",
+    )
+    args = parser.parse_args(argv)
+    targets = args.paths or [DEFAULT_DOC_DIR]
+
+    messages = check_all(targets)
+    for message in messages:
+        print(message)
+
+    debt = uncategorized_debt(targets)
+    if debt:
+        total = sum(debt.values())
+        detail = ", ".join(f"{name} {count}" for name, count in sorted(debt.items()))
+        print(f"note: {total} untagged legacy entries pending category migration ({detail})")
+
+    if messages:
+        print(f"FAIL: {len(messages)} format violation(s); see docs/modules/FORMAT.md")
+        return 1
+    print(f"OK: {len(collect_docs(targets))} module doc(s) match docs/modules/FORMAT.md")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_docs_format.py
+++ b/tests/test_docs_format.py
@@ -1,0 +1,146 @@
+"""The module docs under docs/modules/ must match docs/modules/FORMAT.md."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "check_docs_format.py"
+DOC_DIR = REPO_ROOT / "docs" / "modules"
+
+
+def _load_checker():
+    spec = importlib.util.spec_from_file_location("simllm_check_docs_format", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+checker = _load_checker()
+
+
+def test_module_docs_match_the_format_contract():
+    messages = checker.check_all([DOC_DIR])
+    assert not messages, "docs/modules/FORMAT.md violations:\n" + "\n".join(messages)
+
+
+def test_every_module_doc_is_checked():
+    checked = {path.name for path in checker.collect_docs([DOC_DIR])}
+    on_disk = {path.name for path in DOC_DIR.glob("*.md")}
+    assert checked == on_disk - checker.EXCLUDED_FILES
+    assert len(checked) > 5
+
+
+@pytest.mark.parametrize(
+    ("body", "expected"),
+    [
+        pytest.param(
+            "## Open tasks\n\n### Completeness\n\n- CORE-1 (Completeness; P1; S): x.\n\n"
+            "### Precision\n\n- CORE-2 (Precision; P1; S): y.\n",
+            "task buckets must appear in the order",
+            id="bucket-order",
+        ),
+        pytest.param(
+            "## Open tasks\n\n### Precision\n\n- CORE-1 (Completeness; P1; S): x.\n",
+            "is tagged Completeness but sits under",
+            id="tag-mismatch",
+        ),
+        pytest.param(
+            "## Open tasks\n\n- CORE-1 (Precision; P1; S): x.\n",
+            "every entry belongs in a task bucket",
+            id="loose-entry",
+        ),
+        pytest.param(
+            "## Open tasks\n\n### Uncategorized\n\n- CORE-1 (Precision; P1; S): x.\n",
+            "is tagged Precision but sits under",
+            id="tagged-in-uncategorized",
+        ),
+        pytest.param(
+            "## Open tasks\n\n### Precision\n\n- CORE-1: x.\n",
+            "carries no '(Category; P<n>; S|M|L)' tag",
+            id="untagged-in-precision",
+        ),
+        pytest.param(
+            "## Open tasks\n\n### Precision\n\n- CORE-1 (Precision; P1; S): x.\n"
+            "- CORE-1 (Precision; P1; S): y.\n",
+            "duplicate task id CORE-1",
+            id="duplicate-id",
+        ),
+        pytest.param(
+            "## Open tasks\n\n### Precision\n\n- CORE-1 (Precision; P1; S): a \u2014 b.\n",
+            "em dash is not allowed",
+            id="em-dash",
+        ),
+    ],
+)
+def test_rejects_malformed_registry(tmp_path, body, expected):
+    doc = tmp_path / "sample.md"
+    doc.write_text(
+        "# simllm.sample\n\nSummary line.\n\n## Interface\n\nStuff.\n\n"
+        "## Status\n\nStuff.\n\n" + body,
+        encoding="utf-8",
+    )
+    messages = checker.check_file(doc)
+    assert any(expected in message for message in messages), messages
+
+
+def test_accepts_the_canonical_skeleton(tmp_path):
+    doc = tmp_path / "sample.md"
+    doc.write_text(
+        "# simllm.sample\n\nSummary line.\n\n"
+        "## Why\n\nContext.\n\n"
+        "## Interface\n\nStuff.\n\n"
+        "## Detail\n\nStuff.\n\n"
+        "## Status\n\nStuff.\n\n"
+        "## Open tasks\n\nLegend.\n\n"
+        "### Precision\n\n- CORE-1 (Precision; P1; S): x.\n\n"
+        "### Completeness\n\n- CORE-2 (Completeness; P2; M): y.\n\n"
+        "### Uncategorized\n\n- CORE-3: z.\n\n"
+        "## Backend-repo follow-ups\n\n"
+        "### Precision\n\n- HTSIM-1 (Precision; P0; L): w.\n",
+        encoding="utf-8",
+    )
+    assert checker.check_file(doc) == []
+
+
+def test_rejects_detail_between_status_and_open_tasks(tmp_path):
+    doc = tmp_path / "sample.md"
+    doc.write_text(
+        "# simllm.sample\n\nSummary line.\n\n## Interface\n\nStuff.\n\n"
+        "## Status\n\nStuff.\n\n## Detail\n\nStuff.\n\n## Open tasks\n\nNone currently.\n",
+        encoding="utf-8",
+    )
+    messages = checker.check_file(doc)
+    assert any("must directly follow '## Status'" in message for message in messages), messages
+
+
+def test_rejects_missing_required_section(tmp_path):
+    doc = tmp_path / "sample.md"
+    doc.write_text(
+        "# simllm.sample\n\nSummary line.\n\n## Status\n\nStuff.\n\n"
+        "## Open tasks\n\nNone currently.\n",
+        encoding="utf-8",
+    )
+    messages = checker.check_file(doc)
+    assert any("missing the required section '## Interface'" in m for m in messages), messages
+
+
+def test_rejects_missing_summary(tmp_path):
+    doc = tmp_path / "sample.md"
+    doc.write_text(
+        "# simllm.sample\n\n## Interface\n\nStuff.\n\n## Status\n\nStuff.\n\n"
+        "## Open tasks\n\nNone currently.\n",
+        encoding="utf-8",
+    )
+    messages = checker.check_file(doc)
+    assert any("summary paragraph" in message for message in messages), messages
+
+
+def test_script_runs_as_a_command():
+    assert checker.main([str(DOC_DIR)]) == 0


### PR DESCRIPTION
Turns the module doc skeleton into a contract that CI enforces.

`docs/modules/FORMAT.md` states the skeleton, `scripts/check_docs_format.py`
is its executable half, and `tests/test_docs_format.py` runs it so `pytest -q`
and CI fail on a violation. The tooling was written earlier and never landed;
this lands it against current main and fixes what it found.

What it found on main, all pre-existing drift rather than anything a recent
change introduced:

- 20 task entries across four modules sat directly under `## Open tasks`
  instead of inside a category bucket.
- `docs/modules/core.md` carried CORE-26 and CORE-27 twice each, as
  byte-identical copies in the `### Completeness` bucket while both are tagged
  Precision. The misplaced copies are removed and the correctly bucketed ones
  kept.
- `docs/modules/core.md` had a design section between `## Status` and
  `## Open tasks`, which the skeleton reserves for the registry. The
  pre-registered runtime sanity experiments move above `## Status`.
- `docs/modules/preplay.md` had no `## Interface` section. It now names the
  actual exported surface: the three CPU runners, the artifact schemas and
  their reader, writer and validator families, the arrival join, the packed
  routing arena and the observed-dispatch and KV event types. Every name in it
  was checked against `simllm/preplay.__all__`.

The doc changes are structural. No task text was reworded, no task was opened
or closed, and the registry count is unchanged at 82 of 193 closed.

The 28 untagged legacy entries are reported as a note rather than an error, so
the remaining migration debt stays countable without forcing anyone to invent
a priority and difficulty they cannot defend. AGENTS.md migrates those when
each task is next changed, not in bulk.

Verified: ruff clean, 1403 passed and 7 skipped, and the gate was shown to
fail on a deliberately broken bucket and pass again when restored.
