### PR TITLE
Fix duplicate distribution authority validation

### DIFF
--- a/examples/sglang_a100_kernel_pilot_v2/run_study.py
+++ b/examples/sglang_a100_kernel_pilot_v2/run_study.py
@@ -64,6 +64,20 @@ EXPECTED_RUNTIME_VERSIONS = {
     "transformers": "5.12.1",
     "triton": "3.6.0",
 }
+EXPECTED_DISTRIBUTION_VERSIONS = {
+    "torch": EXPECTED_RUNTIME_VERSIONS["torch"],
+    "sglang": EXPECTED_RUNTIME_VERSIONS["sglang_substrate"],
+    "sglang-kernel": EXPECTED_RUNTIME_VERSIONS["sglang_kernel"],
+    "transformers": EXPECTED_RUNTIME_VERSIONS["transformers"],
+    "triton": EXPECTED_RUNTIME_VERSIONS["triton"],
+}
+DISTRIBUTION_INVENTORY_FIELDS = {
+    "name",
+    "normalized_name",
+    "version",
+    "metadata_path",
+    "direct_url",
+}
 
 EXPECTED_OCI_MANIFEST_DIGEST = (
     "sha256:bbe1ec8694ab6b0e6ea0a567c2d492ed7c9bed13cb33ffe356ade0aaa8343c9f"
@@ -679,28 +693,7 @@ def _validate_runtime_environment_manifest(manifest: Mapping[str, Any]) -> None:
     _expect(oci.get("manifest_digest"), EXPECTED_OCI_MANIFEST_DIGEST, "manifest OCI digest")
     _expect(oci.get("config_digest"), EXPECTED_OCI_CONFIG_DIGEST, "manifest OCI config")
     distributions = manifest["distributions"]
-    if not isinstance(distributions, list) or not distributions:
-        raise RuntimeError("distribution inventory is empty")
-    normalized_names: set[str] = set()
-    substrate_seen = False
-    for row in distributions:
-        name = re.sub(r"[-_.]+", "-", str(row.get("name", "")).lower())
-        version = str(row.get("version", ""))
-        direct_url = str(row.get("direct_url", ""))
-        if not name or not version or name in normalized_names:
-            raise RuntimeError("distribution inventory is malformed or duplicated")
-        normalized_names.add(name)
-        identity = f"{name}=={version} {direct_url}".lower()
-        if name.endswith("-cu13") or "cu13" in direct_url.lower() or "+cu13" in identity:
-            raise RuntimeError(f"CUDA 13 distribution marker is forbidden: {identity}")
-        if name == "cuda-python":
-            major_text = re.match(r"(\d+)", version)
-            if major_text is not None and int(major_text.group(1)) >= 13:
-                raise RuntimeError("cuda-python 13 or newer is forbidden")
-        if name == "sglang" and version == EXPECTED_RUNTIME_VERSIONS["sglang_substrate"]:
-            substrate_seen = True
-    if not substrate_seen:
-        raise RuntimeError("frozen substrate SGLang distribution is absent")
+    _validate_distribution_inventory(distributions)
     _validate_loaded_object_ledger(manifest["critical_files"])
     for row in manifest["critical_files"]:
         if any(not isinstance(row.get(field), int) for field in STAT_IDENTITY_FIELDS):
@@ -3710,38 +3703,194 @@ def _time_cuda_target(
 
 
 def _distribution_inventory() -> list[dict[str, Any]]:
-    rows = []
+    rows_by_metadata_path: dict[str, dict[str, Any]] = {}
     for distribution in importlib.metadata.distributions():
-        name = str(distribution.metadata.get("Name", "")).strip()
-        version = str(distribution.version).strip()
+        raw_name = distribution.metadata.get("Name")
+        raw_version = distribution.version
+        if not isinstance(raw_name, str) or not isinstance(raw_version, str):
+            raise TypeError("installed distribution lacks textual name or version")
+        name = raw_name.strip()
+        version = raw_version.strip()
         if not name or not version:
             raise RuntimeError("installed distribution lacks name or version")
-        direct_url = distribution.read_text("direct_url.json") or ""
-        if direct_url:
-            try:
-                direct_url = json.dumps(json.loads(direct_url), sort_keys=True, separators=(",", ":"))
-            except ValueError as error:
-                raise RuntimeError(f"distribution {name} has malformed direct_url.json") from error
-        metadata_path = Path(str(getattr(distribution, "_path", ""))).resolve()
-        rows.append(
-            {
-                "name": name,
-                "normalized_name": re.sub(r"[-_.]+", "-", name.lower()),
-                "version": version,
-                "metadata_path": str(metadata_path),
-                "direct_url": direct_url,
-            }
-        )
+        raw_direct_url = distribution.read_text("direct_url.json")
+        if raw_direct_url is not None and not isinstance(raw_direct_url, str):
+            raise RuntimeError(f"distribution {name} direct_url.json is not text")
+        direct_url = _canonical_distribution_direct_url(raw_direct_url or "", name)
+        raw_metadata_path = getattr(distribution, "_path", None)
+        try:
+            metadata_path_text = os.fspath(raw_metadata_path)
+        except TypeError as error:
+            raise RuntimeError(f"distribution {name} has no metadata authority path") from error
+        if not isinstance(metadata_path_text, str) or not metadata_path_text:
+            raise RuntimeError(f"distribution {name} has no metadata authority path")
+        try:
+            metadata_path = Path(metadata_path_text).resolve(strict=True)
+        except OSError as error:
+            raise RuntimeError(
+                f"distribution {name} metadata authority does not exist: {metadata_path_text!r}"
+            ) from error
+        if not metadata_path.is_file() and not metadata_path.is_dir():
+            raise RuntimeError(
+                f"distribution {name} metadata authority is not a file or directory: "
+                f"{metadata_path}"
+            )
+        row = {
+            "name": name,
+            "normalized_name": re.sub(r"[-_.]+", "-", name.lower()),
+            "version": version,
+            "metadata_path": str(metadata_path),
+            "direct_url": direct_url,
+        }
+        existing = rows_by_metadata_path.get(str(metadata_path))
+        if existing is not None and existing != row:
+            raise RuntimeError(
+                "distribution metadata authority changed across discovery: "
+                f"path={metadata_path}, first={existing!r}, repeated={row!r}"
+            )
+        rows_by_metadata_path[str(metadata_path)] = row
+    rows = list(rows_by_metadata_path.values())
     rows.sort(key=lambda row: (row["normalized_name"], row["version"], row["metadata_path"]))
     return rows
 
 
+def _canonical_distribution_direct_url(value: str, name: str) -> str:
+    if not value:
+        return ""
+    try:
+        parsed = json.loads(
+            value,
+            object_pairs_hook=_strict_json_object,
+            parse_constant=_reject_json_constant,
+        )
+    except (TypeError, ValueError) as error:
+        raise RuntimeError(f"distribution {name} has malformed direct URL authority") from error
+    if not isinstance(parsed, dict):
+        raise TypeError(f"distribution {name} direct URL authority is not a JSON object")
+    url = parsed.get("url")
+    if not isinstance(url, str):
+        raise TypeError(f"distribution {name} direct URL authority has no textual URL")
+    if not url or url != url.strip():
+        raise RuntimeError(f"distribution {name} direct URL authority has an empty URL")
+    if _contains_nonfinite_json_number(parsed):
+        raise RuntimeError(f"distribution {name} direct URL authority has a nonfinite number")
+    return json.dumps(parsed, sort_keys=True, separators=(",", ":"))
+
+
+def _strict_json_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            raise ValueError(f"duplicate JSON object key: {key!r}")
+        value[key] = item
+    return value
+
+
+def _reject_json_constant(value: str) -> Any:
+    raise ValueError(f"nonstandard JSON constant: {value}")
+
+
+def _contains_nonfinite_json_number(value: Any) -> bool:
+    if isinstance(value, float):
+        return not math.isfinite(value)
+    if isinstance(value, dict):
+        return any(_contains_nonfinite_json_number(item) for item in value.values())
+    if isinstance(value, list):
+        return any(_contains_nonfinite_json_number(item) for item in value)
+    return False
+
+
+def _validate_distribution_inventory(rows: Any) -> None:
+    if not isinstance(rows, list) or not rows:
+        raise RuntimeError("distribution inventory is empty")
+    by_name: dict[str, list[Mapping[str, Any]]] = {}
+    metadata_paths: set[str] = set()
+    for row in rows:
+        if not isinstance(row, Mapping) or set(row) != DISTRIBUTION_INVENTORY_FIELDS:
+            raise RuntimeError("distribution inventory row shape drifted")
+        non_text_fields = sorted(
+            field
+            for field in DISTRIBUTION_INVENTORY_FIELDS
+            if not isinstance(row[field], str)
+        )
+        if non_text_fields:
+            raise RuntimeError(
+                f"distribution inventory fields are not text: {non_text_fields}"
+            )
+        name = row["name"]
+        normalized_name = re.sub(r"[-_.]+", "-", name.lower())
+        version = row["version"]
+        direct_url = row["direct_url"]
+        metadata_path = row["metadata_path"]
+        if (
+            not name
+            or name != name.strip()
+            or not version
+            or version != version.strip()
+            or row["normalized_name"] != normalized_name
+        ):
+            raise RuntimeError("distribution inventory row is malformed")
+        path = PurePosixPath(metadata_path)
+        if (
+            not path.is_absolute()
+            or metadata_path.startswith("//")
+            or ".." in path.parts
+            or str(path) != metadata_path
+        ):
+            raise RuntimeError(f"distribution metadata path is not absolute and normalized: {path}")
+        if metadata_path in metadata_paths:
+            raise RuntimeError(f"distribution metadata authority is duplicated: {metadata_path}")
+        metadata_paths.add(metadata_path)
+        if direct_url:
+            canonical_direct_url = _canonical_distribution_direct_url(
+                direct_url, normalized_name
+            )
+            if direct_url != canonical_direct_url:
+                raise RuntimeError(
+                    f"distribution {normalized_name} direct URL authority is not canonical"
+                )
+        identity = f"{normalized_name}=={version} {direct_url}".lower()
+        if (
+            normalized_name.endswith("-cu13")
+            or "cu13" in direct_url.lower()
+            or "+cu13" in identity
+        ):
+            raise RuntimeError(f"CUDA 13 distribution marker is forbidden: {identity}")
+        if normalized_name == "cuda-python":
+            major_text = re.match(r"(\d+)", version)
+            if major_text is not None and int(major_text.group(1)) >= 13:
+                raise RuntimeError("cuda-python 13 or newer is forbidden")
+        by_name.setdefault(normalized_name, []).append(row)
+    for normalized_name, matches in by_name.items():
+        authorities = {(row["version"], row["direct_url"]) for row in matches}
+        if len(authorities) > 1:
+            details = sorted(
+                (row["version"], row["direct_url"], row["metadata_path"])
+                for row in matches
+            )
+            raise RuntimeError(
+                f"conflicting duplicate distribution {normalized_name}: {details}"
+            )
+    for name, expected_version in EXPECTED_DISTRIBUTION_VERSIONS.items():
+        _expect(
+            _distribution_version(rows, name),
+            expected_version,
+            f"manifest {name} distribution",
+        )
+
+
 def _distribution_version(rows: Sequence[Mapping[str, Any]], name: str) -> str:
     normalized = re.sub(r"[-_.]+", "-", name.lower())
-    matches = [str(row["version"]) for row in rows if row["normalized_name"] == normalized]
+    matches = [
+        (str(row["version"]), str(row["metadata_path"]))
+        for row in rows
+        if row["normalized_name"] == normalized
+    ]
     if len(matches) != 1:
-        raise RuntimeError(f"expected one installed {name} distribution, observed {matches}")
-    return matches[0]
+        raise RuntimeError(
+            f"expected one installed {name} distribution authority, observed {matches}"
+        )
+    return matches[0][0]
 
 
 def _stat_identity(path: Path, *, follow_symlinks: bool = True) -> dict[str, int]:
@@ -3923,14 +4072,7 @@ def _build_runtime_environment_manifest(seed: Mapping[str, Any]) -> dict[str, An
     python_version = ".".join(str(value) for value in sys.version_info[:3])
     if ".".join(str(value) for value in sys.version_info[:2]) != "3.12":
         raise RuntimeError(f"container Python ABI drifted: {python_version}")
-    expected = {
-        "torch": EXPECTED_RUNTIME_VERSIONS["torch"],
-        "sglang": EXPECTED_RUNTIME_VERSIONS["sglang_substrate"],
-        "sglang-kernel": EXPECTED_RUNTIME_VERSIONS["sglang_kernel"],
-        "transformers": EXPECTED_RUNTIME_VERSIONS["transformers"],
-        "triton": EXPECTED_RUNTIME_VERSIONS["triton"],
-    }
-    for name, version in expected.items():
+    for name, version in EXPECTED_DISTRIBUTION_VERSIONS.items():
         _expect(_distribution_version(distributions, name), version, f"{name} distribution")
     mount_contract = _normalized_mount_contract(_effective_mount_inventory())
     nsys_root = Path(os.environ["SIMLLM_NSYS_INSTALL"]) / "nsight-systems-2025.1.3"

--- a/tests/test_sglang_a100_kernel_pilot_v2.py
+++ b/tests/test_sglang_a100_kernel_pilot_v2.py
@@ -27,6 +27,26 @@ FREEZE_COMMIT = "dee129923883d6b8cc394933b4944a4ff50193e5"
 FREEZE_PARENT = "43064d6ae88d6380c86bd400d336a07aa504ccbd"
 EXPECTATIONS_JSON_SHA256 = "f22ddd9a6a7223f3c2a7a836c0fd29d5a0ee66282212413c6ea5ddac22308894"
 EXPECTATIONS_MARKDOWN_SHA256 = "6175ee55323a89ac027fdf4d81acb26dc4b49f8c2ae7569dbc95cc9410b563ed"
+MISSING_DISTRIBUTION_PATH = object()
+
+
+class DistributionFixture:
+    def __init__(
+        self,
+        name,
+        version,
+        metadata_path=MISSING_DISTRIBUTION_PATH,
+        direct_url=None,
+    ):
+        self.metadata = {"Name": name}
+        self.version = version
+        self._direct_url = direct_url
+        if metadata_path is not MISSING_DISTRIBUTION_PATH:
+            self._path = metadata_path
+
+    def read_text(self, name):
+        assert name == "direct_url.json"
+        return self._direct_url
 
 
 def _runner_module():
@@ -132,6 +152,24 @@ def _source_fixture() -> tuple[dict[str, object], list[dict[str, object]], dict[
     return manifest, modules, entry_points
 
 
+def _distribution_record(
+    name: str,
+    version: str,
+    *,
+    direct_url: str = "",
+    metadata_path: str | None = None,
+) -> dict[str, str]:
+    normalized_name = re.sub(r"[-_.]+", "-", name.lower())
+    return {
+        "name": name,
+        "normalized_name": normalized_name,
+        "version": version,
+        "metadata_path": metadata_path
+        or f"/usr/local/lib/python3.12/site-packages/{normalized_name}-{version}.dist-info",
+        "direct_url": direct_url,
+    }
+
+
 def _runtime_manifest(runner) -> dict[str, object]:
     layers = [
         {"digest": f"sha256:{index:064x}", "size": 1}
@@ -155,11 +193,11 @@ def _runtime_manifest(runner) -> dict[str, object]:
         },
         "python": {"abi": "3.12", "executable": "/usr/bin/python3.12"},
         "distributions": [
-            {"name": "torch", "version": "2.11.0+cu129", "direct_url": ""},
-            {"name": "sglang", "version": "0.5.17", "direct_url": ""},
-            {"name": "sglang-kernel", "version": "0.4.5+cu129", "direct_url": ""},
-            {"name": "transformers", "version": "5.12.1", "direct_url": ""},
-            {"name": "triton", "version": "3.6.0", "direct_url": ""},
+            _distribution_record("torch", "2.11.0+cu129"),
+            _distribution_record("sglang", "0.5.17"),
+            _distribution_record("sglang-kernel", "0.4.5+cu129"),
+            _distribution_record("transformers", "5.12.1"),
+            _distribution_record("triton", "3.6.0"),
         ],
         "critical_files": [
             {
@@ -1014,25 +1052,35 @@ def test_runtime_manifest_requires_one_hashed_profiler_launcher(authority, mutat
         ),
         (
             lambda value: value["distributions"].append(
-                {"name": "cuda-python", "version": "13.0.0", "direct_url": ""}
+                _distribution_record("cuda-python", "13.0.0")
             ),
             "CUDA 13|cuda.python|cu13",
         ),
         (
             lambda value: value["distributions"].append(
-                {
-                    "name": "addon",
-                    "version": "1.0",
-                    "direct_url": "file:///wheelhouse/cu13/addon.whl",
-                }
+                _distribution_record(
+                    "addon",
+                    "1.0",
+                    direct_url=json.dumps(
+                        {"url": "file:///wheelhouse/cu13/addon.whl"},
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ),
+                )
             ),
             "CUDA 13|cu13|provenance",
         ),
         (
             lambda value: value["distributions"].append(
-                {"name": "Torch", "version": "2.11.0+cu129", "direct_url": ""}
+                {
+                    **value["distributions"][0],
+                    "name": "Torch",
+                    "metadata_path": (
+                        "/usr/local/lib/python3.12/site-packages/torch-copy.dist-info"
+                    ),
+                }
             ),
-            "duplicate|distribution|torch",
+            "expected one installed torch|manifest torch distribution",
         ),
     ],
 )
@@ -1043,6 +1091,299 @@ def test_runtime_manifest_rejects_oci_cuda13_or_distribution_drift(mutator, patt
 
     with pytest.raises((RuntimeError, ValueError), match=pattern):
         runner._validate_runtime_environment_manifest(manifest)
+
+
+def test_runtime_manifest_accepts_identical_noncritical_distribution_authorities():
+    runner = _runner_module()
+    manifest = _runtime_manifest(runner)
+    first = _distribution_record(
+        "auxiliary-package",
+        "1.2.3",
+        metadata_path="/usr/local/lib/python3.12/site-packages/auxiliary-a.dist-info",
+    )
+    second = _distribution_record(
+        "auxiliary-package",
+        "1.2.3",
+        metadata_path="/usr/local/lib/python3.12/site-packages/auxiliary-b.dist-info",
+    )
+    manifest["distributions"].extend((first, second))
+
+    assert runner._validate_runtime_environment_manifest(manifest) is None
+
+
+@pytest.mark.parametrize(
+    ("mutation", "pattern"),
+    [
+        (lambda row: row.update({"version": "2.0.0"}), "conflicting duplicate"),
+        (
+            lambda row: row.update(
+                {
+                    "direct_url": json.dumps(
+                        {"url": "https://example.invalid/auxiliary.whl"},
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    )
+                }
+            ),
+            "conflicting duplicate",
+        ),
+        (
+            lambda row: row.update(
+                {
+                    "metadata_path": (
+                        "/usr/local/lib/python3.12/site-packages/auxiliary-a.dist-info"
+                    )
+                }
+            ),
+            "metadata authority is duplicated",
+        ),
+        (lambda row: row.update({"normalized_name": "wrong"}), "row is malformed"),
+    ],
+)
+def test_runtime_manifest_rejects_conflicting_or_malformed_duplicate_authority(
+    mutation, pattern
+):
+    runner = _runner_module()
+    manifest = _runtime_manifest(runner)
+    first = _distribution_record(
+        "auxiliary-package",
+        "1.2.3",
+        metadata_path="/usr/local/lib/python3.12/site-packages/auxiliary-a.dist-info",
+    )
+    second = _distribution_record(
+        "auxiliary-package",
+        "1.2.3",
+        metadata_path="/usr/local/lib/python3.12/site-packages/auxiliary-b.dist-info",
+    )
+    mutation(second)
+    manifest["distributions"].extend((first, second))
+
+    with pytest.raises(RuntimeError, match=pattern):
+        runner._validate_runtime_environment_manifest(manifest)
+
+
+@pytest.mark.parametrize(
+    ("mutation", "pattern"),
+    [
+        (lambda row: row.pop("direct_url"), "row shape drifted"),
+        (lambda row: row.update({"unexpected": "field"}), "row shape drifted"),
+        (lambda row: row.update({"version": 1}), "fields are not text"),
+        (
+            lambda row: row.update({"metadata_path": "relative/package.dist-info"}),
+            "not absolute and normalized",
+        ),
+        (
+            lambda row: row.update({"metadata_path": "/usr/local/../package.dist-info"}),
+            "not absolute and normalized",
+        ),
+        (lambda row: row.update({"direct_url": "{"}), "malformed direct URL"),
+        (lambda row: row.update({"direct_url": "[]"}), "not a JSON object"),
+        (lambda row: row.update({"direct_url": "{}"}), "no textual URL"),
+        (lambda row: row.update({"direct_url": '{"url":null}'}), "no textual URL"),
+        (lambda row: row.update({"direct_url": '{"url":7}'}), "no textual URL"),
+        (lambda row: row.update({"direct_url": '{"url":""}'}), "empty URL"),
+        (
+            lambda row: row.update(
+                {"direct_url": '{"url":"first","url":"second"}'}
+            ),
+            "malformed direct URL",
+        ),
+        (
+            lambda row: row.update(
+                {"direct_url": '{"weight":1e999,"url":"https://example.invalid"}'}
+            ),
+            "nonfinite number",
+        ),
+        (
+            lambda row: row.update(
+                {"direct_url": '{"url": "https://example.invalid/package.whl"}'}
+            ),
+            "not canonical",
+        ),
+    ],
+)
+def test_runtime_manifest_rejects_distribution_row_contract_drift(mutation, pattern):
+    runner = _runner_module()
+    manifest = _runtime_manifest(runner)
+    mutation(manifest["distributions"][0])
+
+    with pytest.raises((RuntimeError, TypeError), match=pattern):
+        runner._validate_runtime_environment_manifest(manifest)
+
+
+@pytest.mark.parametrize(
+    ("name", "version"),
+    [
+        ("torch", "2.11.0+cu129"),
+        ("sglang", "0.5.17"),
+        ("sglang-kernel", "0.4.5+cu129"),
+        ("transformers", "5.12.1"),
+        ("triton", "3.6.0"),
+    ],
+)
+def test_runtime_manifest_rejects_duplicate_critical_distribution(name, version):
+    runner = _runner_module()
+    manifest = _runtime_manifest(runner)
+    manifest["distributions"].append(
+        _distribution_record(
+            name,
+            version,
+            metadata_path=f"/usr/local/lib/python3.12/site-packages/{name}-copy.dist-info",
+        )
+    )
+
+    with pytest.raises(RuntimeError, match=f"expected one installed {re.escape(name)}"):
+        runner._validate_runtime_environment_manifest(manifest)
+
+
+@pytest.mark.parametrize(
+    "name", ["torch", "sglang", "sglang-kernel", "transformers", "triton"]
+)
+def test_runtime_manifest_rejects_critical_distribution_version_drift(name):
+    runner = _runner_module()
+    manifest = _runtime_manifest(runner)
+    row = next(item for item in manifest["distributions"] if item["normalized_name"] == name)
+    row["version"] = "0.invalid"
+
+    with pytest.raises(RuntimeError, match=f"manifest {re.escape(name)} distribution"):
+        runner._validate_runtime_environment_manifest(manifest)
+
+
+def test_runtime_manifest_scans_later_duplicate_for_cuda13_marker():
+    runner = _runner_module()
+    manifest = _runtime_manifest(runner)
+    first = _distribution_record(
+        "auxiliary-package",
+        "1.2.3",
+        metadata_path="/usr/local/lib/python3.12/site-packages/auxiliary-a.dist-info",
+    )
+    second = _distribution_record(
+        "auxiliary-package",
+        "1.2.3",
+        metadata_path="/usr/local/lib/python3.12/site-packages/auxiliary-b.dist-info",
+        direct_url=json.dumps(
+            {"url": "file:///wheelhouse/cu13/auxiliary.whl"},
+            sort_keys=True,
+            separators=(",", ":"),
+        ),
+    )
+    manifest["distributions"].extend((first, second))
+
+    with pytest.raises(RuntimeError, match="CUDA 13 distribution marker"):
+        runner._validate_runtime_environment_manifest(manifest)
+
+
+def test_distribution_inventory_deduplicates_repeated_metadata_path(monkeypatch, tmp_path):
+    runner = _runner_module()
+    metadata_path = tmp_path / "auxiliary-package.dist-info"
+    metadata_path.mkdir()
+    distribution = DistributionFixture("auxiliary-package", "1.2.3", metadata_path)
+    monkeypatch.setattr(
+        runner.importlib.metadata,
+        "distributions",
+        lambda: (distribution, distribution),
+    )
+
+    rows = runner._distribution_inventory()
+
+    assert len(rows) == 1
+    assert rows[0]["normalized_name"] == "auxiliary-package"
+
+
+def test_distribution_inventory_rejects_conflicting_repeated_metadata_path(
+    monkeypatch, tmp_path
+):
+    runner = _runner_module()
+    metadata_path = tmp_path / "auxiliary-package.dist-info"
+    metadata_path.mkdir()
+    distributions = (
+        DistributionFixture("auxiliary-package", "1.2.3", metadata_path),
+        DistributionFixture("auxiliary-package", "2.0.0", metadata_path),
+    )
+    monkeypatch.setattr(runner.importlib.metadata, "distributions", lambda: distributions)
+
+    with pytest.raises(RuntimeError, match="authority changed across discovery.*first=.*repeated="):
+        runner._distribution_inventory()
+
+
+@pytest.mark.parametrize("authority", [MISSING_DISTRIBUTION_PATH, "missing.dist-info"])
+def test_distribution_inventory_requires_existing_metadata_authority(
+    monkeypatch, tmp_path, authority
+):
+    runner = _runner_module()
+    metadata_path = (
+        authority if authority is MISSING_DISTRIBUTION_PATH else tmp_path / authority
+    )
+    distribution = DistributionFixture("auxiliary-package", "1.2.3", metadata_path)
+    monkeypatch.setattr(
+        runner.importlib.metadata, "distributions", lambda: (distribution,)
+    )
+
+    with pytest.raises(RuntimeError, match="metadata authority"):
+        runner._distribution_inventory()
+
+
+@pytest.mark.parametrize(
+    ("name", "version"),
+    [(None, "1.2.3"), (7, "1.2.3"), ("auxiliary-package", None), ("auxiliary-package", 7)],
+)
+def test_distribution_inventory_requires_textual_name_and_version(
+    monkeypatch, tmp_path, name, version
+):
+    runner = _runner_module()
+    metadata_path = tmp_path / "auxiliary-package.dist-info"
+    metadata_path.mkdir()
+    distribution = DistributionFixture(name, version, metadata_path)
+    monkeypatch.setattr(
+        runner.importlib.metadata, "distributions", lambda: (distribution,)
+    )
+
+    with pytest.raises(TypeError, match="lacks textual name or version"):
+        runner._distribution_inventory()
+
+
+def test_distribution_inventory_canonicalizes_direct_url_and_discovery_order(
+    monkeypatch, tmp_path
+):
+    runner = _runner_module()
+    first_path = tmp_path / "first.dist-info"
+    second_path = tmp_path / "second.dist-info"
+    first_path.mkdir()
+    second_path.mkdir()
+    first = DistributionFixture(
+        "z-package",
+        "1.0",
+        first_path,
+        '{"url": "https://example.invalid/z.whl", "archive_info": {}}',
+    )
+    second = DistributionFixture("a-package", "2.0", second_path)
+    monkeypatch.setattr(
+        runner.importlib.metadata, "distributions", lambda: (first, second)
+    )
+    forward = runner._distribution_inventory()
+    monkeypatch.setattr(
+        runner.importlib.metadata, "distributions", lambda: (second, first)
+    )
+
+    assert runner._distribution_inventory() == forward
+    assert forward[1]["direct_url"] == (
+        '{"archive_info":{},"url":"https://example.invalid/z.whl"}'
+    )
+
+
+def test_distribution_inventory_rejects_nonobject_direct_url(monkeypatch, tmp_path):
+    runner = _runner_module()
+    metadata_path = tmp_path / "auxiliary-package.dist-info"
+    metadata_path.mkdir()
+    distribution = DistributionFixture(
+        "auxiliary-package", "1.2.3", metadata_path, "[]"
+    )
+    monkeypatch.setattr(
+        runner.importlib.metadata, "distributions", lambda: (distribution,)
+    )
+
+    with pytest.raises(TypeError, match="not a JSON object"):
+        runner._distribution_inventory()
 
 
 def test_loaded_object_ledger_accepts_authorized_cuda12_driver_and_profiler_objects():


### PR DESCRIPTION
## Summary

- preserve every distinct installed-distribution metadata authority in the immutable runtime manifest
- collapse only identical rediscovery of the same resolved metadata path
- permit equivalent duplicate authorities for noncritical packages while retaining exact single-authority and version checks for the five critical runtime packages
- reject malformed metadata paths, ambiguous identities, invalid direct URL provenance, and CUDA 13 markers with actionable diagnostics

## Motivation

Merlin job 195397 reached the container manifest gate and correctly voided because the previous validator treated every repeated normalized package name as malformed. Python environments may expose multiple distinct metadata authorities with the same version and provenance. This change records those authorities without weakening the frozen Torch, SGLang, SGLang kernel, Transformers, Triton, CUDA, or OCI constraints.

## Validation

- `ruff check .`
- `pytest -q`: 2059 passed, 8 skipped
- `python scripts/check_docs_format.py`
- SGLang A100 pilot `--check-only`
- independent adversarial review of the distribution authority seam

The expectations-only commit and frozen expectation hashes are unchanged. No GPU result is claimed by this pull request.
