### PR TITLE
Pin the COMP-72 sizing note to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -247,3 +247,4 @@ tests/test_deployment_curve_core61.py text eol=lf
 tests/test_hopper_mtp_recovery.py text eol=lf
 tests/test_hopper_deepseek_repeat_recovery.py text eol=lf
 tests/test_hopper_campaign_successor.py text eol=lf
+notes/2026-08-27-comp72-worker-sizing.md text eol=lf


### PR DESCRIPTION
The one-commit remainder of the comp72 verification pass: the campaign sizing note joins the LF attribute list per the byte-lock rule (verified with git check-attr). The worker this commit came from independently reproduced all four tracked successor-record digests byte for byte on top of the merged campaign evidence, confirmed the DeepSeek physical ledger at MEASURED 5 / ABSENT 0 with two observations per priced key, and honored both registered blockers (the Granite staging gap and the depth-8 frozen gate, recorded as COMP-78).

Integrator verification: ruff and the full suite green (3,206 passed, 13 skipped) with direct exit codes.