### PR TITLE
Re-pin the frozen expectation commits after the history rewrite

### DIFF
--- a/examples/nvlink_credit_arbitration_v1/run_hardware_campaign.py
+++ b/examples/nvlink_credit_arbitration_v1/run_hardware_campaign.py
@@ -24,7 +24,15 @@ ROOT = HERE.parents[1]
 TRAF70_ROOT = HERE.parent / "a100_nvlink_packet_v2"
 PRODUCER_EXTENSION_PATH = HERE / "producer_traf73.patch"
 EXPECTATIONS_PATH = HERE / "aligned_expectations.json"
-EXPECTATIONS_COMMIT = "f3f2624e7a96efe3ad67eac5940fee8746e40b98"
+# Re-pin amendment, 2026-09-02. The default branch was rewritten and force
+# pushed on 2026-09-01 to purge co-author trailers, which gave every commit
+# from the rewrite point onward a new identifier. The freeze itself did not
+# move. The original pin f3f2624e7a96efe3ad67eac5940fee8746e40b98 and the pin
+# below carry the same tree 54ef266d5f81437c583c2522701c0bd744dd7b44, the same
+# subject "Freeze aligned NVLink identification" and the same author date
+# 2026-09-01T15:53:41+02:00. The frozen digest below is unchanged, and the
+# published TRAF-73 record keeps the pre-rewrite identifier it ran under.
+EXPECTATIONS_COMMIT = "7cab9cd84dfcfce50c7b45553bcd4a54ec4a8ea0"
 EXPECTATIONS_SHA256 = "a17b9e298d11a4a6ba92b382121c15a5a48f8100b6f343893260419b1d3382f6"
 DERIVED_PRODUCER_SHA256 = "3e4b24382314f5f0dd84f4b54d126c5777e6c92a71c3644f8835b2f5cd3a4694"
 CELL_SCHEMA = "simllm-nvlink-credit-identification-cell-v1"

--- a/examples/nvlink_incast_validation_v1/run_campaign_run2.py
+++ b/examples/nvlink_incast_validation_v1/run_campaign_run2.py
@@ -27,7 +27,15 @@ def _load_module(name: str, path: Path) -> Any:
 _runner = _load_module("_traf74_first_campaign_reused_for_run2", FIRST_RUNNER_PATH)
 
 EXPECTATIONS_PATH = HERE / "expectations_run2.json"
-EXPECTATIONS_COMMIT = "b21ba822707d2d7c80b83ee2d3fb87f4fa93178d"
+# Re-pin amendment, 2026-09-02. The default branch was rewritten and force
+# pushed on 2026-09-01 to purge co-author trailers, which gave every commit
+# from the rewrite point onward a new identifier. The freeze itself did not
+# move. The original pin b21ba822707d2d7c80b83ee2d3fb87f4fa93178d and the pin
+# below carry the same tree d212e995bf5e16fd5a03f35258d134909b7936cd, the same
+# subject "Freeze the TRAF-74 second capture" and the same author date
+# 2026-09-01T13:43:24+02:00. The frozen digest below is unchanged, and the
+# published TRAF-74 record keeps the pre-rewrite identifier it ran under.
+EXPECTATIONS_COMMIT = "ff76eb5ed57f30f43cf1e7f097435e54b46212a9"
 EXPECTATIONS_SHA256 = "5465271e9909cebc214c153209316a6f266ec142d7e578b3279935b1c6a10a53"
 REGISTRY_TASK_ID = "TRAF-74"
 CELL_ID = "nv4-long-flow-incast-run2"

--- a/tests/test_nvlink_credit_arbitration_hardware_campaign.py
+++ b/tests/test_nvlink_credit_arbitration_hardware_campaign.py
@@ -103,7 +103,9 @@ def mock_binary(tmp_path_factory):
 
 
 def test_campaign_pins_final_aligned_freeze(runner, frozen):
-    assert runner.EXPECTATIONS_COMMIT == "f3f2624e7a96efe3ad67eac5940fee8746e40b98"
+    # Re-pinned 2026-09-02 after the 2026-09-01 history rewrite renamed the
+    # freeze. Same tree, same subject, same author date, same digest below.
+    assert runner.EXPECTATIONS_COMMIT == "7cab9cd84dfcfce50c7b45553bcd4a54ec4a8ea0"
     assert runner.EXPECTATIONS_SHA256 == (
         "a17b9e298d11a4a6ba92b382121c15a5a48f8100b6f343893260419b1d3382f6"
     )

--- a/tests/test_nvlink_incast_validation_run2_study.py
+++ b/tests/test_nvlink_incast_validation_run2_study.py
@@ -70,8 +70,10 @@ def _synthetic_rows() -> list[dict[str, object]]:
 
 
 def test_run2_runner_pins_the_final_expectations_commit_and_digest() -> None:
+    # Re-pinned 2026-09-02 after the 2026-09-01 history rewrite renamed the
+    # freeze. Same tree, same subject, same author date, same digest below.
     assert run_campaign.EXPECTATIONS_COMMIT == (
-        "b21ba822707d2d7c80b83ee2d3fb87f4fa93178d"
+        "ff76eb5ed57f30f43cf1e7f097435e54b46212a9"
     )
     assert run_campaign.EXPECTATIONS_SHA256 == (
         "5465271e9909cebc214c153209316a6f266ec142d7e578b3279935b1c6a10a53"


### PR DESCRIPTION
## What broke

The default branch was rewritten and force pushed on 2026-09-01 to purge
co-author trailers. Commits from the rewrite point onward received new
identifiers. Two study runners pin their pre-registration commit by identifier
and check that the pin is an ancestor of HEAD before they will load a freeze,
so both checks started failing. Eleven tests failed on every CI run since:

- `tests/test_nvlink_credit_arbitration_hardware_campaign.py`, one failure and
  nine errors, all reporting "the aligned expectations commit is not an
  ancestor".
- `tests/test_nvlink_incast_validation_run2_study.py::test_run2_runner_pins_the_final_expectations_commit_and_digest`,
  reporting "the TRAF-74 expectations commit is not an ancestor".

The rewrite changed the identifiers, not the content. Nothing about either
freeze moved.

## What changed

Only the two identifiers, plus the two test assertions that mirror them. Every
digest in the tree is untouched.

### Mapping 1

`examples/nvlink_credit_arbitration_v1/run_hardware_campaign.py`

| field | value |
|---|---|
| old pin | `f3f2624e7a96efe3ad67eac5940fee8746e40b98` |
| new pin | `7cab9cd84dfcfce50c7b45553bcd4a54ec4a8ea0` |
| subject | Freeze aligned NVLink identification |
| author date | 2026-09-01T15:53:41+02:00 |
| shared tree | `54ef266d5f81437c583c2522701c0bd744dd7b44` |
| frozen digest, unchanged | `a17b9e298d11a4a6ba92b382121c15a5a48f8100b6f343893260419b1d3382f6` |

### Mapping 2

`examples/nvlink_incast_validation_v1/run_campaign_run2.py`

| field | value |
|---|---|
| old pin | `b21ba822707d2d7c80b83ee2d3fb87f4fa93178d` |
| new pin | `ff76eb5ed57f30f43cf1e7f097435e54b46212a9` |
| subject | Freeze the TRAF-74 second capture |
| author date | 2026-09-01T13:43:24+02:00 |
| shared tree | `d212e995bf5e16fd5a03f35258d134909b7936cd` |
| frozen digest, unchanged | `5465271e9909cebc214c153209316a6f266ec142d7e578b3279935b1c6a10a53` |

## How each mapping was confirmed

Four independent facts per pin, all of which had to agree:

1. The old and the new commit carry the identical whole-repository tree, so
   `git diff <old> <new>` is empty. The old objects are still reachable
   locally, so this was a direct comparison rather than an inference.
2. The subject is identical, and it is the only commit on the default branch
   with that subject.
3. The author name, author email and author date match to the second, and so
   do the committer fields.
4. The expectations file as stored at the new commit hashes to the digest the
   runner already pinned, so the content the pin exists to protect is provably
   the same file.

## What was deliberately left alone

The published run records keep their pre-rewrite identifiers, because a result
record states what a run actually used and the repo rules forbid rewriting a
result after it has been observed. That covers
`examples/nvlink_credit_arbitration_v1/hardware_identification.json`,
`examples/nvlink_incast_validation_v1/results_run2.json`, the two rendered
reports generated from them, and the dated notes alongside them. Those files
are also byte-compared against their own generators in the test suite, so a
silent edit there would have been both wrong and loud.

Instead, each live pin and each test assertion now carries a dated amendment
note that names the identifier it replaced and why, so a reader who finds the
old identifier in a record can follow it forward without guessing.

The wider tree still contains roughly thirty other pre-rewrite identifiers in
result records and notes. None of them feed an ancestor check, all of their
tests pass, and they are historical statements about completed runs, so they
were left as they are.

## Verification

Local runs on Python 3.10:

| gate | before | after |
|---|---|---|
| `pytest -q` | 2 failed, 9 errors, 4145 passed, 26 skipped | 4156 passed, 26 skipped |
| `ruff check .` | pass | pass |
| `python scripts/check_docs_format.py` | pass | pass |

The 26 skips are identical before and after. All of them are environment gates
for software or hardware that is not present: vLLM, torch, the pinned SGLang
install, the LogGOPSim and htsim binaries, external evidence roots for fetched
hardware capture, and one Windows-only job-object path. Nothing in this change
touches them.
