### PR TITLE
Validate the SGLang CUDA wheel version

### DIFF
--- a/examples/sglang_a100_kernel_pilot_v2/run_study.py
+++ b/examples/sglang_a100_kernel_pilot_v2/run_study.py
@@ -60,7 +60,7 @@ EXPECTED_RUNTIME_VERSIONS = {
     "torch_cuda": "12.9",
     "sglang_source": "0.0.0.dev1+g8f2a3ad6d",
     "sglang_substrate": "0.5.17",
-    "sglang_kernel": "0.4.5",
+    "sglang_kernel": "0.4.5+cu129",
     "transformers": "5.12.1",
     "triton": "3.6.0",
 }
@@ -364,6 +364,11 @@ def _validate_expectations(value: Mapping[str, Any]) -> None:
     )
     runtime = value["runtime"]
     _expect(runtime["pytorch_cuda"], "12.9", "PyTorch CUDA build")
+    _expect(
+        EXPECTED_RUNTIME_VERSIONS["sglang_kernel"],
+        f"{runtime['sglang_kernel_release']}+{runtime['sglang_kernel_variant']}",
+        "SGLang kernel distribution version",
+    )
     _expect(runtime["oci_manifest_digest"], EXPECTED_OCI_MANIFEST_DIGEST, "OCI manifest")
     _expect(runtime["oci_config_digest"], EXPECTED_OCI_CONFIG_DIGEST, "OCI config")
     _expect(runtime["index_sha256"], EXPECTED_OCI_INDEX_SHA256, "OCI index hash")

--- a/tests/test_sglang_a100_kernel_pilot_v2.py
+++ b/tests/test_sglang_a100_kernel_pilot_v2.py
@@ -157,7 +157,7 @@ def _runtime_manifest(runner) -> dict[str, object]:
         "distributions": [
             {"name": "torch", "version": "2.11.0+cu129", "direct_url": ""},
             {"name": "sglang", "version": "0.5.17", "direct_url": ""},
-            {"name": "sglang-kernel", "version": "0.4.5", "direct_url": ""},
+            {"name": "sglang-kernel", "version": "0.4.5+cu129", "direct_url": ""},
             {"name": "transformers", "version": "5.12.1", "direct_url": ""},
             {"name": "triton", "version": "3.6.0", "direct_url": ""},
         ],
@@ -536,6 +536,7 @@ def test_frozen_v2_identity_allocation_and_measurement_are_exact():
     assert frozen["runtime"]["python_abi"] == "3.12"
     assert frozen["runtime"]["pytorch"] == "2.11.0+cu129"
     assert frozen["runtime"]["sglang_kernel_variant"] == "cu129"
+    assert runner.EXPECTED_RUNTIME_VERSIONS["sglang_kernel"] == "0.4.5+cu129"
     assert frozen["measurement"]["required_lanes"] == [
         "timing:prefill-t512-r4",
         "timing:decode-b4-c2048",


### PR DESCRIPTION
## Summary

- validate the full PEP 440 SGLang kernel distribution version
- map the frozen 0.4.5 release and cu129 variant to 0.4.5+cu129
- keep the frozen expectations byte-for-byte unchanged

## Evidence

Merlin job 195386 completed offline sandbox construction, then stopped before model import because the implementation compared distribution metadata against the release component alone. The retained result was correctly classified VOID.

Ruff passed. The focused V2 suite passed 100 tests. The full suite passed 2001 tests with 8 skips. The module document format and V2 check-only gates passed.