### PR TITLE
Accept the preserved manifest snapshot in the dataset guard

### DIFF
--- a/examples/merlin_ss_fabric_loadbearing_v1/RESULTS.md
+++ b/examples/merlin_ss_fabric_loadbearing_v1/RESULTS.md
@@ -381,6 +381,24 @@ to their commits; no band, verdict or registered value changed.
    freeze's deliverable list named (the safe direction: the rules
    preceded every tracked artifact they cover).
 
+- Correction 10 (post-published, fold-in compatibility, 2026-08-18
+  evening): the FG-1 dataset clause originally hashed the LIVING
+  capture MANIFEST.json against the frozen digest, which voided every
+  rerun the moment the capture study's committed fold-in protocol
+  advanced the dataset (the tranche-2 landing did exactly that, and
+  the same protocol delivered the x4 cell this study consumed). The
+  clause now verifies the freeze's actual claim: it accepts the living
+  manifest only while it still is the frozen version, and otherwise
+  requires the preserved byte-exact snapshot at
+  dataset/manifest_versions/ under the frozen digest, failing closed
+  on absence or self-hash mismatch, with the consumed files verified
+  against the frozen entries either way. The guard's recorded basis is
+  unchanged (the frozen digest), the analyzer rerun on the
+  post-fold-in dataset reproduces the tracked summary byte for byte,
+  and the companion CI test performs the matching snapshot
+  verification. This mirrors, one level deeper, the disclosed test
+  repoint the tranche-2 landing made for the same reason.
+
 ## Reproduction
 
 ```bash

--- a/examples/merlin_ss_fabric_loadbearing_v1/analyze_recalibration.py
+++ b/examples/merlin_ss_fabric_loadbearing_v1/analyze_recalibration.py
@@ -189,10 +189,28 @@ def derive_x4_inputs(dataset_root: Path) -> dict[str, object]:
 
 
 def verify_dataset(dataset_root: Path, fatal: list[str]) -> None:
+    # The freeze's claim is the CONSUMED manifest version, not the living
+    # dataset tip: the capture study's committed fold-in protocol advances
+    # MANIFEST.json, preserving each superseded version byte-exact and
+    # self-verifying under dataset/manifest_versions/<its sha256>.json.
+    # Accept the living manifest only while it still IS the frozen version;
+    # otherwise require the preserved snapshot and fail closed on absence
+    # or self-hash mismatch. The guard's recorded basis is the frozen
+    # digest either way (post-published amendment, disclosed in RESULTS
+    # correction 10; published outputs proven byte-identical).
     manifest_path = dataset_root / "MANIFEST.json"
     if sha256_file(manifest_path) != FROZEN_DATASET_MANIFEST_SHA256:
-        fatal.append("FG-1: dataset manifest sha mismatch")
-        return
+        snapshot = (dataset_root / "manifest_versions"
+                    / f"{FROZEN_DATASET_MANIFEST_SHA256}.json")
+        if not snapshot.is_file():
+            fatal.append("FG-1: frozen dataset manifest version absent "
+                         "(neither the living manifest nor a preserved "
+                         "snapshot matches the freeze)")
+            return
+        if sha256_file(snapshot) != FROZEN_DATASET_MANIFEST_SHA256:
+            fatal.append("FG-1: manifest snapshot fails its self-hash")
+            return
+        manifest_path = snapshot
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     consumed = ["stats/x4-incast_stats.json"] + [
         f"x4-incast/x4-incast_flow{i}_dest.csv.gz" for i in range(4)]

--- a/tests/test_merlin_ss_fabric_loadbearing_results.py
+++ b/tests/test_merlin_ss_fabric_loadbearing_results.py
@@ -116,3 +116,24 @@ def test_mutation_is_detected():
     truncated = dict(manifest)
     truncated[rel] = dict(truncated[rel], bytes=manifest[rel]["bytes"] + 1)
     assert _verify(truncated, RESULTS) != []
+
+
+def test_dataset_guard_accepts_the_preserved_manifest_snapshot():
+    # Correction 10: after a capture fold-in advances the living
+    # manifest, FG-1 must verify the frozen snapshot instead of
+    # voiding. On the current tree the living manifest has moved, so
+    # this exercises the snapshot path end to end; the negative
+    # control mutates the resolved manifest bytes and must void.
+    import importlib.util
+    spec = importlib.util.spec_from_file_location(
+        "analyze_recalibration",
+        RESULTS.parent / "analyze_recalibration.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    fatal: list[str] = []
+    mod.verify_dataset(mod.DEFAULT_DATASET, fatal)
+    assert fatal == [], f"FG-1 must accept the frozen snapshot: {fatal}"
+    bogus: list[str] = []
+    mod.FROZEN_DATASET_MANIFEST_SHA256 = "0" * 64
+    mod.verify_dataset(mod.DEFAULT_DATASET, bogus)
+    assert bogus and "FG-1" in bogus[0], "mutated pin must fail closed"


### PR DESCRIPTION
The one-level-deeper completion of the tranche-2 landing's disclosed test repoint: the recalibration analyzer's FG-1 dataset clause still hashed the LIVING capture MANIFEST.json against the frozen digest, so every rerun on the post-fold-in dataset voided, including the study's own frozen late-arrival scoring that the tranche-2 cells now feed.

The clause now verifies the freeze's actual claim: it accepts the living manifest only while it still is the frozen version, and otherwise requires the preserved byte-exact snapshot under dataset/manifest_versions/ at the frozen digest, failing closed on absence or self-hash mismatch, with the consumed files verified against the frozen entries either way. The guard's recorded basis is unchanged (the frozen digest); the analyzer rerun against the tracked bulk tree on the post-fold-in dataset reproduces the tracked summary byte for byte; a regression test exercises the snapshot path end to end with a mutated-pin negative control that must fail closed. Disclosed as correction 10 in the study RESULTS, mirroring the capture study's own disclosed accommodation.

Gates: ruff clean, full pytest green, docs format and task-progress checks OK.