### PR TITLE
Skip the aggregate plotter test when matplotlib is absent

### DIFF
--- a/tests/test_matched_seam_aggregate_study.py
+++ b/tests/test_matched_seam_aggregate_study.py
@@ -206,6 +206,7 @@ def test_aggregate_plot_contract_names_strategy_and_traffic() -> None:
 
 
 def test_aggregate_plotter_renders_both_additive_pairs(tmp_path: Path) -> None:
+    pytest.importorskip("matplotlib")
     plotter = _load(PLOTTER, "matched_seam_aggregate_renderer")
     paths = {
         "study_pdf": tmp_path / "study.pdf",


### PR DESCRIPTION
Repairs the red main from PR #181: the new aggregate plotter test imported matplotlib unconditionally, and CI installs only the dev extra. The guard matches the repo's existing pattern (pytest.importorskip) used by every other plotter test. Root cause of the bad merge is process, not code: the integrator merged on a completed-but-failed check run without parsing check states; the merge ritual is corrected to gate on parsed check conclusions. All other #181 content is unaffected (the failing test was environment-import only; the study itself is figure-independent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)