### PR TITLE
Reduce dependency lookup work with exact completion compatibility

### DIFF
--- a/docs/modules/core.md
+++ b/docs/modules/core.md
@@ -1756,9 +1756,13 @@ capture exists.
   The fresh [host diagnostic](../../examples/pd_host_execution_diagnostic_v1/RESULTS.md)
   completes all 28 requests with exact compatibility. Dependency checking
   consumes 35.4 to 36.1 percent of enclosing process CPU time as exclusive
-  main-thread work in its passive four-request cells. Freeze an optimization
-  separately before changing that source, preserve all rejection semantics,
-  and then freeze a fresh target campaign. The first diagnostic remains VOID
+  main-thread work in its passive four-request cells. The separately frozen
+  [dependency index study](../../examples/dependency_index_v1/RESULTS.md)
+  reduces direct-verifier conversions from 8,976 to 272 in its largest case,
+  exactly the predicted factor of 33, with identical modeled outcomes and
+  rejection semantics. Freeze a fresh native target campaign using the
+  qualified optimization; its operation counts do not establish host-time
+  speedup or target feasibility. The first diagnostic remains VOID
   after its checker rejected the native writer's unchanged JSON encoding;
   the repaired encoding contract is explicitly post-specified. Host attribution
   closes neither target feasibility nor independent-engine timing.

--- a/examples/dependency_index_v1/RESULTS.md
+++ b/examples/dependency_index_v1/RESULTS.md
@@ -1,0 +1,124 @@
+# Call-local dependency lookup result
+
+The source-paired study **PASS** removes repeated dependency searches without
+changing any modeled outcome. In the largest direct-verifier case, conversion
+calls fall from 8,976 to 272, exactly the frozen factor of 33. CORE-52 gains a
+qualified host-work optimization and can freeze its next native target
+campaign. Its 56-engine feasibility task remains open.
+
+## What ran
+
+Two fresh local processes execute the same committed worker against the old
+and new installed package sources. Twelve graph configurations cross depth
+`{1,2,4,8}` with width `{2,4,8}`. Each retains the full graph, communication
+schedule and direct-call profile. Two valid key controls per source exercise
+distinct dependency origins and participant ranks. Fourteen corruptions in
+each graph produce 168 rejected projections per source.
+
+Four supported `HtsimStepSink` jobs per source cross prompt lengths 8 and 16
+with one and four serial requests. Each request has one prefill and four
+decode steps, giving 50 steps per source. The selected Granite configuration
+uses 24 layers, eight local ranks, the B100 architecture envelope, roofline
+efficiency 0.7 and ideal host initiation. No native serving frontend, GPU or
+packet backend executes in this study.
+
+All eight required stages complete. Evidence classes remain separate:
+3,208 unscored guards have no violation; 24 exact conversion-count oracle
+rows match; 12 behavioral instances in one reduction family pass; and five
+semantic corruption controls reject the intended damage. These classes are
+not added into a combined score.
+
+## Expected work and observed reduction
+
+Let `E` count effective-edge occurrences, `B` boundary occurrences and `S`
+serialized occurrences. The retained conversion sites require at least
+`E+B+S` calls. The old search can inspect at most `E` candidates for each
+serialized occurrence, giving the ceiling `E+B+S+E*S`. These bounds are
+recorded before either worker starts.
+
+For this frozen graph family, the exact old count is
+`(2*w+1)*d*(2+w*d)` and the new count is `2*(2*w+1)*d`. Their ratio is
+`1+w*d/2`. Every observed count lies inside its bounds and equals its frozen
+formula. The width-eight slice shows both the direction and shape:
+
+| Depth | Old calls | New calls | Old/new |
+|---|---|---|---|
+| 1 | 170 | 34 | 5 |
+| 2 | 612 | 68 | 9 |
+| 4 | 2,312 | 136 | 17 |
+| 8 | 8,976 | 272 | 33 |
+
+At fixed width, doubling depth doubles the new conversion count; the old
+count follows the frozen quadratic-plus-linear relation. In the largest
+case, the floor is 272 and the ceiling is 17,680. The new path reaches the
+floor because it retains each first matching edge while building the existing
+occurrence counter. It no longer converts discarded search candidates.
+This proves a reduction in this operation count, not linear complexity of the
+whole verifier or a 33-fold reduction in elapsed execution time.
+
+The complete before and after processes take 200.258 and 174.231 seconds.
+Their sampled maximum current resident memory is 535,132 and 566,764 KiB.
+These single-run observations include profiling, evidence construction and
+sink jobs. They are diagnostics without a scored speedup or memory claim.
+
+## Completion and rejection compatibility
+
+The existing resident-weight streaming surrogate gives a conditional floor
+of 320,864,256 bytes divided by 8 TB/s, or 40,108,032 ps per step. The sum of
+the declared services gives the serial-job ceiling and exact completion
+oracle. The observed decode services, 77,952,000 and 77,976,000 ps, exceed
+that floor. Both sources finish each job exactly at its declared ceiling:
+
+| Prompt tokens | Serial requests | Steps | Completion, ps |
+|---|---|---|---|
+| 8 | 1 | 5 | 407,232,000 |
+| 8 | 4 | 20 | 1,628,928,000 |
+| 16 | 1 | 5 | 426,840,000 |
+| 16 | 4 | 20 | 1,707,360,000 |
+
+Four serial requests take exactly four times one request. All full step
+inputs, results and ten sink publication collections remain identical; each
+paired sink file has identical bytes. This floor belongs to the existing
+surrogate. COMP-7 retains routed-expert compute precision, so these checks do
+not establish a hardware decoding rate.
+
+Full graph and projection values also remain identical before and after.
+Every invalid projection retains the exact exception class and message,
+including which error appears first when two fields are corrupted. Inputs
+remain unchanged after both accepted and rejected calls. Multiplicity,
+canonical schedule order and the five-field dependency key keep their prior
+meaning.
+
+## Chronology and retained evidence
+
+The expectations-only freeze is
+`581d41531c42759e1fd1f9b7af3a0f45844f51a2`, preceding implementation and the
+first source-paired run. The old package source is
+`67cb2dbdfc393400f1c760a0d24534ad3c494094`; the executed new source is
+`8dcf9858a881f8c2b42207c1ab644fb0d471ea88`.
+Only `simllm/traffic/execution_goal.py` changes among installed package files.
+The worker, configuration helper, actual imports, complete package inventories
+and profile function identities are source-bound.
+
+The raw summary SHA-256 is
+`afe3e18026443e0b92f2f45de781465a4152456847f13a8c5ff526a8b53a0821`.
+The [portable publication](results.json) retains the source and raw receipts,
+conversion matrix and paired job results. There are 86 process raw files
+totaling 334,338,908 bytes, with identical initial and final receipt domains
+and hashes. Full profiles and captures stay in external evidence storage.
+
+## Project effect and limits
+
+CORE-52 can use the indexed checker in a separately frozen native target
+campaign. Its earlier target and diagnostic VOID attempts retain their
+original receipts and verdicts. This study closes no stable task and changes
+no simulated timestamp, service model or default configuration.
+
+CORE-68 retains independent-engine timing; CORE-51 and CORE-54 retain
+deployment and frontier obligations. These local sink jobs qualify job
+completion compatibility. They do not measure serving time to first token,
+time per output token, GPU service or 56-engine throughput.
+
+Before the first source-paired execution, 45 focused software tests passed
+in 21.43 seconds and Ruff passed. Software gates remain separate from the
+study evidence classes.

--- a/examples/dependency_index_v1/checks.py
+++ b/examples/dependency_index_v1/checks.py
@@ -1,0 +1,270 @@
+"""Separate exact lookup work from unchanged supported-path completion."""
+
+from __future__ import annotations
+
+import ast
+import json
+from copy import deepcopy
+from pathlib import Path
+
+from examples.dependency_index_v1.worker import encoded, profile_rows
+from examples.pd_session_target_scale_v1.checks import GuardFailure, integer
+
+
+def read(path):
+    def unique(pairs):
+        value = {}
+        for key, item in pairs:
+            if key in value:
+                raise GuardFailure("duplicate JSON field: " + key)
+            value[key] = item
+        return value
+
+    raw = path.read_bytes()
+    value = json.loads(raw, object_pairs_hook=unique)
+    if raw != encoded(value):
+        raise GuardFailure("noncanonical evidence: " + path.name)
+    return value
+
+
+def formula(depth, width):
+    edges = depth * (2 * width + 1)
+    boundaries, serialized = depth, 2 * depth * width
+    search = width * (2 * width + 1) * depth * depth
+    return {"edges": edges, "boundaries": boundaries, "serialized": serialized,
+            "artifacts": 2 * depth + 1, "search": search,
+            "floor": edges + boundaries + serialized,
+            "ceiling": edges + boundaries + serialized + edges * serialized,
+            "before": edges + boundaries + serialized + search, "after": edges + boundaries + serialized}
+
+
+def conversion_calls(rows, source, evidence, label):
+    selected = [row for row in rows if row["function"][2] == "_goal_edge"]
+    evidence.equal(label + ":function-domain", len(selected), 1)
+    row = selected[0]
+    definitions = [node for node in ast.parse(source.read_bytes()).body
+                   if isinstance(node, ast.FunctionDef) and node.name == "_goal_edge"]
+    evidence.check(label + ":source-definition", len(definitions) == 1 and not definitions[0].decorator_list)
+    evidence.equal(label + ":source-origin", row["function"], [str(source), definitions[0].lineno, "_goal_edge"])
+    evidence.check(label + ":integer-count", integer(row["calls"], 1)
+                   and row["primitive_calls"] == row["calls"])
+    return row["calls"]
+
+
+def frozen_input(spec, frozen, *, control=None):
+    """Construct the declared graph independently of the capture worker."""
+    from examples.dependency_index_v1.worker import input_value
+    from simllm.core import CollectiveWork, ComputeWork, ExecutionGraph, ExecutionOperation
+    from simllm.traffic import project_execution_graph_goal
+
+    if control:
+        if control == "same-endpoints-distinct-origin":
+            operations = (
+                ExecutionOperation("first", 0, "shared", ComputeWork("first", nominal_duration_ps=1000)),
+                ExecutionOperation("second", 0, "shared", ComputeWork("second", nominal_duration_ps=1000), depends_on=("first",)))
+        else:
+            work = CollectiveWork("all-reduce", (0, 1, 2, 3), 64, "ring")
+            operations = (ExecutionOperation("first", 0, "shared", work),
+                          ExecutionOperation("second", 0, "shared", work, participant_local_depends_on=("first",)))
+        graph = ExecutionGraph(control, 0, 0, operations, ("second",))
+    else:
+        depth, width = spec["depth"], spec["width"]
+        operations = []
+        for layer in range(depth + 1):
+            computes = tuple(f"compute-{layer}-{rank}" for rank in range(width)) if layer else ()
+            for rank, name in enumerate(computes):
+                operations.append(ExecutionOperation(name, rank, name, ComputeWork(name, nominal_duration_ps=frozen["compute_service_ps"]),
+                                  participant_local_depends_on=(f"ring-{layer - 1}",)))
+            operations.append(ExecutionOperation(f"ring-{layer}", 0, "collective",
+                              CollectiveWork("all-reduce", tuple(range(width)), frozen["ring_payload_bytes"], "ring"),
+                              participant_local_depends_on=computes))
+        graph = ExecutionGraph(f"depth-{depth}-width-{width}", 0, 0, tuple(operations), (f"ring-{depth}",))
+    return input_value(graph, project_execution_graph_goal(graph))
+
+
+def declared_corruption(value, name):
+    """Apply the frozen deltas to JSON, separately from worker object mutations."""
+    result = deepcopy(value)
+    projection = result["projection"]
+    serialized, boundaries = projection["serialized_edges"], projection["boundaries"]
+    first = serialized[0]
+    if name == "predecessor":
+        first["predecessor_id"] = "absent"
+    elif name == "target":
+        first["operation_id"] = "absent"
+    elif name == "scope":
+        first.update(scope="whole-operation", participant_rank=None)
+    elif name == "origin":
+        first["origin"] = "logical-queue-fifo"
+    elif name == "participant-rank":
+        first["participant_rank"] = (first["participant_rank"] + 1) % projection["num_goal_ranks"]
+    elif name == "invalid-type":
+        serialized[0] = "invalid-edge"
+    elif name == "delete":
+        serialized.pop(0)
+    elif name == "duplicate":
+        serialized.append(deepcopy(first))
+    elif name == "reverse":
+        serialized.reverse()
+    elif name == "boundary-as-serialized":
+        serialized.append(boundaries.pop(0)["edge"])
+    elif name == "serialized-also-boundary":
+        owner = {operation: index for index, artifact in enumerate(projection["artifacts"]) for operation in artifact["operation_ids"]}
+        boundaries.append({"predecessor_artifact_index": owner[first["predecessor_id"]],
+                           "operation_artifact_index": owner[first["operation_id"]], "edge": deepcopy(first)})
+    elif name == "canonical-text":
+        artifact = projection["artifacts"][1]
+        operation = artifact["operations"][0]
+        operation["text"] = "calc 2"
+        artifact["text"] = artifact["text"].replace(operation["label"] + ": calc 1\n", operation["label"] + ": calc 2\n", 1)
+    elif name == "boundary-index-before-invalid-type":
+        serialized[0] = "invalid-edge"
+        boundaries[0]["predecessor_artifact_index"] = 1
+    elif name == "edge-count-before-canonical-text":
+        return declared_corruption(declared_corruption(value, "canonical-text"), "delete")
+    else:
+        raise GuardFailure("unknown declared corruption")
+    return result
+
+
+def check_graphs(data, frozen, root, path, evidence):
+    prefix = data["arm"]
+    evidence.equal(prefix + ":graph-domain", [row["id"] for row in data["graphs"]], [row["id"] for row in frozen["graph_cases"]])
+    calls = {}
+    for row, spec in zip(data["graphs"], frozen["graph_cases"], strict=True):
+        label = prefix + ":graph:" + spec["id"]
+        evidence.fields(label + ":fields", row, "id before after accepted profile_hook_restored profiles rejections")
+        expected = formula(spec["depth"], spec["width"])
+        evidence.check(label + ":accepted", row["accepted"] is True and row["profile_hook_restored"] is True)
+        evidence.equal(label + ":immutable", row["after"], row["before"])
+        value = row["before"]
+        evidence.fields(label + ":input-fields", value, "graph edges projection")
+        evidence.equal(label + ":frozen-input", value, frozen_input(spec, frozen))
+        projection = value["projection"]
+        evidence.equal(label + ":edge-count", len(value["edges"]), expected["edges"])
+        for collection, field in (("artifacts", "artifacts"), ("boundaries", "boundaries"), ("serialized_edges", "serialized")):
+            evidence.equal(label + ":" + collection, len(projection[collection]), expected[field])
+        raw_profile = path / (spec["id"] + ".pstats")
+        evidence.equal(label + ":profile-export", read(raw_profile.with_suffix(".json")), row["profiles"])
+        evidence.equal(label + ":binary-profile", profile_rows(raw_profile), row["profiles"])
+        observed = conversion_calls(row["profiles"], root / "simllm/traffic/execution_goal.py", evidence, label)
+        evidence.check(label + ":work-bounds", expected["floor"] <= observed <= expected["ceiling"])
+        evidence.equal(label + ":work-oracle", observed, expected[prefix], kind="oracles")
+        calls[spec["id"]] = observed
+        evidence.equal(label + ":rejection-domain", [item["name"] for item in row["rejections"]], frozen["projection_corruptions"])
+        for item in row["rejections"]:
+            tag = label + ":reject:" + item["name"]
+            evidence.fields(tag + ":fields", item, "name before after exception")
+            evidence.equal(tag + ":immutable", item["after"], item["before"])
+            evidence.equal(tag + ":declared-delta", item["before"], declared_corruption(value, item["name"]))
+            evidence.check(tag + ":changed-input", encoded(item["before"]) != encoded(value))
+            evidence.check(tag + ":rejected", type(item["exception"]) is dict
+                           and item["exception"].get("type") in ("TypeError", "ValueError")
+                           and type(item["exception"].get("message")) is str and bool(item["exception"]["message"]))
+            if item["name"] == "boundary-index-before-invalid-type":
+                evidence.equal(tag + ":precedence", item["exception"], {
+                    "type": "ValueError", "message": "artifact boundary indexes do not match graph operations"})
+            elif item["name"] == "edge-count-before-canonical-text":
+                evidence.check(tag + ":precedence", item["exception"]["type"] == "ValueError"
+                               and item["exception"]["message"].startswith("GOAL projection edge mismatch:"))
+    evidence.equal(prefix + ":valid-control-domain", [row["id"] for row in data["controls"]], frozen["valid_key_controls"])
+    for row in data["controls"]:
+        label = prefix + ":control:" + row["id"]
+        evidence.fields(label + ":fields", row, "id before after accepted")
+        evidence.check(label + ":accepted", row["accepted"] is True)
+        evidence.equal(label + ":immutable", row["before"], row["after"])
+        evidence.equal(label + ":frozen-input", row["before"], frozen_input(None, frozen, control=row["id"]))
+        edges = row["before"]["edges"]
+        evidence.check(label + ":same-endpoints", len({(edge["predecessor_id"], edge["operation_id"]) for edge in edges}) == 1)
+        if row["id"] == "same-endpoints-distinct-origin":
+            evidence.equal(label + ":origin-domain", sorted(edge["origin"] for edge in edges), ["explicit", "logical-queue-fifo"])
+        else:
+            evidence.equal(label + ":rank-domain", sorted(edge["participant_rank"] for edge in edges if edge["participant_rank"] is not None), list(range(4)))
+    return calls
+
+
+def check_sinks(data, frozen, evidence):
+    from examples.pd_session_v1 import run_study as baseline
+    from simllm.compute import GPU_ENVELOPES, HostInitiationModel, RooflineProvider
+    from simllm.placement import declared_manifest
+    from simllm.traffic import resolve_collective_fixed_cost_envelope
+
+    envelope = resolve_collective_fixed_cost_envelope("intra-node-fixed-cost-v1")
+    expected_selection = {"gpu": GPU_ENVELOPES["b100"], "host": HostInitiationModel.ideal(), "dims": baseline._granite_dims(),
+                          "provider": vars(RooflineProvider(efficiency=0.7)), "tp_ranks": list(range(8)),
+                          "placement": declared_manifest(tp=8, nodes=1, gpus_per_node=8),
+                          "precision": {"compute": "roofline", "dependency": "serial", "locality": "analytic-nvlink", "network": "rnic-nn-fluid"},
+                          "collective_profile": envelope.arm_profile("lower")}
+    evidence.equal(data["arm"] + ":sink-domain", [row["id"] for row in data["sinks"]], [spec["id"] for spec in frozen["sink_cases"]])
+    for row, spec in zip(data["sinks"], frozen["sink_cases"], strict=True):
+        label = data["arm"] + ":sink:" + spec["id"]
+        evidence.fields(label + ":fields", row, "id steps completed_at_ps selection publications")
+        evidence.check(label + ":source-selection", encoded(row["selection"]) == encoded(expected_selection))
+        evidence.equal(label + ":step-count", len(row["steps"]), 5 * spec["requests"])
+        services = frozen["known_services_ps"][str(spec["prompt_tokens"])]
+        now = 0
+        for index, step in enumerate(row["steps"]):
+            tag = label + ":step:" + str(index)
+            visit, prompt = index % 5, spec["prompt_tokens"]
+            service = services["prefill" if visit == 0 else "decode"]
+            evidence.fields(tag + ":fields", step, "record result")
+            evidence.equal(tag + ":input", step["record"], {"schema": "atlahs-closed-loop-step-v1",
+                "step_index": index, "virtual_time_ps": now, "num_sampled": 1,
+                "preempted_request_ids": [], "finished_request_ids": [],
+                "scheduled": [{"request_id": "request-" + str(index // 5), "phase": "prefill" if visit < 2 else "decode",
+                               "num_new_tokens": prompt if visit == 0 else 1, "num_cached_tokens": prompt if visit == 1 else 0,
+                               "context_length": prompt + visit}]})
+            result = step["result"]
+            evidence.check(tag + ":physical-floor", integer(result["step_latency_ps"], frozen["resident_surrogate_floor_ps"]))
+            evidence.equal(tag + ":known-service", result, {"step_index": index, "step_latency_ps": service,
+                           "completed_at_ps": now + service, "request_metrics": [], "additive_visit_totals": None})
+            now += service
+        evidence.equal(label + ":job-completion", row["completed_at_ps"], now)
+        evidence.equal(label + ":serial-oracle", now, spec["requests"] * (services["prefill"] + 4 * services["decode"]))
+        publications = row["publications"]
+        evidence.equal(label + ":publication-domain", sorted(publications), sorted(frozen["sink_collections"]))
+        for name, rows in publications.items():
+            expected = list(range(5 * spec["requests"])) if name in ("outcomes", "locality_outcomes", "collective_timing_outcomes") else []
+            evidence.equal(label + ":published-steps:" + name, [item["step_index"] for item in rows], expected)
+        for index, outcome in enumerate(publications["outcomes"]):
+            evidence.equal(label + ":result-join:" + str(index), outcome["makespan_ps"], row["steps"][index]["result"]["step_latency_ps"])
+            evidence.check(label + ":no-fabric:" + str(index), outcome["num_flows"] == 0
+                           and publications["locality_outcomes"][index]["backend_runs"] == 0)
+
+
+def admit(data, frozen, arm, root, path, sources, worker_sha, monitor, evidence):
+    evidence.fields(arm + ":fields", data, "schema arm pid interpreter package_sources_before package_sources_after module_origins worker_sha256 expectations_sha256 helper_origin helper_source_before helper_source_after graphs controls sinks")
+    evidence.equal(arm + ":schema", data["schema"], "simllm-dependency-index-worker-v1")
+    evidence.equal(arm + ":arm", data["arm"], arm)
+    evidence.equal(arm + ":pid", data["pid"], monitor["pid"])
+    evidence.equal(arm + ":sources-before", data["package_sources_before"], sources)
+    evidence.equal(arm + ":sources-after", data["package_sources_after"], sources)
+    evidence.equal(arm + ":worker-source", data["worker_sha256"], worker_sha)
+    evidence.equal(arm + ":helper-origin", data["helper_origin"], str(root / "examples/pd_session_v1/run_study.py"))
+    evidence.equal(arm + ":helper-before", data["helper_source_before"], frozen["granite_helper_sha256"])
+    evidence.equal(arm + ":helper-after", data["helper_source_after"], frozen["granite_helper_sha256"])
+    evidence.check(arm + ":required-imports", all(name in data["module_origins"] for name in (
+        "simllm", "simllm.traffic.execution_goal", "simllm.backends.step_sink", "simllm.compute.provider", "simllm.compute.transformer")))
+    for name, origin in data["module_origins"].items():
+        module = Path(*name.split("."))
+        candidates = (root / module.with_suffix(".py"), root / module / "__init__.py")
+        evidence.check(arm + ":origin:" + name, Path(origin) in candidates and Path(origin).relative_to(root).as_posix() in sources)
+    evidence.check(arm + ":completed-process", monitor["exit_code"] == 0 and monitor["stopping_reason"] is None)
+    evidence.check(arm + ":host-bounds", 0 < monitor["rss_kib"] < frozen["limits"]["rss_cap_kib"]
+                   and 0 < monitor["wall_seconds"] < frozen["limits"]["process_timeout_seconds"])
+    calls = check_graphs(data, frozen, root, path, evidence)
+    check_sinks(data, frozen, evidence)
+    return calls
+
+
+def compare(before, after, calls, frozen, evidence):
+    evidence.equal("pair:key-controls", before["controls"], after["controls"])
+    evidence.equal("pair:sink-jobs", before["sinks"], after["sinks"])
+    for first, second, spec in zip(before["graphs"], after["graphs"], frozen["graph_cases"], strict=True):
+        label = "pair:" + spec["id"]
+        for name in ("before", "after", "rejections"):
+            evidence.equal(label + ":" + name, first[name], second[name])
+        factor = 2 + spec["width"] * spec["depth"]
+        evidence.check(label, 2 * calls["before"][spec["id"]] == factor * calls["after"][spec["id"]],
+                       kind="relations", family="lookup-conversion-reduction")
+    evidence.finish("paired-relations")

--- a/examples/dependency_index_v1/expectations.json
+++ b/examples/dependency_index_v1/expectations.json
@@ -1,0 +1,189 @@
+{
+  "schema": "simllm-dependency-index-expectations-v1",
+  "task": "CORE-52",
+  "as_of_commit": "67cb2dbdfc393400f1c760a0d24534ad3c494094",
+  "allowed_package_change": "simllm/traffic/execution_goal.py",
+  "before_verifier_sha256": "88aecaddaf4aad9b732fc763675db226d04b9fd60586591993eeac113ee2100d",
+  "granite_helper_sha256": "56d96ba0f1979ddf5160b93c19c4e93b57406c6ebf76d61e4a5661f9b317410b",
+  "depths": [
+    1,
+    2,
+    4,
+    8
+  ],
+  "widths": [
+    2,
+    4,
+    8
+  ],
+  "ring_payload_bytes": 64,
+  "compute_service_ps": 1000,
+  "graph_cases": [
+    {
+      "id": "d1-w2",
+      "depth": 1,
+      "width": 2
+    },
+    {
+      "id": "d1-w4",
+      "depth": 1,
+      "width": 4
+    },
+    {
+      "id": "d1-w8",
+      "depth": 1,
+      "width": 8
+    },
+    {
+      "id": "d2-w2",
+      "depth": 2,
+      "width": 2
+    },
+    {
+      "id": "d2-w4",
+      "depth": 2,
+      "width": 4
+    },
+    {
+      "id": "d2-w8",
+      "depth": 2,
+      "width": 8
+    },
+    {
+      "id": "d4-w2",
+      "depth": 4,
+      "width": 2
+    },
+    {
+      "id": "d4-w4",
+      "depth": 4,
+      "width": 4
+    },
+    {
+      "id": "d4-w8",
+      "depth": 4,
+      "width": 8
+    },
+    {
+      "id": "d8-w2",
+      "depth": 8,
+      "width": 2
+    },
+    {
+      "id": "d8-w4",
+      "depth": 8,
+      "width": 4
+    },
+    {
+      "id": "d8-w8",
+      "depth": 8,
+      "width": 8
+    }
+  ],
+  "valid_key_controls": [
+    "same-endpoints-distinct-origin",
+    "same-endpoints-distinct-rank"
+  ],
+  "projection_corruptions": [
+    "predecessor",
+    "target",
+    "scope",
+    "origin",
+    "participant-rank",
+    "invalid-type",
+    "delete",
+    "duplicate",
+    "reverse",
+    "boundary-as-serialized",
+    "serialized-also-boundary",
+    "canonical-text",
+    "boundary-index-before-invalid-type",
+    "edge-count-before-canonical-text"
+  ],
+  "sink_cases": [
+    {
+      "id": "prompt-8-requests-1",
+      "prompt_tokens": 8,
+      "requests": 1
+    },
+    {
+      "id": "prompt-8-requests-4",
+      "prompt_tokens": 8,
+      "requests": 4
+    },
+    {
+      "id": "prompt-16-requests-1",
+      "prompt_tokens": 16,
+      "requests": 1
+    },
+    {
+      "id": "prompt-16-requests-4",
+      "prompt_tokens": 16,
+      "requests": 4
+    }
+  ],
+  "known_services_ps": {
+    "8": {
+      "prefill": 95424000,
+      "decode": 77952000
+    },
+    "16": {
+      "prefill": 114936000,
+      "decode": 77976000
+    }
+  },
+  "resident_per_rank_bytes": 320864256,
+  "memory_bandwidth_bytes_per_second": 8000000000000,
+  "resident_surrogate_floor_ps": 40108032,
+  "sink_collections": [
+    "outcomes",
+    "locality_outcomes",
+    "collective_timing_outcomes",
+    "collective_floor_timing_outcomes",
+    "dependency_cross_check_reports",
+    "collective_registration_outcomes",
+    "packet_breakdowns",
+    "bottleneck_reports",
+    "session_evidence",
+    "peer_evidence"
+  ],
+  "limits": {
+    "process_timeout_seconds": 900,
+    "rss_cap_kib": 8388608,
+    "rss_sample_seconds": 0.25
+  },
+  "behavioral_families": {
+    "lookup-conversion-reduction": [
+      "d1-w2",
+      "d1-w4",
+      "d1-w8",
+      "d2-w2",
+      "d2-w4",
+      "d2-w8",
+      "d4-w2",
+      "d4-w4",
+      "d4-w8",
+      "d8-w2",
+      "d8-w4",
+      "d8-w8"
+    ]
+  },
+  "exact_oracle_count": 24,
+  "corruption_controls": [
+    "source-receipt",
+    "profile-count",
+    "positive-projection",
+    "sink-result",
+    "disk-only-bytes"
+  ],
+  "required_stages": [
+    "protocol",
+    "before-capture",
+    "before-admission",
+    "after-capture",
+    "after-admission",
+    "paired-relations",
+    "corruption-controls",
+    "final-receipts"
+  ]
+}

--- a/examples/dependency_index_v1/expectations.md
+++ b/examples/dependency_index_v1/expectations.md
@@ -1,0 +1,183 @@
+# Call-local dependency lookup
+
+This expectations-only contract precedes implementation and the first run.
+CORE-52 owns this bounded host-cost change. Its target-scale feasibility task
+stays open until a separately frozen native successor completes. The retained
+host diagnostic and its earlier VOID attempts remain unchanged.
+
+## Mechanism and authority
+
+The host checks that every modeled dependency appears exactly once in the
+generated communication schedule. For every serialized dependency, its current
+checker scans the entire ordered effective-edge tuple until the first matching
+edge. That repeated search creates temporary edge objects for candidates it
+does not use. A call-local dictionary can retain the same first matching edge
+while the existing occurrence Counter is built.
+
+The key contains predecessor, target, scope, origin and participant rank.
+Retain the first effective occurrence with `setdefault`; keep the Counter,
+validation order, full multiplicity checks and final canonical-order checks.
+Only this lookup changes. No cross-call cache, disabled validation, identity
+alias, timer, modeled service or emitted byte changes. The graph stays the
+sole dependency authority and projections remain read-only.
+
+## Source-paired protocol
+
+Use two fresh worker processes, before then after, with explicit repository
+roots. The before root is the exact commit recorded in `expectations.json`.
+The after root contains this freeze as an ancestor and a committed, clean
+implementation. The only changed installed package file is
+`simllm/traffic/execution_goal.py`. All other package files and the existing
+Granite configuration helper remain identical. Hash every package file and
+the study sources before and after execution; verify actual imported module
+origins. Never replace the old verifier with a reconstruction of its source.
+
+The same committed worker script runs against each package root through its
+explicit import path. Record its own independent source receipt. Each process
+has a 900-second host limit and an 8-GiB sampled resident-memory limit. Bulk
+files live outside both repositories. A timeout, process failure, changed
+source, failed guard or relation makes the campaign VOID with a null score.
+Retain logs and initial raw receipts; do not rescore a failed attempt.
+
+## Direct-verifier sweep
+
+Build a valid graph and projection before profiling one direct call to
+`verify_execution_goal_projection`. Exclude projection construction from the
+count. Use depth `d` in `{1,2,4,8}` crossed with width `w` in `{2,4,8}`, in
+that order, for twelve configurations.
+
+Start with ring R0. For each layer j, append w compute operations C(j,r),
+ordered by rank, each locally dependent on R(j-1). Append ring Rj, locally
+dependent on all those compute operations in rank order. All rings share one
+logical queue. Every compute operation has a distinct queue. Rings carry
+64 bytes per rank, use the ring algorithm, and span ranks 0 through w-1.
+Compute service is 1,000 ps. The final ring is the completion operation.
+
+Let E be the number of effective-edge occurrences, B the boundary occurrences,
+S the serialized occurrences, and p_s the one-based position of the first
+matching effective edge for serialized occurrence s. The exact formulas are:
+
+```
+artifacts = 2*d + 1
+E = d*(2*w + 1)
+B = d
+S = 2*d*w
+sum(p_s) = w*(2*w + 1)*d*d
+before_calls = E + B + S + sum(p_s) = (2*w + 1)*d*(2 + w*d)
+after_calls = E + B + S = 2*(2*w + 1)*d
+before_calls / after_calls = 1 + w*d/2
+```
+
+Count actual `_goal_edge` invocations with the standard deterministic call
+profiler. Retain the complete profile and exported call records. Independently
+read the binary profile and join function identity to the captured source.
+No callable replacement supplies a count. Re-read profiles after admission.
+The canonical artifact subgraphs have no effective inter-operation edges,
+so their rerenders add no `_goal_edge` invocations in this finite family.
+
+The floor is E+B+S conversions under the retained three conversion sites.
+The existing linear search cannot inspect more than E candidates per
+serialized occurrence, giving the ceiling E+B+S+E*S. Both observed counts
+must lie within these bounds before exact matching. This is operation-count
+evidence. It neither states whole-verifier complexity nor predicts elapsed
+host-time speedup. At fixed width, doubling depth doubles the new count;
+the old count follows its quadratic-plus-linear formula exactly.
+
+## Projection and rejection identity
+
+For every sweep cell retain the full graph, effective-edge inventory and
+projection: all artifact operation IDs, rank counts, GOAL text, operations,
+messages and dependency provenance, plus ordered boundaries and serialized
+edges. Before and after values must match without normalization. Both calls
+must leave their graph and projection unchanged.
+
+Two additional valid graphs exercise keys sharing endpoints: a rank-local
+compute dependency that is both explicit and implicit queue order, and a
+distributed dependency expanded into separate participant-rank edges. These
+are different full keys, not duplicate full-key effective edges. Their
+projections and successful outcomes must remain exact. Current valid graph
+validation excludes identical full-key effective duplicates; repeated
+projection occurrences still must fail.
+
+Apply the following fourteen corruptions to fresh projection copies in each
+of the twelve sweep cells. Compare exact exception class and message between
+sources; accepting any corrupted projection is fatal. Rejection comparisons
+are unscored guards, separate from successful-call count relations.
+
+1. Change the first serialized predecessor to an absent ID.
+2. Change its target to an absent ID.
+3. Change its scope to whole-operation and clear its participant rank.
+4. Change its origin to logical-queue-fifo.
+5. Change its participant rank to another valid rank of the graph.
+6. Replace it with a non-edge string.
+7. Delete the first serialized occurrence.
+8. Duplicate the first serialized occurrence.
+9. Reverse the serialized inventory.
+10. Move the first required boundary edge into the serialized inventory.
+11. Also register the first serialized edge as a boundary with its correct
+    artifact indexes.
+12. Change the first compute artifact's rank-zero calculation from 1 ns to
+    2 ns without changing its owner or dependency provenance.
+13. Combine an incorrect first boundary index with corruption 6. The boundary
+    index error must remain the first failure.
+14. Combine corruption 12 with corruption 7. The edge occurrence mismatch
+    must remain the first failure, ahead of the deferred canonical-text check.
+
+Construct mutated edge values legally before invoking the verifier; an error
+from the mutation constructor cannot count as a verifier rejection. Snapshot
+each corrupted input before and after the rejected call and require identity.
+
+## Supported sink jobs
+
+Use the actual `HtsimStepSink` with the accepted Granite 24-layer dimensions,
+B100 envelope, eight local ranks, one node, roofline efficiency 0.7, ideal host
+initiation and the lower `intra-node-fixed-cost-v1` collective envelope. No
+packet backend, GPU, native serving frontend or weights are used in this slice.
+
+Cross prompt tokens `{8,16}` with serial request counts `{1,4}`. For each
+request submit one prefill step and four decode steps, using deterministic
+request IDs and dense step indexes. The first decode step carries one new
+token, the prompt as cached tokens, phase prefill and context prompt+1; later
+decode steps carry one new token, no cached tokens, phase decode and increasing
+context. Each next step starts at the prior `StepResult.completed_at_ps`.
+The prompt prefill context equals its prompt length. There are no preempted
+or finished notifications in this fixed sink workload, and `num_sampled=1`.
+
+Retain all full inputs, results and all ten sink publication collections.
+Require exact before/after bytes, source-bound selection and consecutive
+step/completion intervals. Record job completion time, equal to the final
+completion timestamp of this serial five-step-per-request job. The known
+accepted service values in JSON are regression oracles, not new measurements.
+Completion must equal request_count*(prefill_service+4*decode_service), so
+four serial requests take exactly four times one request. This unchanged
+compatibility relation is unscored.
+
+As a conditional check of the existing resident-streaming surrogate, the
+320,864,256 per-rank weight bytes over 8 TB/s imply a 40,108,032-ps step floor.
+The sum of the declared step services is the job ceiling and exact serial
+oracle. This surrogate is not a routed-expert hardware floor; COMP-7 owns that
+precision. These sink jobs qualify completion compatibility, not serving
+time to first token, time per output token or a deployment frontier.
+
+## Evidence classes and closure
+
+The campaign requires two source processes, twelve direct-verifier paired
+configurations, two valid key controls per process, 168 rejected projections
+per source, and four paired sink jobs totaling fifty steps per source.
+Keep 24 successful-call exact oracles separate from twelve paired count
+reduction relations in one family. Source identity, physical bounds,
+compatibility, rejection fidelity and receipt guards are unscored. Software
+test counts never enter either evidence denominator.
+
+The required stages are protocol, before capture and admission, after capture
+and admission, paired relations, corruption controls and final receipts.
+Corruption controls must reject a changed source receipt, a modified profile
+count, a missing serialized occurrence in the retained positive projection,
+a changed sink result, and a disk-only raw-byte change. Lock raw files before
+parsing and require exact domains and bytes at final reread. Any violated
+fatal guard voids the result, regardless of earlier successful relations.
+
+A passing result makes this lookup optimization defensible and unblocks the
+next CORE-52 target freeze. It closes no target-scale or model-fidelity task.
+Fresh native target feasibility, independent-engine timing, GPU calibration
+and end-to-end deployment frontiers keep their existing owning tasks.

--- a/examples/dependency_index_v1/results.json
+++ b/examples/dependency_index_v1/results.json
@@ -1,0 +1,532 @@
+{
+  "admitted_sources": [
+    "before",
+    "after"
+  ],
+  "before_commit": "67cb2dbdfc393400f1c760a0d24534ad3c494094",
+  "behavioral_families": 1,
+  "behavioral_instances": 12,
+  "behavioral_score": 1,
+  "changed_package_sources": {
+    "after": {
+      "simllm/traffic/execution_goal.py": "d66e03f59a51a34556a35c1ab35e292936378d1c1e19ea0fa7639e20dee87548"
+    },
+    "before": {
+      "simllm/traffic/execution_goal.py": "88aecaddaf4aad9b732fc763675db226d04b9fd60586591993eeac113ee2100d"
+    }
+  },
+  "checks_sha256": "f517f214c197f38302be5a9abb302e451d2e5b9ce6a4a8867ddcca201e4dc80c",
+  "conversion_calls": {
+    "after": {
+      "d1-w2": 10,
+      "d1-w4": 18,
+      "d1-w8": 34,
+      "d2-w2": 20,
+      "d2-w4": 36,
+      "d2-w8": 68,
+      "d4-w2": 40,
+      "d4-w4": 72,
+      "d4-w8": 136,
+      "d8-w2": 80,
+      "d8-w4": 144,
+      "d8-w8": 272
+    },
+    "before": {
+      "d1-w2": 20,
+      "d1-w4": 54,
+      "d1-w8": 170,
+      "d2-w2": 60,
+      "d2-w4": 180,
+      "d2-w8": 612,
+      "d4-w2": 200,
+      "d4-w4": 648,
+      "d4-w8": 2312,
+      "d8-w2": 720,
+      "d8-w4": 2448,
+      "d8-w8": 8976
+    }
+  },
+  "corruption_controls": [
+    {
+      "name": "source-receipt",
+      "rejected_by": "after:sources-before"
+    },
+    {
+      "name": "profile-count",
+      "rejected_by": "after:graph:d1-w2:profile-export"
+    },
+    {
+      "name": "positive-projection",
+      "rejected_by": "after:graph:d1-w2:frozen-input"
+    },
+    {
+      "name": "sink-result",
+      "rejected_by": "after:sink:prompt-8-requests-1:step:0:known-service"
+    },
+    {
+      "name": "disk-only-bytes",
+      "rejected_by": "disk-only-bytes:raw-domain-and-bytes"
+    }
+  ],
+  "exact_oracles": 24,
+  "expectations_commit": "581d41531c42759e1fd1f9b7af3a0f45844f51a2",
+  "failure": null,
+  "fatal_guards_violated": [],
+  "initial_and_final_raw_receipts_equal": true,
+  "monitors": {
+    "after": {
+      "exit_code": 0,
+      "pid": 28667,
+      "rss_kib": 566764,
+      "stopping_reason": null,
+      "wall_seconds": 174.23146254196763
+    },
+    "before": {
+      "exit_code": 0,
+      "pid": 24391,
+      "rss_kib": 535132,
+      "stopping_reason": null,
+      "wall_seconds": 200.25831088144332
+    }
+  },
+  "raw_bytes": 334338908,
+  "raw_file_count": 86,
+  "raw_receipts": {
+    "after": {
+      "d1-w2-graph.json": {
+        "bytes": 331069,
+        "sha256": "467753c141297c34ad6caf9cd5d63d6a5d65ac501f43205b4193da90e6e70f8d"
+      },
+      "d1-w2.json": {
+        "bytes": 70143,
+        "sha256": "383d95161e9cc6fb6e0eec5ba0a94806dfd0a9b5f3094b3600bb5e11b4bd9573"
+      },
+      "d1-w2.pstats": {
+        "bytes": 17747,
+        "sha256": "df59d924d116d54a11993a05b9b7152aae2700418edb7bd4ceeac8524b69cdd9"
+      },
+      "d1-w4-graph.json": {
+        "bytes": 1294339,
+        "sha256": "94ee9cefd04395a90280f3bb1d6322e9e5957b50c39ff2e85d3865d51dded4d9"
+      },
+      "d1-w4.json": {
+        "bytes": 70893,
+        "sha256": "da53be2440fee429e2cb4a828427624529168010a7e8740eb1fb2fe5df5e5f72"
+      },
+      "d1-w4.pstats": {
+        "bytes": 17747,
+        "sha256": "c69ff00e945352fc630e203ae0c891bd8a7f9318da800ef2de605339584c0c3b"
+      },
+      "d1-w8-graph.json": {
+        "bytes": 5498083,
+        "sha256": "be2ba2bc096e421e19b680603038f3dd7c448801b1b0eb927fa6c7f1967fce3a"
+      },
+      "d1-w8.json": {
+        "bytes": 71037,
+        "sha256": "2dae0268066f38a309559c5f2a0b0b7e5ff2744d7dea8383597891402293f7d1"
+      },
+      "d1-w8.pstats": {
+        "bytes": 17747,
+        "sha256": "699088d8ae4a83d729f131a9d589b61b63dc9304a7a756d4f4800fd4f9c20991"
+      },
+      "d2-w2-graph.json": {
+        "bytes": 494216,
+        "sha256": "473bfa23e9f5eb2ddccaa539828fc305aec9e83664dec78c0ea35e0c40e11e06"
+      },
+      "d2-w2.json": {
+        "bytes": 70482,
+        "sha256": "2814b3911a230570e705867959f724e13e3210231147269a9ca250b9499038eb"
+      },
+      "d2-w2.pstats": {
+        "bytes": 17747,
+        "sha256": "0ff043533ea9212e1233c0bb15c577a91e59f20e4c06c555a6da85a106a35bed"
+      },
+      "d2-w4-graph.json": {
+        "bytes": 1969795,
+        "sha256": "bfe9e469657d7497e69e450b8cda09626b3a94e1944fba29fab57f669fde06ad"
+      },
+      "d2-w4.json": {
+        "bytes": 70841,
+        "sha256": "35ec0f9e66f7264852e619ff9dea1c0ad83054f2f168eb388f1c48c854d11652"
+      },
+      "d2-w4.pstats": {
+        "bytes": 17747,
+        "sha256": "7dc252c0efe5a1b7fcd260d23e39aecd6d5eb43d42259691009f0a17216e7ef4"
+      },
+      "d2-w8-graph.json": {
+        "bytes": 8338254,
+        "sha256": "362927eb8b03dfbfc5c1bc8f94399afb3b53274e394bce712e576919e22b63a3"
+      },
+      "d2-w8.json": {
+        "bytes": 71020,
+        "sha256": "df066413c807876be35c240e0fe1c49debdf4397cc7f8149bbc4124064df97eb"
+      },
+      "d2-w8.pstats": {
+        "bytes": 17747,
+        "sha256": "e6bb8e8ad4e90e3694d6dbcc33b9fbb7df658f546260ceffe70c93be547e6b38"
+      },
+      "d4-w2-graph.json": {
+        "bytes": 820087,
+        "sha256": "4f0bd2079828d073df8e960d6c095f3f38821d85fb3ba1da0c8ee4930ffca29d"
+      },
+      "d4-w2.json": {
+        "bytes": 70733,
+        "sha256": "00d93c0ab634fff6769c374b27180717aa6e5cb80b6295df0d397a3c50af50ce"
+      },
+      "d4-w2.pstats": {
+        "bytes": 17747,
+        "sha256": "dfb61cd46acefa7b2dcdc07c49229233c2f758dc97e9d336eff90edb483a1efe"
+      },
+      "d4-w4-graph.json": {
+        "bytes": 3321373,
+        "sha256": "85e46f473cbbae6c0d3f2cdaa6f215545d14648591546da8a9eb4eee409ab6fb"
+      },
+      "d4-w4.json": {
+        "bytes": 71399,
+        "sha256": "88b02dd9fcdb3640c957d0ba8b99fef3b26b81a5fff698f37df8d73d3fb7e333"
+      },
+      "d4-w4.pstats": {
+        "bytes": 17747,
+        "sha256": "a8fcac9af5350861284f3a160da821690de94d0e67858437efbe590da2a515da"
+      },
+      "d4-w8-graph.json": {
+        "bytes": 14019042,
+        "sha256": "2e527dbec0aa1e3e11fae684245fc79a8f4f17b6eb169f4dd5314f90868d5f30"
+      },
+      "d4-w8.json": {
+        "bytes": 71428,
+        "sha256": "8d848fe42e25f10cfad9dbc697e21574adaa337b675fa41144bf551ab2c53339"
+      },
+      "d4-w8.pstats": {
+        "bytes": 17747,
+        "sha256": "c5466cc23ea7186e67e6235f4f940b1590c11e98665deacf724e3b5d1735abad"
+      },
+      "d8-w2-graph.json": {
+        "bytes": 1472017,
+        "sha256": "9b717e1ffd1d3865231e08d1136009b304d4db2420b02b384f58fb4dc6118bac"
+      },
+      "d8-w2.json": {
+        "bytes": 71213,
+        "sha256": "b40b600066cb7a4d33daeaa4f017f6361abfce09c74ee9b6e6835ba9999f4274"
+      },
+      "d8-w2.pstats": {
+        "bytes": 17747,
+        "sha256": "db82cab43d6733d271a578c1a474077ea1c298a6fecb345cf7d84bfffc75d0c6"
+      },
+      "d8-w4-graph.json": {
+        "bytes": 6023806,
+        "sha256": "88ddc6730818fe80c11f1ccf874a12c63d1bac41e9dcd9b5970616da3d2970a8"
+      },
+      "d8-w4.json": {
+        "bytes": 71582,
+        "sha256": "0f29520a0721fb245ca32b4cb8d4b1baa1a6d5653d314e867f3dffc0c604373d"
+      },
+      "d8-w4.pstats": {
+        "bytes": 17747,
+        "sha256": "426fd66e439eb5cc81fc86580088cf323ca6828452a40d094f599cf788505e50"
+      },
+      "d8-w8-graph.json": {
+        "bytes": 25380082,
+        "sha256": "5ac3971dc3e6cd31b422b8bf64709637d4f98f1ff5ff888c4a7bfa10515157a5"
+      },
+      "d8-w8.json": {
+        "bytes": 71498,
+        "sha256": "8352ad486dc190d119cc39edca7bede57a415cbd3a215d4d64a85b25cd285205"
+      },
+      "d8-w8.pstats": {
+        "bytes": 17747,
+        "sha256": "b11753caa288f858c405fff8b05a1be96072974897fdebbf8dc36dcf8646e940"
+      },
+      "process.json": {
+        "bytes": 101,
+        "sha256": "550d3bda9ee5a222bee47fbdfe72a8e3bece2a890b7aa3e3581600c807c1575f"
+      },
+      "process.log": {
+        "bytes": 0,
+        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      },
+      "prompt-16-requests-1-sink.json": {
+        "bytes": 1399107,
+        "sha256": "9f0ff841f3e1a3c36d9edcbe87b44e7f2ac7ad9a42ae563a5eb878ccf6b4f434"
+      },
+      "prompt-16-requests-4-sink.json": {
+        "bytes": 5605722,
+        "sha256": "c64dca4c7fc4c8d4bd74dbb1b3bf8895883e65548ed574781a0248efe59f0805"
+      },
+      "prompt-8-requests-1-sink.json": {
+        "bytes": 1399098,
+        "sha256": "dbe067a847801bf4ad7e8790066aac1f73717f7a1533215b793369a113f1f14e"
+      },
+      "prompt-8-requests-4-sink.json": {
+        "bytes": 5605693,
+        "sha256": "08832e5ea9960c0878911fa035c5609bc5f90ea60b9c09e7c76f8c830ed78077"
+      },
+      "worker.json": {
+        "bytes": 83105891,
+        "sha256": "7ec68211cc81fdc010eca5f502ec9037c16e16c90a60a7313c33e3d68f4814c5"
+      }
+    },
+    "before": {
+      "d1-w2-graph.json": {
+        "bytes": 332249,
+        "sha256": "0058bce34a68c350582872a167a0d945be32d3ebd3fc2d0f63a20168817fa619"
+      },
+      "d1-w2.json": {
+        "bytes": 71323,
+        "sha256": "16c57ccb5751111059ffa07d3af407451d4c3c565e4dc2b8d3f1bbd0723003c1"
+      },
+      "d1-w2.pstats": {
+        "bytes": 18591,
+        "sha256": "872d5eb33ca0f5cde71fbdcd5f0da24edb4ba8f533d2155f55b9140371574012"
+      },
+      "d1-w4-graph.json": {
+        "bytes": 1295180,
+        "sha256": "72211e85bde436e705f4231378429ac5a544a5bc8a775d69c14552fe4f4876f5"
+      },
+      "d1-w4.json": {
+        "bytes": 71734,
+        "sha256": "6da6f202ae1b8111ad9c3a72625eec4710a192fe4ae44e055746f1d2b2f91dca"
+      },
+      "d1-w4.pstats": {
+        "bytes": 18591,
+        "sha256": "b5f11a656b9d9c14679e0e79787c7731440678ae587e94a478c60bd9449ca09a"
+      },
+      "d1-w8-graph.json": {
+        "bytes": 5498989,
+        "sha256": "a1d31aba9cce58fab382b5f3234d90dd13b95015beea4c85c3dd8229ab93d1c5"
+      },
+      "d1-w8.json": {
+        "bytes": 71943,
+        "sha256": "61a2d997d3cd7e26fa4ade0fb280b463f578a6a417346658752c830af86dddbd"
+      },
+      "d1-w8.pstats": {
+        "bytes": 18591,
+        "sha256": "db4b7858cc30942e34012214bf651afcfdbe02bbb96d511ecb5b88bbfbb9909e"
+      },
+      "d2-w2-graph.json": {
+        "bytes": 495954,
+        "sha256": "98854997b5487a30397f98166a6d225c37da9dc811c2d690af5aee06853d5af2"
+      },
+      "d2-w2.json": {
+        "bytes": 72220,
+        "sha256": "3acdaf540493b6e5871d5b67e161b341815e9ef9e7fb785f10c4543b6b314736"
+      },
+      "d2-w2.pstats": {
+        "bytes": 18591,
+        "sha256": "88f8be30994baf90934416d2f31394f4d7257a00d1e3e3bd661bc90b60a26891"
+      },
+      "d2-w4-graph.json": {
+        "bytes": 1971500,
+        "sha256": "7530beef8374d22033ef59940bab472b43187ed8e040c15f572166e34ea6a48f"
+      },
+      "d2-w4.json": {
+        "bytes": 72546,
+        "sha256": "521d21cbcee59eed289814d6463afda5cf9704fda258f5c2f4b1202d791a0c7b"
+      },
+      "d2-w4.pstats": {
+        "bytes": 18591,
+        "sha256": "ebba119a8294a5e954b5f3ed07f3cc008f14c7294d8878aa170681f1f6fe835c"
+      },
+      "d2-w8-graph.json": {
+        "bytes": 8339723,
+        "sha256": "f168ddd67d7058e5ac877f918a6037ad3533808f60c4170db485b774b6936564"
+      },
+      "d2-w8.json": {
+        "bytes": 72489,
+        "sha256": "c9a5ce982140b9291d3913d6fb4140059d7bf551921566c700733cfe05321f67"
+      },
+      "d2-w8.pstats": {
+        "bytes": 18591,
+        "sha256": "015cda8481e722d1f1691287c401aafb7ae1886ee8cc253971a5da66252d81f2"
+      },
+      "d4-w2-graph.json": {
+        "bytes": 821366,
+        "sha256": "7526c7d15bbe136cfabe51db0bd3cc8cdd8c4965853ec74e8914cf5e3cbcf847"
+      },
+      "d4-w2.json": {
+        "bytes": 72012,
+        "sha256": "e001c5eb58ab9ea1b4b2a89b4a92d4f6983a14f3f6f80b173d40b0458606ed36"
+      },
+      "d4-w2.pstats": {
+        "bytes": 18591,
+        "sha256": "4fbe23efa35c73ecb1c4a03ed1e596398610d990da4373068f7ab578bdd6c148"
+      },
+      "d4-w4-graph.json": {
+        "bytes": 3322192,
+        "sha256": "23e4973db1723a05d7105ea282b2fc3794548cc77499d6bb201c5837319802ad"
+      },
+      "d4-w4.json": {
+        "bytes": 72218,
+        "sha256": "47a1e0072bd3e66f03438b3e02e4ecfab3df5fcffbf3e93b57de9be923cea9a2"
+      },
+      "d4-w4.pstats": {
+        "bytes": 18591,
+        "sha256": "1c2dcd43a3eb82b20ccd3f819006273233fdd6e525e80e12552e56c933333567"
+      },
+      "d4-w8-graph.json": {
+        "bytes": 14020152,
+        "sha256": "13726eee7cebaeb9a590ed0d61cc8328e9e7fced5435654085cadb7c94754a97"
+      },
+      "d4-w8.json": {
+        "bytes": 72538,
+        "sha256": "b77be759b376850a53236535e283ebe603eca5236060b3148b936105c545ba50"
+      },
+      "d4-w8.pstats": {
+        "bytes": 18591,
+        "sha256": "2bb2666945371ae21d117259e4e328150e0cdf113ad53f480dea0ce7e380d6d1"
+      },
+      "d8-w2-graph.json": {
+        "bytes": 1472680,
+        "sha256": "4b755cfdfcbb3570c49b12c43bf81f265cabb1a830658e49790dcd194c5825e1"
+      },
+      "d8-w2.json": {
+        "bytes": 71876,
+        "sha256": "4a985762451e55a2779bd7cc31920f82018dd2b0d9dbc39d49307b1158ed112c"
+      },
+      "d8-w2.pstats": {
+        "bytes": 18591,
+        "sha256": "4a5e966b2b2e24da65cd8fec58b0f93b33744c8367938055f56115a2f3385f80"
+      },
+      "d8-w4-graph.json": {
+        "bytes": 6025127,
+        "sha256": "09581897f7c17027c56a61ece534520c22b2c1d6d784ecbe5faf294320d44eb8"
+      },
+      "d8-w4.json": {
+        "bytes": 72903,
+        "sha256": "f8aab17f997fb93606fd59726d30cb369e6f36afb9e3ff62493c1c2b28ae51c1"
+      },
+      "d8-w4.pstats": {
+        "bytes": 18591,
+        "sha256": "ea0d22d7abdf9d2dae3ee0e5f1b3e016809cbe053f5d9d637424a605fc8abf46"
+      },
+      "d8-w8-graph.json": {
+        "bytes": 25381452,
+        "sha256": "a219833e48b63ca0b5911057e2aecc44fb091348d4cc165d423c831478ff0dcf"
+      },
+      "d8-w8.json": {
+        "bytes": 72868,
+        "sha256": "6b16a8546b60dbd5c7e07b1fdc0e01f1129309cc035a4c14851a47bc15742de2"
+      },
+      "d8-w8.pstats": {
+        "bytes": 18591,
+        "sha256": "61cda95c85e8903084b8c85e63a9f2d953498d2ed9cb1c09a37646effb8b12f0"
+      },
+      "process.json": {
+        "bytes": 101,
+        "sha256": "bf8c76489f94d8fd4ab8ad5b8ff90d8dc1b55b7cdb2d1e829ee1445f74a59616"
+      },
+      "process.log": {
+        "bytes": 0,
+        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      },
+      "prompt-16-requests-1-sink.json": {
+        "bytes": 1399107,
+        "sha256": "9f0ff841f3e1a3c36d9edcbe87b44e7f2ac7ad9a42ae563a5eb878ccf6b4f434"
+      },
+      "prompt-16-requests-4-sink.json": {
+        "bytes": 5605722,
+        "sha256": "c64dca4c7fc4c8d4bd74dbb1b3bf8895883e65548ed574781a0248efe59f0805"
+      },
+      "prompt-8-requests-1-sink.json": {
+        "bytes": 1399098,
+        "sha256": "dbe067a847801bf4ad7e8790066aac1f73717f7a1533215b793369a113f1f14e"
+      },
+      "prompt-8-requests-4-sink.json": {
+        "bytes": 5605693,
+        "sha256": "08832e5ea9960c0878911fa035c5609bc5f90ea60b9c09e7c76f8c830ed78077"
+      },
+      "worker.json": {
+        "bytes": 83119853,
+        "sha256": "4ae1ab1cd5a95e9601505b2613e2d7f1d1f44d081e5d9b1549e665df11719146"
+      }
+    }
+  },
+  "root_receipts": {
+    "after-raw-receipts.json": {
+      "bytes": 4722,
+      "sha256": "ece603cfe78dcbf87b95aec81007f85abdd99905d98781c6b4f7a722f4cb71db"
+    },
+    "before-raw-receipts.json": {
+      "bytes": 4722,
+      "sha256": "7146e87fa26ff845d5e701d7a0988d02e52f0ba95ca30bdb3d4329c701c2bef9"
+    },
+    "physical-bounds.json": {
+      "bytes": 1548,
+      "sha256": "41a97df44203fde46db9e29224010b9d24333a060203332cd34f97f17f78945f"
+    },
+    "source-manifest.json": {
+      "bytes": 44530,
+      "sha256": "a6bdaf63161b92d567533c8d0ec53c4bfd5e892f0f1482928e74b83c4fb0d9ea"
+    }
+  },
+  "schema": "simllm-dependency-index-publication-v1",
+  "scope": {
+    "gpu_measurement": false,
+    "host_speedup_scored": false,
+    "native_serving_frontend": false,
+    "packet_backend": false,
+    "target_scale_qualified": false,
+    "whole_verifier_complexity_claimed": false
+  },
+  "sink_jobs": [
+    {
+      "before_after_raw_bytes_identical": true,
+      "completed_at_ps": 407232000,
+      "id": "prompt-8-requests-1",
+      "prompt_tokens": 8,
+      "requests": 1,
+      "sha256": "dbe067a847801bf4ad7e8790066aac1f73717f7a1533215b793369a113f1f14e",
+      "steps_per_source": 5
+    },
+    {
+      "before_after_raw_bytes_identical": true,
+      "completed_at_ps": 1628928000,
+      "id": "prompt-8-requests-4",
+      "prompt_tokens": 8,
+      "requests": 4,
+      "sha256": "08832e5ea9960c0878911fa035c5609bc5f90ea60b9c09e7c76f8c830ed78077",
+      "steps_per_source": 20
+    },
+    {
+      "before_after_raw_bytes_identical": true,
+      "completed_at_ps": 426840000,
+      "id": "prompt-16-requests-1",
+      "prompt_tokens": 16,
+      "requests": 1,
+      "sha256": "9f0ff841f3e1a3c36d9edcbe87b44e7f2ac7ad9a42ae563a5eb878ccf6b4f434",
+      "steps_per_source": 5
+    },
+    {
+      "before_after_raw_bytes_identical": true,
+      "completed_at_ps": 1707360000,
+      "id": "prompt-16-requests-4",
+      "prompt_tokens": 16,
+      "requests": 4,
+      "sha256": "c64dca4c7fc4c8d4bd74dbb1b3bf8895883e65548ed574781a0248efe59f0805",
+      "steps_per_source": 20
+    }
+  ],
+  "source_commit": "8dcf9858a881f8c2b42207c1ab644fb0d471ea88",
+  "stages": [
+    "after-admission",
+    "after-capture",
+    "before-admission",
+    "before-capture",
+    "corruption-controls",
+    "final-receipts",
+    "paired-relations",
+    "protocol"
+  ],
+  "study_sources": {
+    "checks.py": "09e046b0ce30ca59e6e2cb92ccd278dacb0b704f3f8ae9894f0d3b3283667ce3",
+    "expectations.json": "877152d712d7e5e0c88c7a451d1c44eca6b645a031ec85b2060db08ed03e6017",
+    "expectations.md": "9036c0a5d5f2b569fc8f3a548340df2eb5df474377b2578cec11d8cdad18664d",
+    "run_study.py": "b1546d798e46671ea493e49457d497e95d488dd4e5b211cc72965e2fb743454f",
+    "worker.py": "af62f33c7c073671a763ba46ad7d8b9a974b541711d83e4b80d820d8620f6b20"
+  },
+  "summary_sha256": "afe3e18026443e0b92f2f45de781465a4152456847f13a8c5ff526a8b53a0821",
+  "task": "CORE-52",
+  "task_closed": false,
+  "unscored_guards": 3208,
+  "verdict": "PASS"
+}

--- a/examples/dependency_index_v1/run_study.py
+++ b/examples/dependency_index_v1/run_study.py
@@ -1,0 +1,232 @@
+"""Qualify a frozen call-local lookup without fitting host or device time."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+import traceback
+from copy import deepcopy
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from examples.dependency_index_v1.checks import admit, compare, formula, read
+from examples.dependency_index_v1.worker import package_sources, sha, write
+from examples.pd_session_target_scale_v1.checks import Evidence, GuardFailure
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parents[1]
+FREEZE_COMMIT = "581d41531c42759e1fd1f9b7af3a0f45844f51a2"
+
+
+def git(root, *args):
+    return subprocess.check_output(["git", *args], cwd=root)
+
+
+def receipts(path):
+    return {item.relative_to(path).as_posix(): {"sha256": sha(item.read_bytes()), "bytes": item.stat().st_size}
+            for item in sorted(path.rglob("*")) if item.is_file()}
+
+
+def reread(path, first, evidence, label):
+    evidence.equal(label + ":raw-domain-and-bytes", receipts(path), first)
+
+
+def launch(arm, root, args, frozen, monitors):
+    output = args.output_root / arm
+    output.mkdir()
+    command = [sys.executable, str(HERE / "worker.py"), "--arm", arm, "--repository-root", str(root),
+               "--expectations", str(HERE / "expectations.json"), "--output-root", str(output)]
+    env = os.environ.copy()
+    env.update(PYTHONPATH=str(root), PYTHONDONTWRITEBYTECODE="1", CUDA_VISIBLE_DEVICES="", HIP_VISIBLE_DEVICES="")
+    monitor = {"pid": None, "exit_code": None, "rss_kib": 0, "stopping_reason": None, "wall_seconds": 0}
+    monitors[arm] = monitor
+    limits = frozen["limits"]
+    started = time.monotonic()
+    with (output / "process.log").open("wb") as log:
+        process = subprocess.Popen(command, cwd=root, env=env, stdout=log, stderr=subprocess.STDOUT)
+        monitor["pid"] = process.pid
+        try:
+            while process.poll() is None:
+                status = Path(f"/proc/{process.pid}/status")
+                try:
+                    lines = status.read_text().splitlines()
+                except FileNotFoundError:
+                    lines = []
+                rss = next((int(line.split()[1]) for line in lines if line.startswith("VmRSS:")), 0)
+                monitor["rss_kib"] = max(rss, monitor["rss_kib"])
+                if rss >= limits["rss_cap_kib"] or time.monotonic() - started >= limits["process_timeout_seconds"]:
+                    raise GuardFailure("frozen process resource limit")
+                try:
+                    process.wait(timeout=limits["rss_sample_seconds"])
+                except subprocess.TimeoutExpired:
+                    pass
+        except BaseException as error:
+            monitor["stopping_reason"] = str(error)
+            process.kill()
+            process.wait()
+            raise
+        finally:
+            monitor["exit_code"] = process.returncode
+            monitor["wall_seconds"] = time.monotonic() - started
+            write(output / "process.json", monitor)
+    if process.returncode:
+        raise GuardFailure("source worker failed: " + arm)
+
+
+def capture_worker(arm, root, args, frozen, monitors, raw, root_receipts):
+    """Retain first receipts on every process exit, including fatal exits."""
+    try:
+        launch(arm, root, args, frozen, monitors)
+    finally:
+        path = args.output_root / arm
+        if path.exists():
+            raw[arm] = receipts(path)
+            receipt_path = args.output_root / (arm + "-raw-receipts.json")
+            write(receipt_path, raw[arm])
+            root_receipts[receipt_path.name] = {"sha256": sha(receipt_path.read_bytes()), "bytes": receipt_path.stat().st_size}
+
+
+def corruption_controls(all_data, frozen, roots, sources, worker_sha, args, monitors, evidence):
+    outcomes = []
+    for name in frozen["corruption_controls"]:
+        if name == "disk-only-bytes":
+            with TemporaryDirectory(dir=args.output_root, prefix="corruption-") as directory:
+                path = Path(directory)
+                write(path / "original.json", {"value": 1})
+                initial = receipts(path)
+                write(path / "original.json", {"value": 2})
+                try:
+                    reread(path, initial, Evidence([]), name)
+                except GuardFailure as error:
+                    reason = str(error)
+                else:
+                    raise GuardFailure("changed raw bytes were accepted")
+        else:
+            data = deepcopy(all_data["after"])
+            if name == "source-receipt":
+                data["package_sources_before"][frozen["allowed_package_change"]] = "0" * 64
+                data["package_sources_after"] = deepcopy(data["package_sources_before"])
+            elif name == "profile-count":
+                row = next(row for row in data["graphs"][0]["profiles"] if row["function"][2] == "_goal_edge")
+                row["calls"] += 1
+            elif name == "positive-projection":
+                data["graphs"][0]["before"]["projection"]["serialized_edges"].pop()
+                data["graphs"][0]["after"] = deepcopy(data["graphs"][0]["before"])
+            elif name == "sink-result":
+                data["sinks"][0]["steps"][0]["result"]["step_latency_ps"] += 1
+            else:
+                raise GuardFailure("unknown semantic control")
+            try:
+                admit(data, frozen, "after", roots["after"], args.output_root / "after", sources["after"],
+                      worker_sha, monitors["after"], Evidence([]))
+            except GuardFailure as error:
+                reason = str(error)
+            else:
+                raise GuardFailure("semantic corruption was accepted: " + name)
+        evidence.check("corruption:" + name, bool(reason))
+        outcomes.append({"name": name, "rejected_by": reason})
+    evidence.finish("corruption-controls")
+    return outcomes
+
+
+def execute(args):
+    frozen = json.loads((HERE / "expectations.json").read_bytes())
+    roots = {"before": args.before_repository.resolve(), "after": ROOT}
+    args.output_root = args.output_root.resolve()
+    if any(args.output_root == root or root in args.output_root.parents for root in roots.values()):
+        raise ValueError("raw evidence must be outside both source trees")
+    args.output_root.mkdir(parents=True, exist_ok=False)
+    evidence = Evidence(frozen["required_stages"])
+    data, sources, monitors, raw, root_receipts, calls, controls = {}, {}, {}, {}, {}, {}, []
+    source = git(ROOT, "rev-parse", "HEAD").decode().strip()
+    worker_sha = sha((HERE / "worker.py").read_bytes())
+    failure = None
+    try:
+        git(ROOT, "merge-base", "--is-ancestor", FREEZE_COMMIT, "HEAD")
+        for name in ("expectations.md", "expectations.json"):
+            evidence.equal("freeze:" + name, sha((HERE / name).read_bytes()),
+                           sha(git(ROOT, "show", FREEZE_COMMIT + ":" + (HERE.relative_to(ROOT) / name).as_posix())))
+        for root in roots.values():
+            git(root, "diff", "--quiet", "HEAD", "--")
+        evidence.equal("protocol:baseline-commit", git(roots["before"], "rev-parse", "HEAD").decode().strip(), frozen["as_of_commit"])
+        for item in HERE.glob("*.py"):
+            git(ROOT, "ls-files", "--error-unmatch", item.relative_to(ROOT).as_posix())
+        study_sources = {item.name: sha(item.read_bytes()) for item in HERE.iterdir() if item.suffix in (".py", ".md", ".json")}
+        sources = {arm: package_sources(root) for arm, root in roots.items()}
+        evidence.equal("protocol:package-domain", sorted(sources["before"]), sorted(sources["after"]))
+        changed = [name for name in sources["before"] if sources["before"][name] != sources["after"][name]]
+        evidence.equal("protocol:only-package-change", changed, [frozen["allowed_package_change"]])
+        evidence.equal("protocol:baseline-verifier", sources["before"][frozen["allowed_package_change"]], frozen["before_verifier_sha256"])
+        for arm, root in roots.items():
+            evidence.equal("protocol:granite-helper:" + arm, sha((root / "examples/pd_session_v1/run_study.py").read_bytes()), frozen["granite_helper_sha256"])
+        write(args.output_root / "source-manifest.json", {"source_commit": source, "study": study_sources, "packages": sources})
+        write(args.output_root / "physical-bounds.json", {spec["id"]: formula(spec["depth"], spec["width"]) for spec in frozen["graph_cases"]})
+        root_receipts = receipts(args.output_root)
+        evidence.finish("protocol")
+        for arm, root in roots.items():
+            print("Starting " + arm, flush=True)
+            capture_worker(arm, root, args, frozen, monitors, raw, root_receipts)
+            path = args.output_root / arm
+            evidence.finish(arm + "-capture")
+            current = read(path / "worker.json")
+            reread(path, raw[arm], evidence, arm + ":initial")
+            evidence.equal(arm + ":process-receipt", read(path / "process.json"), monitors[arm])
+            evidence.equal(arm + ":interpreter", current["interpreter"], sys.executable)
+            evidence.equal(arm + ":frozen-input", current["expectations_sha256"], sha((HERE / "expectations.json").read_bytes()))
+            for row in current["graphs"]:
+                evidence.equal(arm + ":graph-disk:" + row["id"], read(path / (row["id"] + "-graph.json")), row)
+            for row in current["sinks"]:
+                evidence.equal(arm + ":sink-disk:" + row["id"], read(path / (row["id"] + "-sink.json")), row)
+            calls[arm] = admit(current, frozen, arm, root, path, sources[arm], worker_sha, monitors[arm], evidence)
+            data[arm] = current
+            evidence.finish(arm + "-admission")
+            print("Qualified " + arm, flush=True)
+        compare(data["before"], data["after"], calls, frozen, evidence)
+        controls = corruption_controls(data, frozen, roots, sources, worker_sha, args, monitors, evidence)
+        evidence.equal("complete:fresh-processes", len({row["pid"] for row in monitors.values()}), 2)
+        evidence.equal("complete:oracle-count", len(evidence.oracles), frozen["exact_oracle_count"])
+        evidence.equal("complete:relation-domain", sorted(row["name"] for row in evidence.relations),
+                       sorted("pair:" + spec["id"] for spec in frozen["graph_cases"]))
+        for arm, root in roots.items():
+            reread(args.output_root / arm, raw[arm], evidence, arm + ":final")
+            evidence.equal(arm + ":final-source", package_sources(root), sources[arm])
+            git(root, "diff", "--quiet", "HEAD", "--")
+        evidence.equal("complete:study-source", {item.name: sha(item.read_bytes()) for item in HERE.iterdir() if item.suffix in (".py", ".md", ".json")}, study_sources)
+        evidence.equal("complete:head", git(ROOT, "rev-parse", "HEAD").decode().strip(), source)
+        evidence.equal("complete:root-domain", sorted(path.name for path in args.output_root.iterdir() if path.is_file()), sorted(root_receipts))
+        for name, receipt in root_receipts.items():
+            path = args.output_root / name
+            evidence.equal("complete:root-bytes:" + name, {"sha256": sha(path.read_bytes()), "bytes": path.stat().st_size}, receipt)
+        evidence.finish("final-receipts")
+        evidence.equal("complete:stages", sorted(evidence.finished_stages), sorted(frozen["required_stages"]))
+    except Exception as error:  # noqa: BLE001
+        failure = str(error)
+        (args.output_root / "exception.txt").write_text(traceback.format_exc(), encoding="utf-8")
+    result = {"schema": "simllm-dependency-index-summary-v1", "task": "CORE-52", "verdict": "PASS" if failure is None else "VOID",
+              "expectations_commit": FREEZE_COMMIT, "source_commit": source, "failure": failure,
+              "behavioral_score": 1 if failure is None else None,
+              "fatal_guards_violated": [row for row in evidence.guards if not row["passed"]],
+              "unscored_guards": len(evidence.guards), "exact_oracles": len(evidence.oracles),
+              "behavioral_instances": len(evidence.relations), "behavioral_families": len({row["family"] for row in evidence.relations}),
+              "stages": sorted(evidence.finished_stages), "admitted_sources": list(data), "monitors": monitors,
+              "conversion_calls": calls, "corruption_controls": controls, "root_receipts": root_receipts,
+              "initial_raw_receipts": raw, "retained_raw_receipts": {arm: receipts(args.output_root / arm) for arm in roots if (args.output_root / arm).exists()}}
+    write(args.output_root / "checks.json", {"guards": evidence.guards, "oracles": evidence.oracles, "relations": evidence.relations})
+    write(args.output_root / "summary.json", result)
+    print(json.dumps({key: result[key] for key in ("verdict", "failure", "admitted_sources", "behavioral_score")}), flush=True)
+    return 0 if failure is None else 1
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--before-repository", type=Path, required=True)
+    parser.add_argument("--output-root", type=Path, required=True)
+    return execute(parser.parse_args())
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/dependency_index_v1/worker.py
+++ b/examples/dependency_index_v1/worker.py
@@ -1,0 +1,269 @@
+"""Run one installed source tree under the frozen dependency lookup protocol."""
+
+from __future__ import annotations
+
+import argparse
+import cProfile
+import hashlib
+import json
+import os
+import pstats
+import subprocess
+import sys
+import traceback
+from copy import deepcopy
+from dataclasses import asdict, is_dataclass, replace
+from enum import Enum
+from pathlib import Path
+
+
+def plain(value):
+    if isinstance(value, Enum):
+        return plain(value.value)
+    if is_dataclass(value) and not isinstance(value, type):
+        return plain(asdict(value))
+    if isinstance(value, dict):
+        return {key: plain(item) for key, item in value.items()}
+    if isinstance(value, (tuple, list)):
+        return [plain(item) for item in value]
+    if type(value) in (str, int, float, bool, type(None)):
+        return value
+    raise TypeError("unsupported evidence value: " + type(value).__name__)
+
+
+def encoded(value):
+    return json.dumps(plain(value), sort_keys=True, separators=(",", ":"), allow_nan=False).encode("ascii")
+
+
+def sha(value):
+    return hashlib.sha256(value).hexdigest()
+
+
+def write(path, value):
+    path.write_bytes(encoded(value))
+
+
+def package_sources(root):
+    paths = subprocess.check_output(["git", "ls-files", "--", "simllm"], cwd=root, text=True).splitlines()
+    return {name: sha((root / name).read_bytes()) for name in paths}
+
+
+def profile_rows(path):
+    stats = pstats.Stats(str(path))
+    return [{"function": list(key), "primitive_calls": primitive, "calls": calls,
+             "self_seconds": self_seconds, "cumulative_seconds": cumulative_seconds,
+             "callers": [{"function": list(caller), "counts": list(counts)}
+                         for caller, counts in sorted(callers.items())]}
+            for key, (primitive, calls, self_seconds, cumulative_seconds, callers) in sorted(stats.stats.items())]
+
+
+def graph_case(depth, width, *, payload=64, service=1000):
+    from simllm.core import CollectiveWork, ComputeWork, ExecutionGraph, ExecutionOperation
+
+    def ring(index, dependencies=()):
+        return ExecutionOperation("ring-" + str(index), 0, "collective",
+                                  CollectiveWork("all-reduce", tuple(range(width)), payload, "ring"),
+                                  participant_local_depends_on=dependencies)
+
+    operations = [ring(0)]
+    for layer in range(1, depth + 1):
+        names = tuple(f"compute-{layer}-{rank}" for rank in range(width))
+        operations.extend(ExecutionOperation(name, rank, name, ComputeWork(name, nominal_duration_ps=service),
+                                            participant_local_depends_on=("ring-" + str(layer - 1),))
+                          for rank, name in enumerate(names))
+        operations.append(ring(layer, names))
+    return ExecutionGraph(f"depth-{depth}-width-{width}", 0, 0, tuple(operations), ("ring-" + str(depth),))
+
+
+def key_control(name):
+    from simllm.core import CollectiveWork, ComputeWork, ExecutionGraph, ExecutionOperation
+
+    if name == "same-endpoints-distinct-origin":
+        first = ExecutionOperation("first", 0, "shared", ComputeWork("first", nominal_duration_ps=1000))
+        second = ExecutionOperation("second", 0, "shared", ComputeWork("second", nominal_duration_ps=1000), depends_on=("first",))
+    elif name == "same-endpoints-distinct-rank":
+        work = CollectiveWork("all-reduce", (0, 1, 2, 3), 64, "ring")
+        first = ExecutionOperation("first", 0, "shared", work)
+        second = ExecutionOperation("second", 0, "shared", work, participant_local_depends_on=("first",))
+    else:
+        raise ValueError("unknown valid key control")
+    return ExecutionGraph(name, 0, 0, (first, second), ("second",))
+
+
+def projection_value(projection):
+    return {"execution_id": projection.execution_id, "num_goal_ranks": projection.num_goal_ranks,
+            "base_tag": projection.base_tag, "boundaries": plain(projection.boundaries),
+            "serialized_edges": plain(projection.serialized_edges),
+            "artifacts": [{"operation_ids": plain(artifact.operation_ids), "num_ranks": artifact.trace.num_ranks,
+                           "text": artifact.trace.render(), "operations": plain(artifact.trace.operations),
+                           "messages": plain(artifact.trace.messages), "dependencies": plain(artifact.trace.dependencies)}
+                          for artifact in projection.artifacts]}
+
+
+def input_value(graph, projection):
+    from simllm.core.execution_io import effective_dependency_edges, execution_graph_to_json
+
+    return {"graph": execution_graph_to_json(graph), "edges": plain(effective_dependency_edges(graph)),
+            "projection": projection_value(projection)}
+
+
+def corrupt(projection, name):
+    from simllm.traffic import ExecutionGoalArtifactBoundary
+
+    value = deepcopy(projection)
+    first = value.serialized_edges[0]
+    changed = {
+        "predecessor": {"predecessor_id": "absent"}, "target": {"operation_id": "absent"},
+        "scope": {"scope": "whole-operation", "participant_rank": None},
+        "origin": {"origin": "logical-queue-fifo"},
+        "participant-rank": {"participant_rank": (first.participant_rank + 1) % value.num_goal_ranks},
+    }
+    if name in changed:
+        return replace(value, serialized_edges=(replace(first, **changed[name]), *value.serialized_edges[1:]))
+    if name == "invalid-type":
+        return replace(value, serialized_edges=("invalid-edge", *value.serialized_edges[1:]))
+    if name == "delete":
+        return replace(value, serialized_edges=value.serialized_edges[1:])
+    if name == "duplicate":
+        return replace(value, serialized_edges=(*value.serialized_edges, first))
+    if name == "reverse":
+        return replace(value, serialized_edges=tuple(reversed(value.serialized_edges)))
+    if name == "boundary-as-serialized":
+        return replace(value, boundaries=value.boundaries[1:], serialized_edges=(*value.serialized_edges, value.boundaries[0].edge))
+    if name == "serialized-also-boundary":
+        owner = {operation: index for index, artifact in enumerate(value.artifacts) for operation in artifact.operation_ids}
+        boundary = ExecutionGoalArtifactBoundary(owner[first.predecessor_id], owner[first.operation_id], first)
+        return replace(value, boundaries=(*value.boundaries, boundary))
+    if name == "canonical-text":
+        operations = value.artifacts[1].trace.rank(0)._ops
+        if operations[0].text != "calc 1":
+            raise ValueError("frozen compute mutation has no one-nanosecond operation")
+        operations[0] = replace(operations[0], text="calc 2")
+        return value
+    if name == "boundary-index-before-invalid-type":
+        value = corrupt(value, "invalid-type")
+        return replace(value, boundaries=(replace(value.boundaries[0], predecessor_artifact_index=1), *value.boundaries[1:]))
+    if name == "edge-count-before-canonical-text":
+        return corrupt(corrupt(value, "canonical-text"), "delete")
+    raise ValueError("unknown frozen projection corruption")
+
+
+def run_graph(spec, frozen, output):
+    from simllm.traffic import project_execution_graph_goal, verify_execution_goal_projection
+
+    graph = graph_case(spec["depth"], spec["width"], payload=frozen["ring_payload_bytes"], service=frozen["compute_service_ps"])
+    projection = project_execution_graph_goal(graph)
+    before = input_value(graph, projection)
+    if sys.getprofile() is not None:
+        raise ValueError("profile hook already installed")
+    profile = cProfile.Profile()
+    path = output / (spec["id"] + ".pstats")
+    try:
+        profile.enable()
+        result = verify_execution_goal_projection(graph, projection)
+    finally:
+        profile.disable()
+        profile.dump_stats(str(path))
+    profiles = profile_rows(path)
+    write(path.with_suffix(".json"), profiles)
+    rejected = []
+    for name in frozen["projection_corruptions"]:
+        candidate = corrupt(projection, name)
+        prior = input_value(graph, candidate)
+        try:
+            verify_execution_goal_projection(graph, candidate)
+        except (TypeError, ValueError) as error:
+            outcome = {"type": type(error).__name__, "message": str(error)}
+        else:
+            outcome = None
+        rejected.append({"name": name, "before": prior, "after": input_value(graph, candidate), "exception": outcome})
+    return {"id": spec["id"], "before": before, "after": input_value(graph, projection), "accepted": result is None,
+            "profile_hook_restored": sys.getprofile() is None, "profiles": profiles, "rejections": rejected}
+
+
+def run_sink(spec, frozen, output):
+    from examples.pd_session_v1 import run_study as baseline
+    from simllm.backends import HtsimStepSink, HtsimStepSinkConfig
+    from simllm.compute import RooflineProvider
+    from simllm.core import RequestPhase, ScheduledRequest, StepRecord
+    from simllm.core.step import step_record_to_json
+    from simllm.placement import declared_manifest
+
+    sink = HtsimStepSink(HtsimStepSinkConfig(
+        profile="rnic-nn-fluid", tp_ranks=tuple(range(8)), dims=baseline._granite_dims(), workdir=output / spec["id"],
+        provider=RooflineProvider(efficiency=0.7), placement_manifest=declared_manifest(tp=8, nodes=1, gpus_per_node=8),
+        collective_fixed_cost_envelope="intra-node-fixed-cost-v1", collective_fixed_cost_arm="lower"))
+    prompt, now, steps = spec["prompt_tokens"], 0, []
+    for request in range(spec["requests"]):
+        for visit in range(5):
+            record = StepRecord(len(steps), now, [ScheduledRequest(
+                "request-" + str(request), RequestPhase.PREFILL if visit < 2 else RequestPhase.DECODE,
+                prompt if visit == 0 else 1, num_cached_tokens=prompt if visit == 1 else 0,
+                context_length=prompt + visit)], num_sampled=1)
+            result = sink(record)
+            steps.append({"record": step_record_to_json(record), "result": plain(result)})
+            now = result.completed_at_ps
+    config = sink.config
+    selection = {"gpu": plain(config.gpu), "host": plain(config.host_model), "dims": plain(config.dims),
+                 "provider": vars(config.provider), "tp_ranks": plain(config.tp_ranks),
+                 "placement": plain(config.placement_manifest), "precision": plain(config.selected_precision_levels),
+                 "collective_profile": plain(config.resolved_collective_latency_profile)}
+    return {"id": spec["id"], "steps": steps, "completed_at_ps": now, "selection": selection,
+            "publications": {name: plain(getattr(sink, name)) for name in frozen["sink_collections"]}}
+
+
+def execute(args):
+    import simllm
+    from examples.pd_session_v1 import run_study as baseline
+    from simllm.traffic import project_execution_graph_goal, verify_execution_goal_projection
+
+    root = args.repository_root.resolve()
+    if Path(simllm.__file__).resolve() != root / "simllm/__init__.py":
+        raise ValueError("worker imported another source tree")
+    frozen = json.loads(args.expectations.read_bytes())
+    before = package_sources(root)
+    helper_path = Path(baseline.__file__).resolve()
+    helper_before = sha(helper_path.read_bytes())
+    graphs = []
+    for spec in frozen["graph_cases"]:
+        value = run_graph(spec, frozen, args.output_root)
+        graphs.append(value)
+        write(args.output_root / (spec["id"] + "-graph.json"), value)
+    controls = []
+    for name in frozen["valid_key_controls"]:
+        graph = key_control(name)
+        projection = project_execution_graph_goal(graph)
+        value = input_value(graph, projection)
+        result = verify_execution_goal_projection(graph, projection)
+        controls.append({"id": name, "before": value, "after": input_value(graph, projection), "accepted": result is None})
+    sinks = []
+    for spec in frozen["sink_cases"]:
+        value = run_sink(spec, frozen, args.output_root)
+        sinks.append(value)
+        write(args.output_root / (spec["id"] + "-sink.json"), value)
+    value = {"schema": "simllm-dependency-index-worker-v1", "arm": args.arm, "pid": os.getpid(),
+             "interpreter": sys.executable, "package_sources_before": before, "package_sources_after": package_sources(root),
+             "module_origins": {name: str(Path(module.__file__).resolve()) for name, module in sorted(sys.modules.items())
+                                if name.startswith("simllm") and getattr(module, "__file__", None)},
+             "worker_sha256": sha(Path(__file__).read_bytes()), "expectations_sha256": sha(args.expectations.read_bytes()),
+             "helper_origin": str(helper_path), "helper_source_before": helper_before,
+             "helper_source_after": sha(helper_path.read_bytes()),
+             "graphs": graphs, "controls": controls, "sinks": sinks}
+    write(args.output_root / "worker.json", value)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--arm", choices=("before", "after"), required=True)
+    for name in ("repository-root", "expectations", "output-root"):
+        parser.add_argument("--" + name, type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        execute(args)
+    except Exception:
+        (args.output_root / "exception.txt").write_text(traceback.format_exc(), encoding="utf-8")
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/simllm/traffic/execution_goal.py
+++ b/simllm/traffic/execution_goal.py
@@ -813,7 +813,15 @@ def verify_execution_goal_projection(
             "projection artifacts are not the canonical causal-level partition"
         )
 
-    expected_edges = Counter(_edge_tuple(_goal_edge(edge)) for edge in edges)
+    expected_edges: Counter[tuple[str, str, str, str, int | None]] = Counter()
+    effective_by_key: dict[
+        tuple[str, str, str, str, int | None], EffectiveDependencyEdge
+    ] = {}
+    for edge in edges:
+        key = _edge_tuple(_goal_edge(edge))
+        expected_edges[key] += 1
+        # Preserve the first matching occurrence and the separate multiplicity.
+        effective_by_key.setdefault(key, edge)
     emitted_edges: Counter[tuple[str, str, str, str, int | None]] = Counter()
     boundary_edges: Counter[tuple[str, str, str, str, int | None]] = Counter()
     serialized_edges: Counter[tuple[str, str, str, str, int | None]] = Counter()
@@ -917,11 +925,7 @@ def verify_execution_goal_projection(
             edge.operation_id
         ]:
             raise ValueError("serialized projection edge does not advance artifact order")
-        effective = next(
-            candidate
-            for candidate in edges
-            if _edge_tuple(_goal_edge(candidate)) == key
-        )
+        effective = effective_by_key[key]
         if _requires_artifact_boundary(effective, operation_by_id):
             raise ValueError(
                 "distributed whole-operation edge must form an artifact boundary"

--- a/tests/test_dependency_index_study.py
+++ b/tests/test_dependency_index_study.py
@@ -1,0 +1,174 @@
+"""Frozen lookup and source-compatibility controls, separate from study scores."""
+
+import json
+from copy import deepcopy
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from examples.dependency_index_v1.checks import (
+    check_graphs,
+    check_sinks,
+    conversion_calls,
+    formula,
+    read,
+)
+from examples.dependency_index_v1.run_study import HERE, receipts, reread
+from examples.dependency_index_v1.worker import (
+    encoded,
+    graph_case,
+    input_value,
+    key_control,
+    profile_rows,
+    projection_value,
+    run_graph,
+    run_sink,
+    sha,
+    write,
+)
+from examples.pd_session_target_scale_v1.checks import Evidence, GuardFailure
+from simllm.core.execution_io import effective_dependency_edges
+from simllm.traffic import project_execution_graph_goal, verify_execution_goal_projection
+
+FROZEN = json.loads((HERE / "expectations.json").read_bytes())
+VERIFIER = HERE.parents[1] / "simllm/traffic/execution_goal.py"
+
+
+@pytest.mark.parametrize("spec", FROZEN["graph_cases"], ids=lambda row: row["id"])
+def test_frozen_graph_geometry_has_the_declared_occurrence_counts(spec):
+    graph = graph_case(spec["depth"], spec["width"])
+    projection = project_execution_graph_goal(graph)
+    expected = formula(spec["depth"], spec["width"])
+    assert len(effective_dependency_edges(graph)) == expected["edges"]
+    assert len(projection.artifacts) == expected["artifacts"]
+    assert len(projection.boundaries) == expected["boundaries"]
+    assert len(projection.serialized_edges) == expected["serialized"]
+
+
+@pytest.mark.parametrize("spec", [FROZEN["graph_cases"][0], FROZEN["graph_cases"][-1]], ids=lambda row: row["id"])
+def test_actual_profile_and_distinct_rejections_match_the_frozen_contract(tmp_path, spec):
+    row = run_graph(spec, FROZEN, tmp_path)
+    count = conversion_calls(row["profiles"], VERIFIER, Evidence([]), "profile")
+    assert count == formula(spec["depth"], spec["width"])["after"]
+    assert profile_rows(tmp_path / (spec["id"] + ".pstats")) == row["profiles"]
+    assert row["before"] == row["after"]
+    assert row["profile_hook_restored"] is True
+    controls = row["rejections"]
+    assert len({sha(encoded(item["before"])) for item in controls}) == 14
+    assert all(item["before"] == item["after"] and item["exception"] for item in controls)
+    errors = {item["name"]: item["exception"] for item in controls}
+    assert errors["invalid-type"]["type"] == "TypeError"
+    assert errors["boundary-index-before-invalid-type"] == {
+        "type": "ValueError", "message": "artifact boundary indexes do not match graph operations"}
+    assert errors["edge-count-before-canonical-text"]["message"].startswith("GOAL projection edge mismatch:")
+
+
+@pytest.mark.parametrize("name", FROZEN["valid_key_controls"])
+def test_shared_endpoints_keep_distinct_origin_and_rank_keys(name):
+    graph = key_control(name)
+    projection = project_execution_graph_goal(graph)
+    before = projection_value(projection)
+    verify_execution_goal_projection(graph, projection)
+    assert projection_value(projection) == before
+    assert len({(edge.predecessor_id, edge.operation_id) for edge in effective_dependency_edges(graph)}) == 1
+    if name.endswith("origin"):
+        assert len(projection.serialized_edges) == 2
+        assert len({edge.origin for edge in projection.serialized_edges}) == 2
+    else:
+        assert [edge.participant_rank for edge in projection.serialized_edges] == list(range(4))
+
+
+def test_actual_granite_sink_job_and_corrupted_result(tmp_path):
+    spec = FROZEN["sink_cases"][0]
+    row = run_sink(spec, FROZEN, tmp_path)
+    frozen = {**FROZEN, "sink_cases": [spec]}
+    data = {"arm": "after", "sinks": [row]}
+    check_sinks(data, frozen, Evidence([]))
+    corrupted = deepcopy(data)
+    corrupted["sinks"][0]["steps"][0]["result"]["step_latency_ps"] += 1
+    with pytest.raises(GuardFailure, match="known-service"):
+        check_sinks(corrupted, frozen, Evidence([]))
+
+
+@pytest.mark.parametrize("raw", [b'{"x":1,"x":2}', b'{"x":NaN}', b'{"x":Infinity}', b'{"x":1}\n', b'{ "x":1}'])
+def test_reader_rejects_ambiguous_or_changed_writer_bytes(tmp_path, raw):
+    path = tmp_path / "bad.json"
+    path.write_bytes(raw)
+    with pytest.raises((GuardFailure, ValueError)):
+        read(path)
+
+
+def test_raw_receipts_lock_byte_content_and_file_domain(tmp_path):
+    path = tmp_path / "value.json"
+    write(path, {"x": 1})
+    first = receipts(tmp_path)
+    reread(tmp_path, first, Evidence([]), "unchanged")
+    write(path, {"x": 2})
+    with pytest.raises(GuardFailure):
+        reread(tmp_path, first, Evidence([]), "changed")
+    write(path, {"x": 1})
+    (tmp_path / "extra").write_bytes(b"unreceipted")
+    with pytest.raises(GuardFailure):
+        reread(tmp_path, first, Evidence([]), "added")
+
+
+def test_binary_profile_identity_cannot_be_replaced_with_a_count():
+    rows = [{"function": [str(Path("foreign.py")), 1, "_goal_edge"], "calls": 1, "primitive_calls": 1}]
+    with pytest.raises(GuardFailure, match="source-origin"):
+        conversion_calls(rows, VERIFIER, Evidence([]), "profile")
+
+
+def test_profile_function_line_must_match_the_source_definition():
+    rows = [{"function": [str(VERIFIER), 1, "_goal_edge"], "calls": 1, "primitive_calls": 1}]
+    with pytest.raises(GuardFailure, match="source-origin"):
+        conversion_calls(rows, VERIFIER, Evidence([]), "profile")
+
+
+@pytest.mark.parametrize("mutation", [None, "release", "same-rejections", "control-release"])
+def test_full_frozen_input_and_each_declared_corruption_are_bound(tmp_path, mutation):
+    spec = FROZEN["graph_cases"][0]
+    row = run_graph(spec, FROZEN, tmp_path)
+    controls = []
+    for name in FROZEN["valid_key_controls"]:
+        graph = key_control(name)
+        value = input_value(graph, project_execution_graph_goal(graph))
+        controls.append({"id": name, "before": value, "after": deepcopy(value), "accepted": True})
+    data = {"arm": "after", "graphs": [row], "controls": controls}
+    if mutation == "release":
+        row["before"]["graph"]["released_at_ps"] = row["after"]["graph"]["released_at_ps"] = 1
+    elif mutation == "same-rejections":
+        first = row["rejections"][0]
+        row["rejections"] = [{**deepcopy(first), "name": name} for name in FROZEN["projection_corruptions"]]
+    elif mutation == "control-release":
+        controls[0]["before"]["graph"]["released_at_ps"] = controls[0]["after"]["graph"]["released_at_ps"] = 1
+    frozen = {**FROZEN, "graph_cases": [spec]}
+    if mutation is None:
+        check_graphs(data, frozen, HERE.parents[1], tmp_path, Evidence([]))
+    else:
+        with pytest.raises(GuardFailure, match="frozen-input|declared-delta"):
+            check_graphs(data, frozen, HERE.parents[1], tmp_path, Evidence([]))
+
+
+def test_failed_worker_retains_first_receipts_and_original_failure(tmp_path, monkeypatch):
+    from examples.dependency_index_v1 import run_study
+
+    failure = GuardFailure("worker exited")
+
+    def fail(arm, root, args, frozen, monitors):
+        path = args.output_root / arm
+        path.mkdir()
+        (path / "process.log").write_bytes(b"failure retained")
+        write(path / "process.json", {"exit_code": 1})
+        raise failure
+
+    monkeypatch.setattr(run_study, "launch", fail)
+    raw, root_receipts = {}, {}
+    with pytest.raises(GuardFailure) as caught:
+        run_study.capture_worker("before", HERE.parents[1], SimpleNamespace(output_root=tmp_path), FROZEN, {}, raw, root_receipts)
+    assert caught.value is failure
+    assert read(tmp_path / "before-raw-receipts.json") == raw["before"]
+    assert root_receipts["before-raw-receipts.json"]["sha256"] == sha((tmp_path / "before-raw-receipts.json").read_bytes())
+    (tmp_path / "before/process.log").write_bytes(b"changed after failure")
+    with pytest.raises(GuardFailure):
+        reread(tmp_path / "before", raw["before"], Evidence([]), "changed")


### PR DESCRIPTION
Repeated dependency lookup converted every preceding candidate again for each serialized edge. Build a first-match index beside the existing occurrence counter, preserving full dependency keys, rejection order, multiplicity and canonical schedule checks.

The prospectively frozen source-paired study reduces direct-verifier conversions from 8,976 to 272 in its largest case, exactly 33-fold. All four paired sink jobs retain identical bytes, results and completion times. Independent review confirms all raw receipts, profiles, rejection records and publication claims. CORE-52 remains open for the 56-engine native feasibility campaign; this result establishes no elapsed-time speedup or hardware calibration.

Validation: the study completes all eight stages with no fatal guard violation, 24 exact oracles and 12 behavioral instances in one family. Five corrupted-evidence controls reject. Repository lint and 45 focused tests passed before execution. The full repository gate passes with 5,874 tests passed, 31 skipped and lint clean at the published source.
