### PR TITLE
Allow the NVIDIA persistence IPC mount

### DIFF
--- a/examples/sglang_a100_kernel_pilot_v2/run_study.py
+++ b/examples/sglang_a100_kernel_pilot_v2/run_study.py
@@ -265,6 +265,14 @@ OPTIONAL_NVIDIA_FILE_MOUNT_POINTS = frozenset(
         "/usr/share/vulkan/implicit_layer.d/nvidia_layers.json",
     }
 )
+OPTIONAL_NVIDIA_IPC_MOUNT_POINTS = frozenset(
+    {
+        "/run/nvidia-persistenced/socket",
+    }
+)
+OPTIONAL_NVIDIA_MOUNT_POINTS = (
+    OPTIONAL_NVIDIA_FILE_MOUNT_POINTS | OPTIONAL_NVIDIA_IPC_MOUNT_POINTS
+)
 STAT_IDENTITY_FIELDS = ("device", "inode", "mtime_ns", "ctime_ns")
 MOUNT_CONTRACT_OPTIONS = {"ro", "rw", "nosuid", "nodev", "noexec"}
 FORBIDDEN_CUDA13_SONAMES = (
@@ -749,6 +757,11 @@ def _validate_runtime_environment_manifest(manifest: Mapping[str, Any]) -> None:
         mount_policy.get("optional_nvidia_file_mounts"),
         sorted(OPTIONAL_NVIDIA_FILE_MOUNT_POINTS),
         "manifest optional NVIDIA file mounts",
+    )
+    _expect(
+        mount_policy.get("optional_nvidia_ipc_mounts"),
+        sorted(OPTIONAL_NVIDIA_IPC_MOUNT_POINTS),
+        "manifest optional NVIDIA IPC mounts",
     )
     mount_contract = manifest["mount_contract"]
     if not isinstance(mount_contract, list) or not mount_contract:
@@ -3000,6 +3013,7 @@ def _prepare_runtime(
         "nv": True,
         "disabled_default_mounts": ["bind-paths", "cwd", "hostfs"],
         "optional_nvidia_file_mounts": sorted(OPTIONAL_NVIDIA_FILE_MOUNT_POINTS),
+        "optional_nvidia_ipc_mounts": sorted(OPTIONAL_NVIDIA_IPC_MOUNT_POINTS),
         "binds": [
             {key: row[key] for key in ("role", "destination", "mode")} for row in binds
         ],
@@ -4311,7 +4325,7 @@ def _mount_point_is_allowed(mount_point: str) -> bool:
     return (
         mount_point in REQUIRED_CONTAINER_MOUNT_MODES
         or mount_point in ALLOWED_SYSTEM_MOUNT_POINTS
-        or mount_point in OPTIONAL_NVIDIA_FILE_MOUNT_POINTS
+        or mount_point in OPTIONAL_NVIDIA_MOUNT_POINTS
         or mount_point == "/.singularity.d/libs"
         or any(mount_point.startswith(prefix) for prefix in ALLOWED_SYSTEM_MOUNT_PREFIXES)
     )
@@ -4386,15 +4400,15 @@ def _effective_mount_inventory() -> list[dict[str, Any]]:
             if expected_mode == "rw":
                 raise RuntimeError("job result/cache bind is not writable")
             raise RuntimeError(f"read-only bind is writable in effective mount inventory: {mount}")
-    for mount in OPTIONAL_NVIDIA_FILE_MOUNT_POINTS:
+    for mount in OPTIONAL_NVIDIA_MOUNT_POINTS:
         matches = [row for row in rows if row["mount_point"] == mount]
         if len(matches) > 1:
-            raise RuntimeError(f"optional NVIDIA file bind is duplicated: {mount}")
+            raise RuntimeError(f"optional NVIDIA bind is duplicated: {mount}")
         if not matches:
             continue
         options = set(matches[0]["mount_options"])
         if "ro" not in options or "rw" in options:
-            raise RuntimeError(f"optional NVIDIA file bind is writable: {mount}")
+            raise RuntimeError(f"optional NVIDIA bind is writable: {mount}")
     policy = _load_authority_seed()["mount_policy"]
     serialized = json.dumps(
         [{"root": row["root"], "source": row["source"]} for row in rows], sort_keys=True

--- a/tests/test_sglang_a100_kernel_pilot_v2.py
+++ b/tests/test_sglang_a100_kernel_pilot_v2.py
@@ -219,6 +219,9 @@ def _runtime_manifest(runner) -> dict[str, object]:
             "optional_nvidia_file_mounts": sorted(
                 runner.OPTIONAL_NVIDIA_FILE_MOUNT_POINTS
             ),
+            "optional_nvidia_ipc_mounts": sorted(
+                runner.OPTIONAL_NVIDIA_IPC_MOUNT_POINTS
+            ),
         },
         "mount_contract": [
             {
@@ -967,6 +970,7 @@ def test_runtime_manifest_residual_environment_structure_is_closed(mutator, patt
         ("no_home", False),
         ("nv", False),
         ("optional_nvidia_file_mounts", ["/usr/share/nvidia/unexpected.bin"]),
+        ("optional_nvidia_ipc_mounts", ["/run/nvidia-persistenced/unexpected"]),
     ],
 )
 def test_runtime_manifest_rejects_mount_policy_drift(key, value):
@@ -1240,12 +1244,12 @@ def test_effective_mount_inventory_enforces_read_only_and_read_write_roles(monke
     )
 
 
-def test_effective_mount_inventory_accepts_exact_read_only_nvidia_files(monkeypatch):
+def test_effective_mount_inventory_accepts_exact_read_only_nvidia_binds(monkeypatch):
     runner = _runner_module()
     mountinfo = _mountinfo(
         additional=tuple(
             (mount_point, "ro")
-            for mount_point in sorted(runner.OPTIONAL_NVIDIA_FILE_MOUNT_POINTS)
+            for mount_point in sorted(runner.OPTIONAL_NVIDIA_MOUNT_POINTS)
         )
     )
 
@@ -1264,7 +1268,7 @@ def test_effective_mount_inventory_accepts_exact_read_only_nvidia_files(monkeypa
     rows = runner._effective_mount_inventory()
 
     observed = {row["mount_point"] for row in rows}
-    assert runner.OPTIONAL_NVIDIA_FILE_MOUNT_POINTS <= observed
+    assert runner.OPTIONAL_NVIDIA_MOUNT_POINTS <= observed
 
 
 @pytest.mark.parametrize(
@@ -1276,6 +1280,8 @@ def test_effective_mount_inventory_accepts_exact_read_only_nvidia_files(monkeypa
         "/usr/share/nvidia/nvoptix.bin/child",
         "/usr/bin/nvidia-backdoor",
         "/run/nvidiarogue",
+        "/run/nvidia-persistenced/socket.backup",
+        "/run/nvidia-persistenced/unexpected",
         "/var/run/nvidia-malicious",
     ],
 )
@@ -1300,12 +1306,18 @@ def test_effective_mount_inventory_rejects_home_and_nvidia_neighbors(
         runner._effective_mount_inventory()
 
 
+@pytest.mark.parametrize(
+    "mount_point",
+    [
+        "/usr/share/nvidia/nvoptix.bin",
+        "/run/nvidia-persistenced/socket",
+    ],
+)
 @pytest.mark.parametrize("mode", ["rw", "ro"])
-def test_effective_mount_inventory_rejects_writable_or_duplicate_nvidia_file(
-    monkeypatch, mode
+def test_effective_mount_inventory_rejects_writable_or_duplicate_nvidia_bind(
+    monkeypatch, mount_point, mode
 ):
     runner = _runner_module()
-    mount_point = "/usr/share/nvidia/nvoptix.bin"
     additional = ((mount_point, mode),)
     pattern = "writable"
     if mode == "ro":


### PR DESCRIPTION
## Summary

- recognize Apptainer's exact legacy NVIDIA persistence IPC destination
- keep that socket optional, unique, and read-only
- record the IPC authority separately from Merlin's `nvliblist.conf` files
- reject writable, duplicate, and neighboring socket destinations

## Root cause

Job 195396 safely stopped because `/run/nvidia-persistenced/socket` was not yet represented in the effective mount policy. Apptainer v1.5.1 discovers `/var/run/nvidia-persistenced/socket` when the daemon is active, resolves the `/var/run` alias, and injects it through the same read-only file-mount path used by legacy `--nv`.

## Impact

The next retry can use the site persistence daemon without admitting a broad `/run` prefix or weakening the existing containment gate. Absence remains valid, and any duplicate, writable, or neighboring mount remains fatal.

## Validation

- `ruff check .`
- `PYTHONPATH=. .venv/bin/pytest -q` (2019 passed, 8 skipped)
- `python scripts/check_docs_format.py`
- runner `--check-only` gate
- `git diff --check`
- independent Apptainer v1.5.1 source and patch audit
