### PR TITLE
Fix OCI archive extraction for SGL-24 pilot

### DIFF
--- a/examples/sglang_a100_kernel_pilot_v2/run_study.py
+++ b/examples/sglang_a100_kernel_pilot_v2/run_study.py
@@ -1788,7 +1788,21 @@ def _create_oci_archive(layout: Path, archive: Path) -> None:
     if archive.exists():
         raise RuntimeError(f"OCI archive already exists: {archive}")
     tar = _required_tool("tar")
-    _run((tar, "--format=posix", "-cf", archive, "-C", layout, "."), timeout=600)
+    # Apptainer rejects a tar root member as an illegal extraction path.
+    _run(
+        (
+            tar,
+            "--format=posix",
+            "-cf",
+            archive,
+            "-C",
+            layout,
+            "oci-layout",
+            "index.json",
+            "blobs",
+        ),
+        timeout=600,
+    )
     if not archive.is_file() or archive.stat().st_size < EXPECTED_OCI_LAYER_BYTES:
         raise RuntimeError("OCI archive construction was incomplete")
 

--- a/tests/test_sglang_a100_kernel_pilot_v2.py
+++ b/tests/test_sglang_a100_kernel_pilot_v2.py
@@ -800,6 +800,46 @@ def test_safe_git_archive_rejects_symlinks_that_escape_root(tmp_path, name, targ
         runner._safe_extract_git_archive(archive, destination)
 
 
+def test_oci_archive_names_only_layout_children_and_omits_root_member(
+    monkeypatch, tmp_path
+):
+    runner = _runner_module()
+    layout = tmp_path / "oci"
+    layout.mkdir()
+    archive = tmp_path / "runtime.oci.tar"
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((tuple(str(item) for item in command), kwargs))
+        archive.write_bytes(b"archive")
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(runner, "_required_tool", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(runner, "_run", fake_run)
+    monkeypatch.setattr(runner, "EXPECTED_OCI_LAYER_BYTES", 1)
+
+    runner._create_oci_archive(layout, archive)
+
+    assert calls == [
+        (
+            (
+                "/usr/bin/tar",
+                "--format=posix",
+                "-cf",
+                str(archive),
+                "-C",
+                str(layout),
+                "oci-layout",
+                "index.json",
+                "blobs",
+            ),
+            {"timeout": 600},
+        )
+    ]
+    assert "." not in calls[0][0]
+    assert "./" not in calls[0][0]
+
+
 @pytest.mark.parametrize(
     ("mutator", "pattern"),
     [


### PR DESCRIPTION
## Summary

- archive only the three OCI layout children instead of the layout root
- avoid the root member rejected by Apptainer 1.5.2
- add a regression test for the exact tar argument contract

## Evidence

Merlin job 195384 stopped during sandbox construction before any SGLang import or calibration workload. The persisted result was correctly classified VOID. GNU tar emitted a root member for the previous command, and Apptainer rejected that member through its extraction containment guard. The frozen expectations are unchanged.

- `ruff check .`
- `pytest -q`: 2001 passed, 8 skipped
- module document format check passed
- V2 check-only contract passed