### PR TITLE
Fix contained NVIDIA auxiliary mounts

### DIFF
--- a/examples/sglang_a100_kernel_pilot_v2/run_study.py
+++ b/examples/sglang_a100_kernel_pilot_v2/run_study.py
@@ -237,7 +237,6 @@ ALLOWED_SYSTEM_MOUNT_POINTS = {
     "/etc/localtime",
     "/etc/passwd",
     "/etc/resolv.conf",
-    "/home",
     "/proc",
     "/run",
     "/sys",
@@ -247,12 +246,24 @@ ALLOWED_SYSTEM_MOUNT_POINTS = {
 ALLOWED_SYSTEM_MOUNT_PREFIXES = (
     "/.singularity.d/libs/",
     "/dev/",
-    "/home/",
     "/proc/",
-    "/run/nvidia",
     "/sys/",
-    "/usr/bin/nvidia-",
-    "/var/run/nvidia",
+)
+OPTIONAL_NVIDIA_FILE_MOUNT_POINTS = frozenset(
+    {
+        "/usr/bin/nvidia-cuda-mps-control",
+        "/usr/bin/nvidia-cuda-mps-server",
+        "/usr/bin/nvidia-debugdump",
+        "/usr/bin/nvidia-persistenced",
+        "/usr/bin/nvidia-smi",
+        "/usr/share/egl/egl_external_platform.d/10_nvidia_wayland.json",
+        "/usr/share/egl/egl_external_platform.d/15_nvidia_gbm.json",
+        "/usr/share/glvnd/egl_vendor.d/10_nvidia.json",
+        "/usr/share/nvidia/nvoptix.bin",
+        "/usr/share/vulkan/icd.d/nvidia_icd.json",
+        "/usr/share/vulkan/icd.d/nvidia_layers.json",
+        "/usr/share/vulkan/implicit_layer.d/nvidia_layers.json",
+    }
 )
 STAT_IDENTITY_FIELDS = ("device", "inode", "mtime_ns", "ctime_ns")
 MOUNT_CONTRACT_OPTIONS = {"ro", "rw", "nosuid", "nodev", "noexec"}
@@ -557,6 +568,7 @@ def _container_command(
         "exec",
         "--cleanenv",
         "--contain",
+        "--no-home",
         "--nv",
         "--no-mount",
         "bind-paths,cwd,hostfs",
@@ -721,6 +733,23 @@ def _validate_runtime_environment_manifest(manifest: Mapping[str, Any]) -> None:
         raise TypeError("manifest OCI config environment is malformed")
     if not isinstance(environment["observed_residual"], dict):
         raise TypeError("manifest residual environment is malformed")
+    mount_policy = manifest["mount_policy"]
+    if not isinstance(mount_policy, dict):
+        raise TypeError("manifest mount policy is malformed")
+    _expect(mount_policy.get("cleanenv"), True, "manifest cleanenv policy")
+    _expect(mount_policy.get("contain"), True, "manifest contain policy")
+    _expect(mount_policy.get("no_home"), True, "manifest no-home policy")
+    _expect(mount_policy.get("nv"), True, "manifest NVIDIA injection policy")
+    _expect(
+        mount_policy.get("disabled_default_mounts"),
+        ["bind-paths", "cwd", "hostfs"],
+        "manifest disabled default mounts",
+    )
+    _expect(
+        mount_policy.get("optional_nvidia_file_mounts"),
+        sorted(OPTIONAL_NVIDIA_FILE_MOUNT_POINTS),
+        "manifest optional NVIDIA file mounts",
+    )
     mount_contract = manifest["mount_contract"]
     if not isinstance(mount_contract, list) or not mount_contract:
         raise RuntimeError("manifest mount contract is absent")
@@ -2967,8 +2996,10 @@ def _prepare_runtime(
     mount_policy = {
         "cleanenv": True,
         "contain": True,
+        "no_home": True,
         "nv": True,
         "disabled_default_mounts": ["bind-paths", "cwd", "hostfs"],
+        "optional_nvidia_file_mounts": sorted(OPTIONAL_NVIDIA_FILE_MOUNT_POINTS),
         "binds": [
             {key: row[key] for key in ("role", "destination", "mode")} for row in binds
         ],
@@ -4280,6 +4311,7 @@ def _mount_point_is_allowed(mount_point: str) -> bool:
     return (
         mount_point in REQUIRED_CONTAINER_MOUNT_MODES
         or mount_point in ALLOWED_SYSTEM_MOUNT_POINTS
+        or mount_point in OPTIONAL_NVIDIA_FILE_MOUNT_POINTS
         or mount_point == "/.singularity.d/libs"
         or any(mount_point.startswith(prefix) for prefix in ALLOWED_SYSTEM_MOUNT_PREFIXES)
     )
@@ -4354,6 +4386,15 @@ def _effective_mount_inventory() -> list[dict[str, Any]]:
             if expected_mode == "rw":
                 raise RuntimeError("job result/cache bind is not writable")
             raise RuntimeError(f"read-only bind is writable in effective mount inventory: {mount}")
+    for mount in OPTIONAL_NVIDIA_FILE_MOUNT_POINTS:
+        matches = [row for row in rows if row["mount_point"] == mount]
+        if len(matches) > 1:
+            raise RuntimeError(f"optional NVIDIA file bind is duplicated: {mount}")
+        if not matches:
+            continue
+        options = set(matches[0]["mount_options"])
+        if "ro" not in options or "rw" in options:
+            raise RuntimeError(f"optional NVIDIA file bind is writable: {mount}")
     policy = _load_authority_seed()["mount_policy"]
     serialized = json.dumps(
         [{"root": row["root"], "source": row["source"]} for row in rows], sort_keys=True

--- a/tests/test_sglang_a100_kernel_pilot_v2.py
+++ b/tests/test_sglang_a100_kernel_pilot_v2.py
@@ -213,7 +213,12 @@ def _runtime_manifest(runner) -> dict[str, object]:
         "mount_policy": {
             "cleanenv": True,
             "contain": True,
+            "no_home": True,
+            "nv": True,
             "disabled_default_mounts": ["bind-paths", "cwd", "hostfs"],
+            "optional_nvidia_file_mounts": sorted(
+                runner.OPTIONAL_NVIDIA_FILE_MOUNT_POINTS
+            ),
         },
         "mount_contract": [
             {
@@ -238,7 +243,12 @@ def _valid_lanes() -> dict[str, dict[str, str]]:
     }
 
 
-def _mountinfo(*, writable_role: str | None = None, unexpected: str | None = None) -> str:
+def _mountinfo(
+    *,
+    writable_role: str | None = None,
+    unexpected: str | None = None,
+    additional: tuple[tuple[str, str], ...] = (),
+) -> str:
     mounts = (
         ("runner", "/host/runner", "ro"),
         ("source", "/host/source", "ro"),
@@ -257,6 +267,11 @@ def _mountinfo(*, writable_role: str | None = None, unexpected: str | None = Non
     if unexpected is not None:
         lines.append(
             f"99 20 0:99 / {unexpected} ro,relatime - ext4 /host/unexpected ro,relatime"
+        )
+    for index, (mount_point, mode) in enumerate(additional, start=100):
+        lines.append(
+            f"{index} 20 0:{index} / {mount_point} {mode},nosuid,nodev,relatime "
+            f"- ext4 /host/nvidia/{index} rw,relatime"
         )
     return "\n".join(lines) + "\n"
 
@@ -673,6 +688,7 @@ def test_container_command_has_exact_isolation_bind_and_environment_contract(tmp
     assert command[0] == str(apptainer)
     assert command.count("--cleanenv") == 1
     assert command.count("--contain") == 1
+    assert command.count("--no-home") == 1
     assert command.count("--nv") == 1
     assert command[command.index("--no-mount") + 1] == "bind-paths,cwd,hostfs"
     assert command[command.index("--pwd") + 1] == str(cwd)
@@ -945,6 +961,23 @@ def test_runtime_manifest_residual_environment_structure_is_closed(mutator, patt
         runner._validate_runtime_environment_manifest(manifest)
 
 
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [
+        ("no_home", False),
+        ("nv", False),
+        ("optional_nvidia_file_mounts", ["/usr/share/nvidia/unexpected.bin"]),
+    ],
+)
+def test_runtime_manifest_rejects_mount_policy_drift(key, value):
+    runner = _runner_module()
+    manifest = _runtime_manifest(runner)
+    manifest["mount_policy"][key] = value
+
+    with pytest.raises(RuntimeError, match="manifest.*policy|optional NVIDIA"):
+        runner._validate_runtime_environment_manifest(manifest)
+
+
 @pytest.mark.parametrize("authority", ["nsys", "ncu"])
 @pytest.mark.parametrize("mutation", ["missing", "duplicate", "wrong-kind", "bad-hash"])
 def test_runtime_manifest_requires_one_hashed_profiler_launcher(authority, mutation):
@@ -1205,6 +1238,94 @@ def test_effective_mount_inventory_enforces_read_only_and_read_write_roles(monke
         "ro" in modes[f"/opt/simllm/{role}"]
         for role in ("runner", "source", "model", "nsys", "ncu")
     )
+
+
+def test_effective_mount_inventory_accepts_exact_read_only_nvidia_files(monkeypatch):
+    runner = _runner_module()
+    mountinfo = _mountinfo(
+        additional=tuple(
+            (mount_point, "ro")
+            for mount_point in sorted(runner.OPTIONAL_NVIDIA_FILE_MOUNT_POINTS)
+        )
+    )
+
+    class MountInfo:
+        def read_text(self, *, encoding):
+            assert encoding == "utf-8"
+            return mountinfo
+
+    monkeypatch.setattr(runner, "Path", lambda value: MountInfo())
+    monkeypatch.setattr(
+        runner,
+        "_load_authority_seed",
+        lambda: {"mount_policy": {"forbidden_host_paths": []}},
+    )
+
+    rows = runner._effective_mount_inventory()
+
+    observed = {row["mount_point"] for row in rows}
+    assert runner.OPTIONAL_NVIDIA_FILE_MOUNT_POINTS <= observed
+
+
+@pytest.mark.parametrize(
+    "unexpected",
+    [
+        str(PurePosixPath("/", "home", "synthetic-user")),
+        str(PurePosixPath("/", "data", "user", "synthetic-user")),
+        "/usr/share/nvidia/nvoptix.bin.bak",
+        "/usr/share/nvidia/nvoptix.bin/child",
+        "/usr/bin/nvidia-backdoor",
+        "/run/nvidiarogue",
+        "/var/run/nvidia-malicious",
+    ],
+)
+def test_effective_mount_inventory_rejects_home_and_nvidia_neighbors(
+    monkeypatch, unexpected
+):
+    runner = _runner_module()
+
+    class MountInfo:
+        def read_text(self, *, encoding):
+            assert encoding == "utf-8"
+            return _mountinfo(unexpected=unexpected)
+
+    monkeypatch.setattr(runner, "Path", lambda value: MountInfo())
+    monkeypatch.setattr(
+        runner,
+        "_load_authority_seed",
+        lambda: {"mount_policy": {"forbidden_host_paths": []}},
+    )
+
+    with pytest.raises(RuntimeError, match="unexpected user binds"):
+        runner._effective_mount_inventory()
+
+
+@pytest.mark.parametrize("mode", ["rw", "ro"])
+def test_effective_mount_inventory_rejects_writable_or_duplicate_nvidia_file(
+    monkeypatch, mode
+):
+    runner = _runner_module()
+    mount_point = "/usr/share/nvidia/nvoptix.bin"
+    additional = ((mount_point, mode),)
+    pattern = "writable"
+    if mode == "ro":
+        additional *= 2
+        pattern = "duplicated"
+
+    class MountInfo:
+        def read_text(self, *, encoding):
+            assert encoding == "utf-8"
+            return _mountinfo(additional=additional)
+
+    monkeypatch.setattr(runner, "Path", lambda value: MountInfo())
+    monkeypatch.setattr(
+        runner,
+        "_load_authority_seed",
+        lambda: {"mount_policy": {"forbidden_host_paths": []}},
+    )
+
+    with pytest.raises(RuntimeError, match=pattern):
+        runner._effective_mount_inventory()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- suppress Apptainer's contained home mount with `--no-home`
- replace broad NVIDIA destination prefixes with the 12 exact file paths authorized by Merlin's `nvliblist.conf`
- accept those driver auxiliaries only when each destination is unique and read-only
- record and validate the no-home and exact NVIDIA mount policy in the runtime manifest
- add rejection coverage for writable, duplicate, home, and neighboring NVIDIA mounts

## Root cause

Job 195391 correctly stopped at the effective mount inventory gate, but the policy treated Apptainer's session-backed contained home and legitimate legacy `--nv` auxiliary files as unexpected user binds. The old NVIDIA prefixes also admitted neighboring destination names too broadly.

## Impact

The retry can retain the exact site-authorized NVIDIA injection needed for CUDA while continuing to reject host-home exposure, arbitrary user binds, writable NVIDIA files, duplicate destinations, and path-prefix lookalikes.

## Validation

- `ruff check .`
- `PYTHONPATH=. .venv/bin/pytest -q` (2014 passed, 8 skipped)
- `python scripts/check_docs_format.py`
- runner `--check-only` gate
- `git diff --check`
- independent adversarial mount-policy review
